### PR TITLE
added scale property to chart configuration, by default is 1

### DIFF
--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -291,6 +291,7 @@ export default class Options {
         group: undefined,
         offsetX: 0,
         offsetY: 0,
+        scale: 1,
         selection: {
           enabled: false,
           type: 'x',

--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -39,8 +39,10 @@ export default class Utils {
       xDivisor = hoverWidth / w.globals.dataPoints
     }
 
-    let hoverX = clientX - seriesBound.left - w.globals.barPadForNumericAxis
-    let hoverY = clientY - seriesBound.top
+    let hoverX =
+      (clientX - seriesBound.left - w.globals.barPadForNumericAxis) /
+      w.config.chart.scale
+    let hoverY = (clientY - seriesBound.top) / w.config.chart.scale
 
     const notInRect =
       hoverX < 0 ||


### PR DESCRIPTION
# New Pull Request

Now charts has the possibility to scale with the css transform

Fixes #1849 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
