### PR TITLE
fix forceNiceScale for small values #759 #672

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -77,8 +77,12 @@ export default class Range {
 
     let mag = Math.floor(Utils.log10(tempStep))
     let magPow = Math.pow(10, mag)
-    let magMsd = parseInt(tempStep / magPow)
+    let magMsd = Math.round(tempStep / magPow)
+    if (magMsd < 1) {
+      magMsd = 1
+    }
     let stepSize = magMsd * magPow
+
 
     // build Y label array.
     // Lower and upper bounds calculations
@@ -87,7 +91,7 @@ export default class Range {
     // Build array
     let val = lb
 
-    if (NO_MIN_MAX_PROVIDED && diff > 6) {
+    if (NO_MIN_MAX_PROVIDED) {
       while (1) {
         result.push(val)
         val += stepSize


### PR DESCRIPTION
# New Pull Request

This fixes rounding errors in forceNiceScale

before, magMsd was 0 as a result of parseInt(0.99999999999)
Now it can't happen.

Fixes # (issue)

I believe this is a correct fix for  #759 #672

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
