### PR TITLE
Remove isFirefox checks which inhibit the lighten/darken …

### DIFF
--- a/src/modules/Filters.js
+++ b/src/modules/Filters.js
@@ -51,10 +51,6 @@ class Filters {
     const w = this.w
     const { intensity } = attrs
 
-    if (Utils.isFirefox()) {
-      return
-    }
-
     el.unfilter(true)
 
     let filter = new window.SVG.Filter()
@@ -79,10 +75,6 @@ class Filters {
   addDarkenFilter(el, i, attrs) {
     const w = this.w
     const { intensity } = attrs
-
-    if (Utils.isFirefox()) {
-      return
-    }
 
     el.unfilter(true)
 
@@ -158,7 +150,7 @@ class Filters {
     el.filter((add) => {
       let shadowBlur = null
       if (Utils.isSafari() || Utils.isFirefox() || Utils.isIE()) {
-        // safari/firefox has some alternative way to use this filter
+        // safari/firefox/IE have some alternative way to use this filter
         shadowBlur = add
           .flood(color, opacity)
           .composite(add.sourceAlpha, 'in')


### PR DESCRIPTION
# New Pull Request

Fixes # (https://github.com/apexcharts/apexcharts.js/issues/1737)

This PR fixes https://github.com/apexcharts/apexcharts.js/issues/1737 by removing the `isFirefox()` checks within the `addLightenFilter` and `addDarkenFilter` functions (which would cause the `addLightenFilter` and `addDarkenFilter` functions to stop execution and simply return when `isFirefox()` is evaluated to `true`). 

**Previous Behaviour (on Firefox):** 
<a href="https://gyazo.com/6bfd5cbc2a3aa59ff6e548a984fe04d4"><img src="https://i.gyazo.com/6bfd5cbc2a3aa59ff6e548a984fe04d4.gif" alt="Image from Gyazo" width="668"/></a>

**New Behaviour (on Firefox):**
<a href="https://gyazo.com/55f67071e5f206405c838e6cf32b6974"><img src="https://i.gyazo.com/55f67071e5f206405c838e6cf32b6974.gif" alt="Image from Gyazo" width="704"/></a>

Note: the unexpected behaviour found on Safari as described in https://github.com/apexcharts/apexcharts.js/issues/1737 could not be reproduced locally on my end using Safari version `14.0`, so it is possible this fix (specific to Firefox) is sufficient to close this issue. For example, the following is the behaviour I can observe locally (on Safari): 

<a href="https://gyazo.com/46fc1ed2897ac9a33cfb2187498e78df"><img src="https://i.gyazo.com/46fc1ed2897ac9a33cfb2187498e78df.gif" alt="Image from Gyazo" width="660"/></a>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
