### PR TITLE
Add number[] to type of stroke.width

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -249,8 +249,8 @@ type ApexStroke = {
   curve?: "smooth" | "straight" | "stepline";
   lineCap?: "butt" | "square" | "round";
   colors?: string[];
-  width?: number;
-  dashArray?: number | number[]
+  width?: number | number[];
+  dashArray?: number | number[];
 };
 
 type ApexAnnotations = {


### PR DESCRIPTION
Hi! As you have demonstrated in the following demo, you can use an array for the stroke width. This should be reflected in the official types.

https://apexcharts.com/javascript-chart-demos/mixed-charts/line-column/

## Type of change
TypeScript types

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
