### PR TITLE
Invert text anchor for negative values

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -977,6 +977,16 @@ class Bar {
           }
         }
       }
+      
+      let modifiedDataLabelsConfig = {...dataLabelsConfig};
+      if(val < 0) {
+        modifiedDataLabelsConfig = { ...dataLabelsConfig };
+        if(dataLabelsConfig.textAnchor === 'start'){
+          modifiedDataLabelsConfig.textAnchor = 'end';
+        } else if (dataLabelsConfig.textAnchor === 'end') {
+          modifiedDataLabelsConfig.textAnchor = 'start';
+        }
+      }
 
       dataLabels.plotDataLabelsText({
         x,
@@ -985,7 +995,7 @@ class Bar {
         i,
         j,
         parent: elDataLabelsWrap,
-        dataLabelsConfig,
+        dataLabelsConfig: modifiedDataLabelsConfig,
         alwaysDrawDataLabel: true,
         offsetCorrection: true
       })

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -967,7 +967,12 @@ class Bar {
         // Note: This issue is only seen in stacked charts
         if (this.isHorizontal) {
           barWidth = this.series[i][j] / this.yRatio[this.yaxisIndex]
-          if (textRects.width / 1.6 > barWidth) {
+
+          // FIXED: Don't always hide the stacked negative side label
+          // A negative value will result in a negative bar width
+          // Only hide the text when the width is smaller (a higher negative number) than the negative bar width.
+          if ((barWidth > 0 && textRects.width / 1.6 > barWidth) || 
+          (barWidth < 0 && textRects.width / 1.6 < barWidth)) {
             text = ''
           }
         } else {

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -971,8 +971,10 @@ class Bar {
           // FIXED: Don't always hide the stacked negative side label
           // A negative value will result in a negative bar width
           // Only hide the text when the width is smaller (a higher negative number) than the negative bar width.
-          if ((barWidth > 0 && textRects.width / 1.6 > barWidth) || 
-          (barWidth < 0 && textRects.width / 1.6 < barWidth)) {
+          if (
+            (barWidth > 0 && textRects.width / 1.6 > barWidth) ||
+            (barWidth < 0 && textRects.width / 1.6 < barWidth)
+          ) {
             text = ''
           }
         } else {
@@ -982,15 +984,15 @@ class Bar {
           }
         }
       }
-      
-      let modifiedDataLabelsConfig = {...dataLabelsConfig};
+
+      let modifiedDataLabelsConfig = { ...dataLabelsConfig }
       if (this.isHorizontal) {
-        if(val < 0) {
-          modifiedDataLabelsConfig = { ...dataLabelsConfig };
-          if(dataLabelsConfig.textAnchor === 'start'){
-            modifiedDataLabelsConfig.textAnchor = 'end';
+        if (val < 0) {
+          modifiedDataLabelsConfig = { ...dataLabelsConfig }
+          if (dataLabelsConfig.textAnchor === 'start') {
+            modifiedDataLabelsConfig.textAnchor = 'end'
           } else if (dataLabelsConfig.textAnchor === 'end') {
-            modifiedDataLabelsConfig.textAnchor = 'start';
+            modifiedDataLabelsConfig.textAnchor = 'start'
           }
         }
       }

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -979,12 +979,14 @@ class Bar {
       }
       
       let modifiedDataLabelsConfig = {...dataLabelsConfig};
-      if(val < 0) {
-        modifiedDataLabelsConfig = { ...dataLabelsConfig };
-        if(dataLabelsConfig.textAnchor === 'start'){
-          modifiedDataLabelsConfig.textAnchor = 'end';
-        } else if (dataLabelsConfig.textAnchor === 'end') {
-          modifiedDataLabelsConfig.textAnchor = 'start';
+      if (this.isHorizontal) {
+        if(val < 0) {
+          modifiedDataLabelsConfig = { ...dataLabelsConfig };
+          if(dataLabelsConfig.textAnchor === 'start'){
+            modifiedDataLabelsConfig.textAnchor = 'end';
+          } else if (dataLabelsConfig.textAnchor === 'end') {
+            modifiedDataLabelsConfig.textAnchor = 'start';
+          }
         }
       }
 


### PR DESCRIPTION
# New Pull Request

Datalabel styling configuration for a horizontal bar chart is not sufficient.
When the bar is not wide enough the text is hardly readable depending on back/front color.

Fixes #675 

It also fixes an issue that when you have stacked:true and hideOverflowingLabels: true it always hides negative value datalabels (see https://codepen.io/anon/pen/KjzJvr)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
