### PR TITLE
Make `fontFamily` and `type` optional

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -56,7 +56,7 @@ declare module ApexCharts {
 type ApexChart = {
   width?: string | number;
   height?: string | number;
-  type: "line" | "area" | "bar" | "histogram" | "pie" | "donut" |
+  type?: "line" | "area" | "bar" | "histogram" | "pie" | "donut" |
   "radialBar" | "scatter" | "bubble" | "heatmap" | "candlestick" | "radar";
   foreColor?: string;
   fontFamily?: string;

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -59,7 +59,7 @@ type ApexChart = {
   type: "line" | "area" | "bar" | "histogram" | "pie" | "donut" |
   "radialBar" | "scatter" | "bubble" | "heatmap" | "candlestick" | "radar";
   foreColor?: string;
-  fontFamily: string;
+  fontFamily?: string;
   background?: string;
   offsetX?: number;
   offsetY?: number;


### PR DESCRIPTION
# New Pull Request

Looking at the [type definition](https://github.com/apexcharts/apexcharts.js/blob/master/types/apexcharts.d.ts#L62) I can see that `fontFamily` is required, but [here](https://github.com/apexcharts/apexcharts.js/blob/master/src/modules/settings/Options.js#L234) it looks like this should be an optional property as it has a default.

The solution

Marked property optional in `apexcharts.d.ts`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
