### PR TITLE
Fix: Chart series support null value as data

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -264,15 +264,17 @@ type ApexTitleSubtitle = {
  * Sections 2.1 and 3.1: data can be a list of tuples of two numbers
  * Sections 2.2 and 3.2: data can be a list of objects where x is a string
  * and y is a number
+ * And according to the demos, data can contain null.
+ * https://apexcharts.com/javascript-chart-demos/line-charts/null-values/
  */
 type ApexAxisChartSeries = {
   name?: string
   type?: string
   data:
-    | number[]
+    | (number | null)[]
     | { x: any; y: any, fillColor?: string, strokeColor?: string }[]
-    | [number, number][]
-    | [number, number[]][]
+    | [number, (number | null)][]
+    | [number, (number | null)[]][]
 }[]
 
 type ApexNonAxisChartSeries = number[]


### PR DESCRIPTION
# New Pull Request
According to demos, data on `ApexAxisChartSeries` can be `null`.
https://apexcharts.com/javascript-chart-demos/line-charts/null-values/
So this PR added null types to `ApexAxisChartSeries`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
