### PR TITLE
Add flag to group rows together in a multi-series timeline chart

### DIFF
--- a/samples/vanilla-js/timelines/multi-series-group-rows.html
+++ b/samples/vanilla-js/timelines/multi-series-group-rows.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Multi-series Timeline with Grouped Rows</title>
+
+  <link href="../../assets/styles.css" rel="stylesheet" />
+
+  <style>
+    #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+  </style>
+
+  <script>
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+      )
+  </script>
+
+
+  <script src="../../../dist/apexcharts.js"></script>
+
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
+</head>
+
+<body>
+  <div id="chart"></div>
+
+  <script>
+
+    var options = {
+      series: [
+        // George Washington
+        {
+          name: 'George Washington',
+          data: [
+            {
+              x: 'President',
+              y: [
+                new Date(1789, 3, 30).getTime(),
+                new Date(1797, 2, 4).getTime()
+              ]
+            },
+          ]
+        },
+        // John Adams
+        {
+          name: 'John Adams',
+          data: [
+            {
+              x: 'President',
+              y: [
+                new Date(1797, 2, 4).getTime(),
+                new Date(1801, 2, 4).getTime()
+              ]
+            },
+            {
+              x: 'Vice President',
+              y: [
+                new Date(1789, 3, 21).getTime(),
+                new Date(1797, 2, 4).getTime()
+              ]
+            }
+          ]
+        },
+        // Thomas Jefferson
+        {
+          name: 'Thomas Jefferson',
+          data: [
+            {
+              x: 'President',
+              y: [
+                new Date(1801, 2, 4).getTime(),
+                new Date(1809, 2, 4).getTime()
+              ]
+            },
+            {
+              x: 'Vice President',
+              y: [
+                new Date(1797, 2, 4).getTime(),
+                new Date(1801, 2, 4).getTime()
+              ]
+            },
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1790, 2, 22).getTime(),
+                new Date(1793, 11, 31).getTime()
+              ]
+            }
+          ]
+        },
+        // Aaron Burr
+        {
+          name: 'Aaron Burr',
+          data: [
+            {
+              x: 'Vice President',
+              y: [
+                new Date(1801, 2, 4).getTime(),
+                new Date(1805, 2, 4).getTime()
+              ]
+            }
+          ]
+        },
+        // George Clinton
+        {
+          name: 'George Clinton',
+          data: [
+            {
+              x: 'Vice President',
+              y: [
+                new Date(1805, 2, 4).getTime(),
+                new Date(1812, 3, 20).getTime()
+              ]
+            }
+          ]
+        },
+        // John Jay
+        {
+          name: 'John Jay',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1789, 8, 25).getTime(),
+                new Date(1790, 2, 22).getTime()
+              ]
+            }
+          ]
+        },
+        // Edmund Randolph
+        {
+          name: 'Edmund Randolph',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1794, 0, 2).getTime(),
+                new Date(1795, 7, 20).getTime()
+              ]
+            }
+          ]
+        },
+        // Timothy Pickering
+        {
+          name: 'Timothy Pickering',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1795, 7, 20).getTime(),
+                new Date(1800, 4, 12).getTime()
+              ]
+            }
+          ]
+        },
+        // Charles Lee
+        {
+          name: 'Charles Lee',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1800, 4, 13).getTime(),
+                new Date(1800, 5, 5).getTime()
+              ]
+            }
+          ]
+        },
+        // John Marshall
+        {
+          name: 'John Marshall',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1800, 5, 13).getTime(),
+                new Date(1801, 2, 4).getTime()
+              ]
+            }
+          ]
+        },
+        // Levi Lincoln
+        {
+          name: 'Levi Lincoln',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1801, 2, 5).getTime(),
+                new Date(1801, 4, 1).getTime()
+              ]
+            }
+          ]
+        },
+        // James Madison
+        {
+          name: 'James Madison',
+          data: [
+            {
+              x: 'Secretary of State',
+              y: [
+                new Date(1801, 4, 2).getTime(),
+                new Date(1809, 2, 3).getTime()
+              ]
+            }
+          ]
+        },
+      ],
+      chart: {
+        height: 350,
+        type: 'rangeBar'
+      },
+      plotOptions: {
+        bar: {
+          horizontal: true,
+          barHeight: '50%',
+          rangeBarGroupRows: true
+        }
+      },
+      colors: [
+        "#008FFB", "#00E396", "#FEB019", "#FF4560", "#775DD0",
+        "#3F51B5", "#546E7A", "#D4526E", "#8D5B4C", "#F86624",
+        "#D7263D", "#1B998B", "#2E294E", "#F46036", "#E2C044"
+      ],
+      fill: {
+        type: 'solid'
+      },
+      xaxis: {
+        type: 'datetime'
+      },
+      legend: {
+        position: 'right'
+      }
+    };
+
+    var chart = new ApexCharts(document.querySelector("#chart"), options);
+    chart.render();
+
+  </script>
+
+</body>
+
+</html>

