### PR TITLE
changed selectedActive to be inclusive

### DIFF
--- a/src/modules/Series.js
+++ b/src/modules/Series.js
@@ -75,7 +75,7 @@ export default class Series {
     const selectedActive = function (range) {
       for (let i = 0; i < allHeatMapElements.length; i++) {
         const val = parseInt(allHeatMapElements[i].getAttribute('val'))
-        if (val > range.from && val < range.to) {
+        if (val >= range.from && val <= range.to) {
           allHeatMapElements[i].classList.remove('legend-mouseover-inactive')
         }
       }


### PR DESCRIPTION
I noticed a minor bug when I was looking at the color range demo on heatmap.
https://apexcharts.com/javascript-chart-demos/heatmap-charts/color-range/

when drawing the color range, it is selecting data inclusively but when selecting the legend to filter it, chart excludes the 'to' and 'from' values. this change might have adverse effect on other chart types. I haven't checked it myself yet..

Thanks
