### PR TITLE
partially support png download in ie11

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ If you need to make it work with IE11, you need to include these polyfills befor
 - [promise-polyfill](https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js)
 - [classlist.js](https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill)
 - [findIndex](https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn) - You will need this only if you require timeline/rangebar charts
+- [canvg](https://unpkg.com/canvg@3.0.4/lib/umd.js) - You will need this only if you require PNG download of your charts
 
 ## Development
 


### PR DESCRIPTION
# New Pull Request

This pull request is a partial fix for inability to download png in IE11 as discussed in issue https://github.com/apexcharts/apexcharts.js/issues/518. The caveat is that the exported image does not contain a legend. Fully fixing this issue would probably require a full rewrite of the legend code to generate svg elements instead of html.

This PR fixes the following problems, which previously prevented this feature from working:
- Fix the invalid svg string generated by IE11 using regex. 
- Use canvg in IE11 (if present) to generate canvas from svg, thus preventing a SecurityError from being thrown when we try to get image from the canvas.
- Remove usage of revokeObjectURL, since it serves only to release objects allocated with createObjectURL, which is not the case here. IE11 and Edge raise an error when it's used with data url.
- Use msSaveBlob instead of trying to navigate to data url, since this is not supported by IE and Edge.

As a side effect, this also fixes download issues in the current version of Edge.

I'm not totally happy with the shape of dataURI method. I wasn't sure how to hack in the blob download.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
