### PR TITLE
Update RangeBar.js

### DIFF
--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -94,113 +94,93 @@ class RangeBar extends Bar {
           }
         }
 
-        let itemsLen = 1
         let y1 = this.seriesRangeStart[i][j]
         let y2 = this.seriesRangeEnd[i][j]
 
-        const srt =
-          w.globals.seriesRangeBarTimeline.length &&
-          w.globals.seriesRangeBarTimeline[i][j]
+        let paths = null
+        let barYPosition = null
+        const params = { x, y, pathTo, pathFrom, strokeWidth, elSeries }
 
-        if (srt) {
-          itemsLen = srt.y.length
-          y = 0
-        }
+        if (this.isHorizontal) {
+          barYPosition = y + barHeight * this.visibleI
 
-        for (let ii = 0; ii < itemsLen; ii++) {
-          let paths = null
-          let barYPosition = null
-          const params = { x, y, pathTo, pathFrom, strokeWidth, elSeries }
+          let srty = (yDivision - barHeight * this.seriesLen) / 2
 
-          if (this.isHorizontal) {
-            barYPosition = y + barHeight * this.visibleI
+          const yPosition = w.globals.labels.indexOf(
+            w.config.series[i].data[j].x
+          )
 
-            if (srt) {
-              let srty = (yDivision - barHeight * this.seriesLen) / 2
-              const rt = srt.y[ii]
-              y1 = rt.y1
-              y2 = rt.y2
+          barYPosition =
+            srty + barHeight * this.visibleI + yDivision * yPosition
 
-              const yPosition = w.globals.labels.indexOf(srt.x)
-
-              barYPosition =
-                srty + barHeight * this.visibleI + yDivision * yPosition
-            } else {
-              // no item exists for further indices in a timeline, hence break
-              if (this.isTimelineBar) {
-                break
-              }
-            }
-
-            paths = this.drawRangeBarPaths({
-              indexes: { i, j, realIndex, bc },
-              barHeight,
-              barYPosition,
-              zeroW,
-              yDivision,
-              y1,
-              y2,
-              ...params
-            })
-
-            barWidth = paths.barWidth
-          } else {
-            paths = this.drawRangeColumnPaths({
-              indexes: { i, j, realIndex, bc },
-              zeroH,
-              barWidth,
-              xDivision,
-              ...params
-            })
-
-            barHeight = paths.barHeight
-          }
-
-          pathTo = paths.pathTo
-          pathFrom = paths.pathFrom
-          y = paths.y
-          x = paths.x
-
-          // push current X
-          let fillColor = null
-
-          if (
-            w.config.series[i].data[j] &&
-            w.config.series[i].data[j].fillColor
-          ) {
-            fillColor = w.config.series[i].data[j].fillColor
-          }
-
-          let pathFill = fill.fillPath({
-            seriesNumber: realIndex,
-            color: fillColor
-          })
-
-          let lineFill = w.globals.stroke.colors[realIndex]
-
-          this.renderSeries({
-            realIndex,
-            pathFill,
-            lineFill,
-            j,
-            i,
-            x,
-            y,
-            y1,
-            y2,
-            pathFrom,
-            pathTo,
-            strokeWidth,
-            elSeries,
-            series,
+          paths = this.drawRangeBarPaths({
+            indexes: { i, j, realIndex, bc },
             barHeight,
             barYPosition,
-            barWidth,
-            elDataLabelsWrap,
-            visibleSeries: this.visibleI,
-            type: 'rangebar'
+            zeroW,
+            yDivision,
+            y1,
+            y2,
+            ...params
           })
+
+          barWidth = paths.barWidth
+        } else {
+          paths = this.drawRangeColumnPaths({
+            indexes: { i, j, realIndex, bc },
+            zeroH,
+            barWidth,
+            xDivision,
+            ...params
+          })
+
+          barHeight = paths.barHeight
         }
+
+        pathTo = paths.pathTo
+        pathFrom = paths.pathFrom
+        y = paths.y
+        x = paths.x
+
+        // push current X
+        let fillColor = null
+
+        if (
+          w.config.series[i].data[j] &&
+          w.config.series[i].data[j].fillColor
+        ) {
+          fillColor = w.config.series[i].data[j].fillColor
+        }
+
+        let pathFill = fill.fillPath({
+          seriesNumber: realIndex,
+          color: fillColor
+        })
+
+        let lineFill = w.globals.stroke.colors[realIndex]
+
+        this.renderSeries({
+          realIndex,
+          pathFill,
+          lineFill,
+          j,
+          i,
+          x,
+          y,
+          y1,
+          y2,
+          pathFrom,
+          pathTo,
+          strokeWidth,
+          elSeries,
+          series,
+          barHeight,
+          barYPosition,
+          barWidth,
+          elDataLabelsWrap,
+          visibleSeries: this.visibleI,
+          type: 'rangebar'
+        })
       }
 
       ret.add(elSeries)


### PR DESCRIPTION
I also faced the bug #1144 - rangeBar doesn't correctly process `fillColor` from data items. It happens because of the for loop

https://github.com/apexcharts/apexcharts.js/blob/41c220c106c0f443a09efa829f56cd615bbff8bb/src/charts/RangeBar.js#L110 

that results in a strange iteration sequence:
* The loop with `j` variable goes over all series items
* The first time a new `x` label is encountered all items with this label (`srt`) are processed in the `ii` loop. That's when each of them is rendered using the same `j` value and corresponding `fillColor`.
* For `j` corresponding to repeating labels the loop breaks at line 131 and no rendered items are indexed with it.

I've removed the `ii` loop, so that items are rendered directly in the `j` loop. It seems correct, but can possibly break compatibility with other scenarios (the tests were randomly failing for me).

Fixes #1144 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
