### PR TITLE
Fix brush chart selection with multiple y axis

### DIFF
--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -535,17 +535,28 @@ export default class Core {
             const scale = new Scales(targetChart)
             yaxis = scale.autoScaleY(targetChart, yaxis, e)
           }
+
+          const multipleYaxis = targetChart.w.config.yaxis.reduce(
+            (acc, curr, index) => {
+              return [
+                ...acc,
+                {
+                  ...targetChart.w.config.yaxis[index],
+                  min: yaxis[0].min,
+                  max: yaxis[0].max
+                }
+              ]
+            },
+            []
+          )
+
           targetChart.ctx.updateHelpers._updateOptions(
             {
               xaxis: {
                 min: e.xaxis.min,
                 max: e.xaxis.max
               },
-              yaxis: {
-                ...targetChart.w.config.yaxis[0],
-                min: yaxis[0].min,
-                max: yaxis[0].max
-              }
+              yaxis: multipleYaxis
             },
             false,
             false,


### PR DESCRIPTION
# New Pull Request

Brush selection removes multiple y axis on the main line/area chart. PR improves this behavior.

Fixes
https://github.com/apexcharts/apexcharts.js/issues/1455
https://github.com/apexcharts/apexcharts.js/issues/801

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
