### PR TITLE
Fix type definition file: support multiline labels

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -797,7 +797,7 @@ type ApexXAxis = {
     offsetX?: number
     offsetY?: number
     format?: string
-    formatter?(value: string, timestamp?: number): string
+    formatter?(value: string, timestamp?: number): string | string[]
     datetimeUTC?: boolean
     datetimeFormatter?: {
       year?: string


### PR DESCRIPTION
Since v3.15.2 (maybe), xaxis formatter supports multiline labels. (ref. https://github.com/apexcharts/apexcharts.js/issues/670#issuecomment-578011468)
But type definition file is not updated, this PR fixed that.
When there are more formatters which support multiline please notice, I fix d.ts :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
