### PR TITLE
Fix an abbreviation in the DE locale

### DIFF
--- a/dist/locales/de.json
+++ b/dist/locales/de.json
@@ -2,7 +2,7 @@
   "name": "de",
   "options": {
     "months": ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"],
-    "shortMonths": ["Jan", "Feb", "Mar", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
+    "shortMonths": ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
     "days": ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
     "shortDays": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
     "toolbar": {


### PR DESCRIPTION
# Fix of an abbrevation in the DE locale

This Pull Request fixes the abbreviation (`shortMonths`) of 'März'. 