### PR TITLE
Range annotations - Fixed existence check for x2 and y2 properties

### DIFF
--- a/src/modules/Annotations.js
+++ b/src/modules/Annotations.js
@@ -66,7 +66,7 @@ export default class Annotations {
 
     if (x1 < 0 || x1 > w.globals.gridWidth) return
 
-    if (!anno.x2) {
+    if (anno.x2 == null) {
       let line = this.graphics.drawLine(
         x1 + anno.offsetX, // x1
         0 + anno.offsetY, // y1
@@ -156,7 +156,7 @@ export default class Annotations {
 
     const text = anno.label.text ? anno.label.text : ''
 
-    if (!anno.y2) {
+    if (anno.y2 == null) {
       let line = this.graphics.drawLine(
         0 + anno.offsetX, // x1
         y1 + anno.offsetY, // y1


### PR DESCRIPTION
Following PR #338 , I adjusted the existence check for x2 and y2 properties with `x2 == null` instead of `!x2` and `y2 == null` instead of `!y2` to allow value of `0`.

Without this fix, having `x2` or `y2` with a value of `0` would make the annotation to be displayed as a single line, as the second property to make it a range annotation would be ignored.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature  
- [x] New and existing unit tests pass locally with my changes
