### PR TITLE
Fix unhandled error when toggling visibility

### DIFF
--- a/dist/apexcharts.js
+++ b/dist/apexcharts.js
@@ -9175,7 +9175,7 @@
             }
           }
         } else if (format === 'xy') {
-          if (ser[i].data[0].y.length !== 4) {
+          if (ser[i].data[0] && ser[i].data[0].y.length !== 4) {
             throw new Error(err);
           }
 


### PR DESCRIPTION
Added additional checking to handle unhandled error when toggling visibility for candlestick.

# New Pull Request

There's an unhandled error when toggling visibility for candlestick when using XY format. Added checking to check to ignore if element is undefined when trying to access series' first element in the respective data array. Alternatively, the checking can be changed to checking the length of the data array as well.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
