### PR TITLE
Automatically zoom on yaxis (brush option autoZoomY) -fixes apexchars#246

### DIFF
--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -844,10 +844,25 @@ class Core {
       }
 
       w.config.chart.events.selection = (chart, e) => {
+        let min, max;
+        if (w.config.chart.brush.autoZoomY) {
+          min = max = 0;
+          targetChart.w.config.series.forEach(serie => {
+            if (serie[1] > max) max = serie[1];
+            if (serie[1] < min) min = serie[1];
+          })
+          min *= 0.95
+          max *= 1.05
+        }
+        let yaxis = {min, max}
         targetChart._updateOptions({
           xaxis: {
             min: e.xaxis.min,
             max: e.xaxis.max
+          },
+          yaxis: {
+            min: yaxis.min,
+            max: yaxis.max
           }
         }, false, false)
       }


### PR DESCRIPTION

# New Pull Request

Change the brush function allow it to automatically adjust scale on y-axis when changing selection

To allow this improvement, we have to set an autoZoomY option in the brush :
```
chart: {
    brush: {
        enabled: true,
        autoZoomY: true
    }
}
```

Fixes #246 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
