### PR TITLE
Alfie j missing valid data type

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -210,10 +210,17 @@ type ApexTitleSubtitle = {
 * Chart Series options.  
 * Use ApexNonAxisChartSeries for Pie and Donut charts.
 * See https://apexcharts.com/docs/options/series/
+*
+* According to the documentation at
+* https://apexcharts.com/docs/series/
+* Section 1: data can be a list of single numbers
+* Sections 2.1 and 3.1: data can be a list of tuples of two numbers
+* Sections 2.2 and 3.1: data can be a list of objects where x is a string
+* and y is a number
 */
 type ApexAxisChartSeries = {
   name: string;
-  data: number[] | { x: string; y: number }[];
+  data: number[] | { x: string; y: number }[] | [number, number][];
 }[];
 
 type ApexNonAxisChartSeries = number[];

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -215,7 +215,7 @@ type ApexTitleSubtitle = {
 * https://apexcharts.com/docs/series/
 * Section 1: data can be a list of single numbers
 * Sections 2.1 and 3.1: data can be a list of tuples of two numbers
-* Sections 2.2 and 3.1: data can be a list of objects where x is a string
+* Sections 2.2 and 3.2: data can be a list of objects where x is a string
 * and y is a number
 */
 type ApexAxisChartSeries = {


### PR DESCRIPTION
My chart is using the number-pair tuple list version of data, as documented at
https://apexcharts.com/docs/series/
in section 2.1/3.1, but that wasn't a valid TypeScript type.

I just made the number-pair tuple list a valid type.

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes