### PR TITLE
Add 'startAngle' property to pie and donut charts

### DIFF
--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -511,6 +511,7 @@ export default class Options {
           customScale: 1,
           offsetX: 0,
           offsetY: 0,
+          startAngle: 0,
           expandOnClick: true,
           dataLabels: {
             // These are the percentage values which are displayed on slice


### PR DESCRIPTION
# New Pull Request

Adds a property named 'startAngle' that determines where pie or donut charts start drawing.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
