### PR TITLE
fixed typo in german locale

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2,7 +2,7 @@
   "name": "de",
   "options": {
     "months": ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"],
-    "shortMonths": ["Jan", "Feb", "Mar", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
+    "shortMonths": ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
     "days": ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
     "shortDays": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
     "toolbar": {


### PR DESCRIPTION
Short form of März is Mär not Mar in german.

# New Pull Request

Just changed one char within a string. :-)
No issue exists.

## Type of change

Please delete options that are not relevant.

- [x] Fixed typo

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
