### PR TITLE
Theme mode "transparent" added, HeatMap rectangles become transparent instead of being shaded

### DIFF
--- a/src/charts/HeatMap.js
+++ b/src/charts/HeatMap.js
@@ -113,6 +113,8 @@ export default class HeatMap {
               utils.shadeColor(colorShadePercent * -1, heatColorProps.color),
               w.config.fill.opacity
             )
+          } else if (this.w.config.theme.mode === 'transparent') {
+            color = Utils.hexToRgba(heatColorProps.color, colorShadePercent)
           } else {
             color = Utils.hexToRgba(
               utils.shadeColor(colorShadePercent, heatColorProps.color),


### PR DESCRIPTION
# New Pull Request

This PR adds a new `theme.mode` option which is `"transparent"` which works on heatmap type of chart. If this option is selected rectangles of the heatmap become transparent instead of being shaded. Here is an example of what am I talking about.
![Screenshot 2020-08-13 at 16 24 02](https://user-images.githubusercontent.com/22592205/90146540-72841580-dd81-11ea-8b04-2963730fceab.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
