### PR TITLE
removes unnecessary update when window height changes

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -37,14 +37,6 @@ export default class ApexCharts {
     initCtx.initModules()
 
     this.create = Utils.bind(this.create, this)
-
-    let width = window.innerWidth
-    this.windowResizeHandler = () => {
-      if (width !== window.innerWidth) {
-        width = window.innerWidth
-        this._windowResize.call(this)
-      }
-    }
   }
 
   /**
@@ -74,7 +66,7 @@ export default class ApexCharts {
         }
 
         this.events.fireEvent('beforeMount', [this, this.w])
-        window.addEventListener('resize', this.windowResizeHandler)
+        window.addEventListener('resize', this._windowResizeHandler.bind(this))
         window.addResizeListener(
           this.el.parentNode,
           this._parentResizeCallback.bind(this)
@@ -344,7 +336,7 @@ export default class ApexCharts {
    * Destroy the chart instance by removing all elements which also clean up event listeners on those elements.
    */
   destroy() {
-    window.removeEventListener('resize', this.windowResizeHandler)
+    window.removeEventListener('resize', this._windowResizeHandler.bind(this))
 
     window.removeResizeListener(
       this.el.parentNode,
@@ -719,5 +711,15 @@ export default class ApexCharts {
       // we need to redraw the whole chart on window resize (with a small delay).
       this.ctx.update()
     }, 150)
+  }
+
+  _windowResizeHandler() {
+    let { redrawOnWindowResize: redraw } = this.w.config.chart
+
+    if (typeof redraw === 'function') {
+      redraw = redraw()
+    }
+
+    redraw && this._windowResize()
   }
 }

--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -37,7 +37,14 @@ export default class ApexCharts {
     initCtx.initModules()
 
     this.create = Utils.bind(this.create, this)
-    this.windowResizeHandler = this._windowResize.bind(this)
+
+    let width = window.innerWidth
+    this.windowResizeHandler = () => {
+      if (width !== window.innerWidth) {
+        width = window.innerWidth
+        this._windowResize.call(this)
+      }
+    }
   }
 
   /**

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -289,6 +289,7 @@ export default class Options {
         height: 'auto',
         parentHeightOffset: 15,
         redrawOnParentResize: true,
+        redrawOnWindowResize: true,
         id: undefined,
         group: undefined,
         offsetX: 0,

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -142,6 +142,7 @@ type ApexChart = {
   defaultLocale?: string
   parentHeightOffset?: number
   redrawOnParentResize?: boolean
+  redrawOnWindowResize?: boolean | Function
   sparkline?: {
     enabled?: boolean
   }


### PR DESCRIPTION
# New Pull Request

Hi, I am using graphics inside an iframe that dynamically changes its height. This triggers the resize event and all charts start updating. Is such a solution to this problem possible?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
