### PR TITLE
fixed circle chart size when show legend

### DIFF
--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -33,10 +33,7 @@ class Pie {
         ? w.globals.stroke.colors
         : w.globals.colors
 
-    this.defaultSize =
-      w.globals.svgHeight < w.globals.svgWidth
-        ? w.globals.gridHeight
-        : w.globals.gridWidth
+    this.defaultSize = Math.min(w.globals.gridWidth, w.globals.gridHeight)
 
     this.centerY = this.defaultSize / 2
     this.centerX = w.globals.gridWidth / 2

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -230,13 +230,13 @@ export default class Dimensions {
     switch (cnf.legend.position) {
       case 'bottom':
         gl.gridHeight = gl.svgHeight - this.lgRect.height - gl.goldenPadding
-        gl.gridWidth = gl.gridHeight
+        gl.gridWidth = gl.svgWidth
         gl.translateY = offY - 10
         gl.translateX = offX + (gl.svgWidth - gl.gridWidth) / 2
         break
       case 'top':
         gl.gridHeight = gl.svgHeight - this.lgRect.height - gl.goldenPadding
-        gl.gridWidth = gl.gridHeight
+        gl.gridWidth = gl.svgWidth
         gl.translateY = this.lgRect.height + offY + 10
         gl.translateX = offX + (gl.svgWidth - gl.gridWidth) / 2
         break


### PR DESCRIPTION
# New Pull Request

Hi, I faced with [some problems](https://codepen.io/funkir/pen/povyOPX) on the pie \donut charts, when I used legend. This PR fixes them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
