### PR TITLE
Fixing timestamp for older dates

### DIFF
--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -390,7 +390,7 @@ export default class Data {
           }
         } else {
           // user provided timestamps
-          if (String(xlabels[j]).length !== 13) {
+          if (String(xlabels[j]).length !== 12 || String(xlabels[j]).length !== 13) {
             throw new Error('Please provide a valid JavaScript timestamp')
           } else {
             this.twoDSeriesX.push(xlabels[j])


### PR DESCRIPTION
# New Pull Request

The code was validating a timestamp by checking if the number of digits was equal to 13. However, dates before 08/08/2001 have a 12 digit timestamp.

I changed the code to validate the timestamp by checking if the number has length 12 or 13.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
