### PR TITLE
Re-calculate tooltip dimensions on text draw

### DIFF
--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -41,6 +41,12 @@ class Labels {
       ttItems,
       shared
     })
+
+    // Re-calculate tooltip dimensions now that we have drawn the text
+    const tooltipEl = this.ttCtx.getElTooltip()
+
+    this.ttCtx.tooltipRect.ttWidth = tooltipEl.getBoundingClientRect().width
+    this.ttCtx.tooltipRect.ttHeight = tooltipEl.getBoundingClientRect().height
   }
 
   printLabels ({


### PR DESCRIPTION
# New Pull Request

As per #264 , on initial tooltip positioning it goes out of bounds. This happens because tooltip dimensions are calculated and then cached before the text in it is updated. This pull request makes sure the dimensions are re-calculated in case the text is updated. Ideally, this would happen in a more structured way (this way the calculation happens twice), but I believe that would require some major re-structuring of the code.

Fixes #264 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
