### PR TITLE
Fix for #761, no legend color when printing

### DIFF
--- a/src/modules/legend/Legend.js
+++ b/src/modules/legend/Legend.js
@@ -132,6 +132,7 @@ class Legend {
 
       mStyle.background = fillcolor[i]
       mStyle.color = fillcolor[i]
+      mStyle.setProperty('background', fillcolor[i], 'important');
 
       // override fill color with custom legend.markers.fillColors
       if (


### PR DESCRIPTION
# New Pull Request
This is the fix that was proposed in #761 by @RollingStone85. I tested it and it works well. Before the fix, no legend was printed (although the browser was set to print background colors) and after the fix it was displayed!
I hope this can be acceptable and can help others!

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
