### PR TITLE
fix: Error: <circle> attribute r: A negative value is not valid

### DIFF
--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -112,6 +112,11 @@ class Pie {
     this.donutSize =
       (this.size * parseInt(w.config.plotOptions.pie.donut.size)) / 100
 
+    // on small chart size after few count of resizes browser window donutSize can be negative
+    if (this.donutSize < 0) {
+      this.donutSize = 0
+    }
+
     let scaleSize = w.config.plotOptions.pie.customScale
     let halfW = w.globals.gridWidth / 2
     let halfH = w.globals.gridHeight / 2


### PR DESCRIPTION
Fixed Error: <circle> attribute r: A negative value is not valid. 
Problem occurs in small pie donut chart if chart block resized.

![Peek 2019-05-31 12-00](https://user-images.githubusercontent.com/16123366/58695557-61c6ca00-839e-11e9-8767-58e11eb477e7.gif)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
