### PR TITLE
Legend showForSingleSeries with no data issue fix

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -128,10 +128,9 @@ export default class ApexCharts {
     gl.comboCharts = combo.comboCharts
     gl.comboBarCount = combo.comboBarCount
 
-    if (
-      ser.length === 0 ||
-      (ser.length === 1 && ser[0].data && ser[0].data.length === 0)
-    ) {
+    const allSeriesAreEmpty = ser.every(s => s.data && s.data.length === 0)
+
+    if (ser.length === 0 || allSeriesAreEmpty) {
       this.series.handleNoData()
     }
 
@@ -153,7 +152,11 @@ export default class ApexCharts {
 
     // legend is calculated here before coreCalculations because it affects the plottable area
     // if there is some data to show or user collapsed all series, then proceed drawing legend
-    if (!gl.noData || gl.collapsedSeries.length === gl.series.length) {
+    if (
+      !gl.noData ||
+      gl.collapsedSeries.length === gl.series.length ||
+      w.config.legend.showForSingleSeries
+    ) {
       this.legend.init()
     }
 


### PR DESCRIPTION
# New Pull Request

ApexCharts documentation states next:
```
showForSingleSeries: Boolean
Show legend even if there is just 1 series.
```
But in case when 
- no series data (empty array)
- and only 1 serie for the chart

The legend doesn't shows up.

I think that `showForSingleSeries = true` flag should be main indicator for legend visibility and overwrite any other conditions.

I also spend some time trying to add tests, but 

- for unit test i've checked that apexcharts project does not uses `toHaveBeenCalled`, and in this case the only good way to unit test is to check if `this.drawLegends()` was called inside Legend.js. so i decided to not add new ways to unit test

- as for e2e i didn't understand how to add sample for generation. if you can give me some reference or describe how to do that - i might add e2e test here, if needed

thanks :) 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
