### PR TITLE
Take into account value offset when calculating the height of radial bar - fixes #930

### DIFF
--- a/src/charts/Radial.js
+++ b/src/charts/Radial.js
@@ -94,7 +94,19 @@ class Radial extends Pie {
       )
     }
 
-    w.globals.radialSize = size - size / (360 / (360 - totalAngle))
+    const angleRatio = (360 - totalAngle) / 360
+
+    w.globals.radialSize = size - size * angleRatio
+
+    if (
+      this.radialDataLabels.value.show &&
+      this.radialDataLabels.value.offsetY > 0
+    ) {
+      const offset = this.radialDataLabels.name.show
+        ? this.radialDataLabels.value.offsetY + 16 // Additional offset when name label is rendered
+        : this.radialDataLabels.value.offsetY
+      w.globals.radialSize += offset * angleRatio
+    }
 
     elSeries.add(elG.g)
 


### PR DESCRIPTION
I'm using apexcharts to render couple of semi-circle radial bars. After bumping version to 3.8.6, I noticed that the value texts get cut off because I'm rendering values slightly below the bar using positive `offsetY`. After a little digging, I noticed that the placelement of the value is not taken into account when calculating the height of the radial bar. It was not taken into account prior 3.8.6 version too, however, there seemed to be a constant spacing added for height, which was enough for my needs.

This PR adds functionality to include the value `offsetY` into the height calculation and sizing it appropriately, depending on the used angle. I'm not sure, but I suppose it may make sense to apply similar logic to other radial data labels.

Behaviour remains unchanged for full circle radial bars and if value offset is 0 or negative (thus shouldn't stretch the height downwards). And also when value text is not visible.

And of course, feel free to reject the PR if the change would cause other issues and/or is unwanted. Cheers!

Fixes #930 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
