### PR TITLE
add widthExcludeAxes prop that will let chart know whether to ignore …

### DIFF
--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -96,6 +96,14 @@ export default class Dimensions {
 
     this.yAxisWidth = this.dimYAxis.getTotalYAxisWidth()
 
+    // account for widthExcludeAxes prop
+    if (w.config.chart.widthExcludeAxes) {
+      gl.svgWidth += this.yAxisWidth
+      Graphics.setAttrs(gl.dom.Paper.node, {
+        width: gl.svgWidth
+      })
+    }
+
     let xaxisLabelCoords = this.dimXAxis.getxAxisLabelsCoords()
     let xtitleCoords = this.dimXAxis.getxAxisTitleCoords()
 
@@ -104,8 +112,8 @@ export default class Dimensions {
     gl.translateXAxisY = w.globals.rotateXLabels ? this.xAxisHeight / 8 : -4
     gl.translateXAxisX =
       w.globals.rotateXLabels &&
-      w.globals.isXNumeric &&
-      w.config.xaxis.labels.rotate <= -45
+        w.globals.isXNumeric &&
+        w.config.xaxis.labels.rotate <= -45
         ? -this.xAxisWidth / 4
         : 0
 
@@ -199,8 +207,8 @@ export default class Dimensions {
 
     const type =
       cnf.chart.type === 'pie' ||
-      cnf.chart.type === 'polarArea' ||
-      cnf.chart.type === 'donut'
+        cnf.chart.type === 'polarArea' ||
+        cnf.chart.type === 'donut'
         ? 'pie'
         : 'radialBar'
 
@@ -254,7 +262,7 @@ export default class Dimensions {
     const w = this.w
     this.xAxisHeight =
       (xaxisLabelCoords.height + xtitleCoords.height) *
-        (w.globals.isMultiLineX ? 1.2 : w.globals.LINE_HEIGHT_RATIO) +
+      (w.globals.isMultiLineX ? 1.2 : w.globals.LINE_HEIGHT_RATIO) +
       (w.globals.rotateXLabels ? 22 : 10)
 
     this.xAxisWidth = xaxisLabelCoords.width

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -367,6 +367,7 @@ export default class Options {
         },
         type: 'line',
         width: '100%',
+        widthExcludeAxes: false,
         zoom: {
           enabled: true,
           type: 'x',
@@ -514,7 +515,7 @@ export default class Options {
               formatter(w) {
                 return (
                   w.globals.seriesTotals.reduce((a, b) => a + b, 0) /
-                    w.globals.series.length +
+                  w.globals.series.length +
                   '%'
                 )
               }


### PR DESCRIPTION
…the axes width when setting the svgwidth

# New Pull Request

This PR adds a widthExcludeAxes prop to the chart options that is defaulted false. If it it set to true by the user, then whatever width that is inputted will be the width of the chart, excluding the axes. This feature was added so that it is easier to line up charts on a page when they have varying axes widths. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
