### PR TITLE
Fixes annotation click issue #1021

### DIFF
--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -32,7 +32,7 @@
   opacity: 0;
 }
 
-.apexcharts-gridline, .apexcharts-text, .apexcharts-yaxis-annotations, .apexcharts-xaxis-annotations {
+.apexcharts-gridline, .apexcharts-text {
   pointer-events: none;
 }
 

--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -32,7 +32,7 @@
   opacity: 0;
 }
 
-.apexcharts-gridline, .apexcharts-text, .apexcharts-yaxis-annotations, .apexcharts-xaxis-annotations, .apexcharts-point-annotations {
+.apexcharts-gridline, .apexcharts-text, .apexcharts-yaxis-annotations, .apexcharts-xaxis-annotations {
   pointer-events: none;
 }
 


### PR DESCRIPTION
Summary: Some CSS had disabled the click event on point annotations, x and y axis annotations as well.

No extra dependencies required.

Fixes: #1021

Change Type: Bug fix (non-breaking change which fixes an issue)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Not required in this case)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works  (Not required in this case)
- [x] New and existing unit tests pass locally with my changes  (this does not appear to be covered by any tests)