### PR TITLE
Reviewed logic of calculating stacked bars in timeseries to account for inconsistent X values

### DIFF
--- a/samples/vanilla-js/column/stacked-column-empty-points.html
+++ b/samples/vanilla-js/column/stacked-column-empty-points.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Stacked Column</title>
+
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+        #chart {
+            max-width: 650px;
+            margin: 35px auto;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="chart">
+
+    </div>
+
+
+    <script src="../../../dist/apexcharts.js"></script>
+
+    <script>
+        var options = {
+            chart: {
+                height: 350,
+                type: 'bar',
+                stacked: true,
+                toolbar: {
+                    show: true
+                },
+                zoom: {
+                    enabled: true
+                }
+            },
+            responsive: [{
+                breakpoint: 480,
+                options: {
+                    legend: {
+                        position: 'bottom',
+                        offsetX: -10,
+                        offsetY: 0
+                    }
+                }
+            }],
+            plotOptions: {
+                bar: {
+                    horizontal: false,
+                },
+            },
+            series: [{
+                name: 'PRODUCT A',
+                data: [['01/01/2011 GMT', 44], ['01/02/2011 GMT', 55], ['01/03/2011 GMT', 41], ['01/04/2011 GMT', 67], ['01/05/2011 GMT', 22],['01/06/2011 GMT', 43]]
+            },{
+                name: 'PRODUCT B',
+                data: [['01/03/2011 GMT', 20], ['01/04/2011 GMT', 8], ['01/05/2011 GMT', 13], ['01/06/2011 GMT', 27]]
+            }],
+            xaxis: {
+                type: 'datetime'
+                // categories: ['01/01/2011 GMT', '01/02/2011 GMT', '01/03/2011 GMT', '01/04/2011 GMT', '01/05/2011 GMT', '01/06/2011 GMT'],
+            },
+            yaxis: {
+                tooltip: {
+                    enabled: true
+                }
+            },
+            legend: {
+                position: 'right',
+                offsetY: 40
+            },
+            fill: {
+                opacity: 1
+            },
+        }
+
+       var chart = new ApexCharts(
+            document.querySelector("#chart"),
+            options
+        );
+
+        chart.render();
+    </script>
+</body>
+
+</html>

--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -452,14 +452,26 @@ class BarStacked extends Bar {
       prevBarH = prevBarH + this.prevYF[k][j]
     }
 
-    if (
-      (i > 0 && !w.globals.isXNumeric) ||
-      (i > 0 &&
-        w.globals.isXNumeric &&
-        w.globals.seriesX[i - 1][j] === w.globals.seriesX[i][j])
-    ) {
+    let prevYValue
+    // get previous Y of any series for current X if there is one,
+    // otherwise we'll fallback to zero later on
+    if (i > 0 && w.globals.isXNumeric) {
+      w.globals.seriesX.forEach((x, k) => {
+        if (k === i || this.prevY[k] == null) return
+
+        x.forEach((y, m) => {
+          if (y === w.globals.seriesX[i][j]) {
+            prevYValue = this.prevY[k][m]
+          }
+        })
+      })
+    }
+
+    if (i > 0 && (!w.globals.isXNumeric || prevYValue != null)) {
       let bYP
-      let prevYValue = this.prevY[i - 1][j]
+      if (prevYValue == null) {
+        prevYValue = this.prevY[i - 1][j]
+      }
 
       if (this.prevYVal[i - 1][j] < 0) {
         if (this.series[i][j] >= 0) {


### PR DESCRIPTION
This is a potential fix for the stacked charts issue (#352).

The idea is to check for all series for a corresponding X key instead of going only by index and previous index as it is now.

This way, even when having inconsistent X values, it will still find matching ones and stack accordingly.

### Before:

![image](https://user-images.githubusercontent.com/16145977/53442549-85f9c000-39d7-11e9-970b-3a1675a344cb.png)


### After:

![image](https://user-images.githubusercontent.com/16145977/53442506-724e5980-39d7-11e9-9eba-008369493543.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - [x] No new tests but I've included a new sample file in this PR
- [x] New and existing unit tests pass locally with my changes

## Additionnal comments

- This particular PR only handles stacked **bar/column** currently. I still decided to submit it to get quick feedback and review on this. If accepted, we can then proceed to tackle other stacked chart types. Let me know.