### PR TITLE
Fix ApexLegend type in apexcharts.d.ts

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -603,7 +603,7 @@ type ApexLegend = {
   tooltipHoverFormatter?(legendName: string, opts?: any): string
   textAnchor?: string
   labels?: {
-    color?: string | string[]
+    colors?: string | string[]
     useSeriesColors?: boolean
   }
   markers?: {


### PR DESCRIPTION
Issue: setting labels color in **ng-apexcharts** doesn't work because `labels.color` in type `ApexLegend` should be `labels.colors`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
