### PR TITLE
Hidden Series and updateOptions() issue fix

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -355,7 +355,7 @@ export default class ApexCharts {
   ) {
     const w = this.w
     if (options.series) {
-      this.series.resetSeries(false)
+      this.series.resetSeries(false, true, false)
       if (options.series.length && options.series[0].data) {
         options.series = options.series.map((s, i) => {
           return this.updateHelpers._extendSeries(s, i)

--- a/src/modules/Series.js
+++ b/src/modules/Series.js
@@ -82,17 +82,20 @@ export default class Series {
     }
   }
 
-  resetSeries(shouldUpdateChart = true, shouldResetZoom = true) {
+  resetSeries(shouldUpdateChart = true, shouldResetZoom = true, shouldResetCollapsed = true) {
     const w = this.w
 
     let series = w.globals.initialSeries.slice()
     w.config.series = series
 
-    w.globals.collapsedSeries = []
-    w.globals.ancillaryCollapsedSeries = []
-    w.globals.collapsedSeriesIndices = []
-    w.globals.ancillaryCollapsedSeriesIndices = []
     w.globals.previousPaths = []
+
+    if (shouldResetCollapsed) {
+      w.globals.collapsedSeries = []
+      w.globals.ancillaryCollapsedSeries = []
+      w.globals.collapsedSeriesIndices = []
+      w.globals.ancillaryCollapsedSeriesIndices = []
+    }
 
     if (shouldUpdateChart) {
       if (shouldResetZoom) {
@@ -315,8 +318,6 @@ export default class Series {
     const w = this.w
     w.globals.previousPaths = []
     w.globals.allSeriesCollapsed = false
-    w.globals.collapsedSeries = []
-    w.globals.collapsedSeriesIndices = []
   }
 
   handleNoData() {


### PR DESCRIPTION
# New Pull Request

Calling `chart.updateOptions()` after `hideSeries(...)`  causes next issues:

1) `updateOptions({...})` should not change the state of hidden/visible series (the case in which no new series get passed).
2) after `updateOptions({...})` was called - it is impossible to toggle serie visibility back by clicking on legend.

Example here (blue timeserie is broken):
https://codepen.io/mallburn/pen/ZEGOZRK 

Fixes # (issue)
https://github.com/apexcharts/apexcharts.js/issues/655
https://github.com/apexcharts/apexcharts.js/issues/656

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
