### PR TITLE
Set HeatMap's baseline color appropriately for dark mode.

### DIFF
--- a/src/charts/HeatMap.js
+++ b/src/charts/HeatMap.js
@@ -108,10 +108,17 @@ export default class HeatMap {
 
         if (w.config.plotOptions.heatmap.enableShades) {
           if (colorShadePercent < 0) colorShadePercent = 0
-          color = Utils.hexToRgba(
-            utils.shadeColor(colorShadePercent, heatColorProps.color),
-            w.config.fill.opacity
-          )
+          if (this.w.config.theme.mode === 'dark') {
+            color = Utils.hexToRgba(
+              utils.shadeColor(colorShadePercent * -1, heatColorProps.color),
+              w.config.fill.opacity
+            )  
+          } else {
+            color = Utils.hexToRgba(
+              utils.shadeColor(colorShadePercent, heatColorProps.color),
+              w.config.fill.opacity
+            )  
+          }
         }
 
         if (w.config.fill.type === 'image') {


### PR DESCRIPTION
Set HeatMap's baseline color for dark mode -- original light mode works as before.  Coloring is still a bit off from the default dark background, but this way of coding is consistent with [other places in the codebase](https://github.com/apexcharts/apexcharts.js/blob/47b97082117d899d86b866bc779ea1e5a649c51a/src/modules/Theme.js#L82).

This addresses: https://github.com/apexcharts/apexcharts.js/issues/1532

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
