### PR TITLE
Add typing for rangeBarGroupRows option

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -469,6 +469,7 @@ type ApexPlotOptions = {
     barHeight?: string
     distributed?: boolean
     rangeBarOverlap?: boolean
+    rangeBarGroupRows?: boolean
     colors?: {
       ranges?: {
         from?: number


### PR DESCRIPTION
# New Pull Request

Add typing for the new `plotOptions.bar.rangeBarGroupRows` option.

Fixes #1418

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
