### PR TITLE
Typo: dominate-baseline

### DIFF
--- a/src/modules/Graphics.js
+++ b/src/modules/Graphics.js
@@ -483,7 +483,7 @@ class Graphics {
       x: x,
       y: y,
       'text-anchor': textAnchor,
-      'dominate-baseline': 'central',
+      'dominant-baseline': 'central',
       'font-size': fontSize,
       'font-family': fontFamily,
       fill: foreColor,


### PR DESCRIPTION
The correct attribute name is [dominant-baseline](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline).