### PR TITLE
fix negative <rect> attribute width error

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -326,7 +326,7 @@ class ZoomPanSelection extends Toolbar {
     let startX = me.startX - 1
     let startY = me.startY
 
-    let selectionWidth = me.clientX - gridRectDim.left - startX - 1
+    let selectionWidth = me.clientX - gridRectDim.left - startX
     let selectionHeight = me.clientY - gridRectDim.top - startY
     let translateX = 0
     let translateY = 0


### PR DESCRIPTION
# Fix Error: <rect> attribute width: A negative value is not valid. ("-1")

I assume that **startX - 1** is duplicated

```php
let startX = me.startX - 1
```

```php
let selectionWidth = me.clientX - gridRectDim.left - startX - 1
```

![apexbug 1](https://user-images.githubusercontent.com/12899080/46737173-82250580-cca3-11e8-83a1-154d8a979ab4.gif)


Fixes # (issue)
Maybe related to #25

## Type of change

-  Bug fix (non-breaking change which fixes an issue)

## Checklist:

-  My code follows the style guidelines of this project
- I have performed a self-review of my own code
