### PR TITLE
Add missing `reversed` property

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -836,6 +836,7 @@ type ApexYAxis = {
   showAlways?: boolean;
   seriesName?: string;
   opposite?: boolean;
+  reversed?: boolean;
   logarithmic?: boolean;
   tickAmount?: number;
   forceNiceScale?: boolean,


### PR DESCRIPTION
Add missing property `reversed` to ApexYAxis.
source: https://apexcharts.com/docs/options/yaxis/#reversed

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings