### PR TITLE
Use the real chart's height when exporting image

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -44,7 +44,7 @@ class Exports {
       this.cleanup()
       const canvas = document.createElement('canvas')
       canvas.width = w.globals.svgWidth
-      canvas.height = w.globals.svgHeight
+      canvas.height = parseInt(w.globals.dom.elWrap.style.height) // because of resizeNonAxisCharts
 
       const canvasBg =
         w.config.chart.background === 'transparent'


### PR DESCRIPTION
# New Pull Request

Hi. We ran on an issue on our project where exported donut charts didn't have the proper hight (bottom legends were cut off).

After investigation, it appeared that exporting canvas' height was based on `svgHeight`, but `svgHeight` is actually not always representing the reality because of what `resizeNonAxisCharts` does.

So, maybe there is a better way, but I grabbed real hight from `dom.elWrap.style.height`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
