### PR TITLE
Added check to prevent dataLabels calculation if the "dataLabel" option is disabled

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -10,6 +10,10 @@ import DataLabels from '../modules/DataLabels'
  * @module Bar
  **/
 
+const DATA_LABELS_WARNING_THRESHOLD = 50
+const DATA_LABELS_WARNING_TEXT =
+  'WARNING: DataLabels are enabled but there are too many to display. This may cause performance issue when rendering'
+
 class Bar {
   constructor(ctx, xyRatios) {
     this.ctx = ctx
@@ -59,6 +63,12 @@ class Bar {
     })
 
     ret.attr('clip-path', `url(#gridRectMask${w.globals.cuid})`)
+
+    if (w.config.dataLabels.enabled) {
+      if (this.totalItems > DATA_LABELS_WARNING_THRESHOLD) {
+        console.warn(DATA_LABELS_WARNING_TEXT)
+      }
+    }
 
     for (let i = 0, bc = 0; i < series.length; i++, bc++) {
       let pathTo, pathFrom

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -12,7 +12,7 @@ import DataLabels from '../modules/DataLabels'
 
 const DATA_LABELS_WARNING_THRESHOLD = 50
 const DATA_LABELS_WARNING_TEXT =
-  'WARNING: DataLabels are enabled but there are too many to display. This may cause performance issue when rendering'
+  'WARNING: DataLabels are enabled but there are too many to display. This may cause performance issue when rendering.'
 
 class Bar {
   constructor(ctx, xyRatios) {

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -680,10 +680,13 @@ class Bar {
     const offX = dataLabelsConfig.offsetX
     const offY = dataLabelsConfig.offsetY
 
-    let textRects = graphics.getTextRects(
-      w.globals.yLabelFormatters[0](w.globals.maxY),
-      parseInt(dataLabelsConfig.style.fontSize)
-    )
+    let textRects = { width: 0, height: 0 }
+    if (w.config.dataLabels.enabled) {
+      textRects = graphics.getTextRects(
+        w.globals.yLabelFormatters[0](w.globals.maxY),
+        parseInt(dataLabelsConfig.style.fontSize)
+      )
+    }
 
     if (this.isHorizontal) {
       dataLabelsPos = this.calculateBarsDataLabelsPosition({


### PR DESCRIPTION
After further investigation of issue #260 , I have identified the bottleneck causing performance issue for bar charts.

In the `calculateDataLabelsPos` method of `charts\Bar.js`, there is a call to the `getTextRects` method to calculate the size of the dataLabels. This is what makes the performance to drop when having a lot of bars to display.

As a quick workaround, I added a check for whether the `dataLabels` option is enabled in the first place. If not, we simply skip this method altogether, preventing performance drop when not needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Comments

In addition to this, I was thinking of adding a threshold (arbitrary value) defining a maximum number of bars to allow DataLabels. If the maximum is reached, it could do one of the following:

- log a console warning in the console (e.g.: "DataLabels are enabled but there are too many to display. This may cause performance issue when rendering")

- disable the datalables automatically, with a console warning (e.g.: "DataLabels are enabled but there are too many to display. To avoid performance issue, dataLabels have been disabled for this chart.")

Note that I did not include this in this PR, it's just a suggestion to discuss about.
