### PR TITLE
Fix wrong polish translation of zoomOut

### DIFF
--- a/dist/locales/pl.json
+++ b/dist/locales/pl.json
@@ -47,7 +47,7 @@
       "selection": "Wybieranie",
       "selectionZoom": "Zoom: Wybieranie",
       "zoomIn": "Zoom: Przybliż",
-      "zoomOut": "Zoom: Oddaj",
+      "zoomOut": "Zoom: Oddal",
       "pan": "Przesuwanie",
       "reset": "Resetuj"
     }


### PR DESCRIPTION
"Oddaj" means "give back"
"Oddal" means "zoom out" :-)