### PR TITLE
Draw lines as shape annotations

### DIFF
--- a/src/modules/annotations/Annotations.js
+++ b/src/modules/annotations/Annotations.js
@@ -175,6 +175,11 @@ export default class Annotations {
       type: params.type,
       x: params.x || 0,
       y: params.y || 0,
+      x1: params.x1 || 0,
+      y1: params.y1 || 0,
+      lineColor: params.lineColor || '#a8a8a8',
+      dashArray: params.dashArray || 0,
+      strokeWidth: params.strokeWidth || null,
       width: params.width || '100%',
       height: params.height || 50,
       circleRadius: params.radius || 25,
@@ -194,27 +199,40 @@ export default class Annotations {
     }
 
     let elShape = null
-    if (opts.type === 'circle') {
-      elShape = this.graphics.drawCircle(opts.circleRadius, {
-        fill: opts.backgroundColor,
-        stroke: opts.borderColor,
-        'stroke-width': opts.borderWidth,
-        opacity: opts.opacity,
-        cx: opts.x,
-        cy: opts.y
-      })
-    } else {
-      elShape = this.graphics.drawRect(
-        opts.x,
-        opts.y,
-        opts.width,
-        opts.height,
-        opts.borderRadius,
-        opts.backgroundColor,
-        opts.opacity,
-        opts.borderWidth,
-        opts.borderColor
-      )
+    switch (opts.type) {
+      case 'circle':
+        elShape = this.graphics.drawCircle(opts.circleRadius, {
+          fill: opts.backgroundColor,
+          stroke: opts.borderColor,
+          'stroke-width': opts.borderWidth,
+          opacity: opts.opacity,
+          cx: opts.x,
+          cy: opts.y
+        })
+        break
+      case 'line':
+        elShape = this.graphics.drawLine(
+          opts.x,
+          opts.y,
+          opts.x1,
+          opts.y1,
+          opts.lineColor,
+          opts.dashArray,
+          opts.strokeWidth
+        )
+        break
+      default:
+        elShape = this.graphics.drawRect(
+          opts.x,
+          opts.y,
+          opts.width,
+          opts.height,
+          opts.borderRadius,
+          opts.backgroundColor,
+          opts.opacity,
+          opts.borderWidth,
+          opts.borderColor
+        )
     }
 
     const parent = w.globals.dom.baseEl.querySelector(opts.appendTo)

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -400,6 +400,11 @@ type PointAnnotations = {
 type ShapeAnnotations = {
   x?: number
   y?: number
+  x1?: number
+  y1?: number
+  lineColor?: string
+  dashArray?: number
+  strokeWidth?: number
   type?: string
   width?: number | string
   height?: number


### PR DESCRIPTION
# Draw lines as shape annotations

This is a new feature that allows lines to be drawn as shape annotations. The motivation was to start partially addressing feature requests like #1280 as we wanted to do simple annotations on radial charts. Though more work would be required to address #1280 as it would be good to get it working like points annotation, it's a start 😄. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
