### PR TITLE
Skip getting elPath.node if element not found in toggleDataPointSelection

### DIFF
--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -164,6 +164,7 @@ export default class UpdateHelpers {
       graphics.pathMouseDown(elPath, null)
     } else {
       console.warn('toggleDataPointSelection: Element not found')
+      return null;
     }
 
     return elPath.node ? elPath.node : null


### PR DESCRIPTION
If seriesIndex / dataPointIndex is incorrect in toggleDataPointSelection it generates this error:

![image](https://user-images.githubusercontent.com/19765124/74293633-45ec3400-4d33-11ea-82b5-24c8d1ad1b4a.png)

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
