### PR TITLE
Added type definition to ApexAxisChartSeries

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -224,6 +224,7 @@ type ApexTitleSubtitle = {
 */
 type ApexAxisChartSeries = {
   name: string;
+  type?: string;
   data: number[] | { x: any; y: any }[] | [number, number][] | [number, number[]][];
 }[];
 


### PR DESCRIPTION
# New Pull Request

Added the type parameter for ApexAxisChartSeries, since it  and is used in the docs here: https://apexcharts.com/javascript-chart-demos/mixed-charts/multiple-yaxis/

It should not break existing TypeScript code since the parameter is optional. I tried it with some examples and it works. I don't know if this parameter works with every type of chart, if so, I can make the definition more specific.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
