### PR TITLE
broken link to patreon not being displayed on github correctly

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -2,7 +2,7 @@
 
 ## Our Backers and supporters
 
-Financial contributions to ApexCharts go towards ongoing development costs, servers, etc. You can join them in supporting ApexCharts development by visiting our page on [Patreon](patreon.com/junedchhipa)!
+Financial contributions to ApexCharts go towards ongoing development costs, servers, etc. You can join them in supporting ApexCharts development by visiting our page on [Patreon](https://www.patreon.com/junedchhipa)!
 
 
 ### Backers


### PR DESCRIPTION
# New Pull Request

Just fixed your patreon link in Backers.md: When clicking on github it was parsed as a relative link and broken.