--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -87,7 +87,12 @@ class RangeBar extends Bar {
         if (this.isHorizontal) {
           barYPosition = y + barHeight * this.visibleI
 
-          let srty = (yDivision - barHeight * this.seriesLen) / 2
+          let seriesLen = this.seriesLen
+          if (w.config.plotOptions.bar.rangeBarGroupRows) {
+            seriesLen = 1
+          }
+
+          let srty = (yDivision - barHeight * seriesLen) / 2
 
           if (typeof w.config.series[i].data[j] === 'undefined') {
             // no data exists for further indexes, hence we need to get out the innr loop.
@@ -190,7 +195,11 @@ class RangeBar extends Bar {
       (tx) => tx.x === labelX && tx.overlaps.length > 0
     )
 
-    barYPosition = srty + barHeight * this.visibleI + yDivision * rowIndex
+    if (w.config.plotOptions.bar.rangeBarGroupRows) {
+      barYPosition = srty + yDivision * rowIndex
+    } else {
+      barYPosition = srty + barHeight * this.visibleI + yDivision * rowIndex
+    }
 
     if (overlappedIndex > -1 && !w.config.plotOptions.bar.rangeBarOverlap) {
       overlaps = w.globals.seriesRangeBarTimeline[i][overlappedIndex].overlaps
@@ -201,8 +210,8 @@ class RangeBar extends Bar {
         barYPosition =
           barHeight * this.visibleI +
           (yDivision * (100 - parseInt(this.barOptions.barHeight, 10))) /
-            100 /
-            2 +
+          100 /
+          2 +
           barHeight * (this.visibleI + overlaps.indexOf(rangeName)) +
           yDivision * rowIndex
       }

--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -52,10 +52,15 @@ export default class Helpers {
       dataPoints = w.globals.labels.length
     }
 
+    let seriesLen = this.barCtx.seriesLen
+    if (w.config.plotOptions.bar.rangeBarGroupRows) {
+      seriesLen = 1
+    }
+
     if (this.barCtx.isHorizontal) {
       // height divided into equal parts
       yDivision = w.globals.gridHeight / dataPoints
-      barHeight = yDivision / this.barCtx.seriesLen
+      barHeight = yDivision / seriesLen
 
       if (w.globals.isXNumeric) {
         yDivision = w.globals.gridHeight / this.barCtx.totalItems

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -383,6 +383,7 @@ export default class Options {
           startingShape: 'flat',
           endingShape: 'flat',
           rangeBarOverlap: true,
+          rangeBarGroupRows: false,
           colors: {
             ranges: [],
             backgroundBarColors: [],


### PR DESCRIPTION

# New Pull Request

## Summary

- Added a flag ‘rangeBarGroupRows’ to group rows (horizontal bars) together in a multi-series timeline chart
- Added a example html page to samples

Fixes #1418

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
