### PR TITLE
add array type to ApexStroke Curve

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -289,7 +289,7 @@ type ApexNonAxisChartSeries = number[]
  */
 type ApexStroke = {
   show?: boolean
-  curve?: 'smooth' | 'straight' | 'stepline'
+  curve?: 'smooth' | 'straight' | 'stepline' | ('smooth' | 'straight' | 'stepline')[]
   lineCap?: 'butt' | 'square' | 'round'
   colors?: string[]
   width?: number | number[]


### PR DESCRIPTION
# New Pull Request
add array type to  ApexStroke curve property.(at type definition)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
