### PR TITLE
Move @rollup/plugin-babel to devDepenendencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "build:samples": "node samples/source/index.js generate"
   },
   "dependencies": {
-    "@rollup/plugin-babel": "^5.2.1",
     "svg.draggable.js": "^2.2.2",
     "svg.easing.js": "^2.0.0",
     "svg.filter.js": "^2.0.2",
@@ -45,6 +44,7 @@
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.8.7",
+    "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-json": "4.0.1",
     "@rollup/plugin-node-resolve": "6.0.0",
     "@rollup/plugin-replace": "2.3.0",


### PR DESCRIPTION
Rollup related NPM packages should be listed in devDependencies

Fixes installation warnings like this:
```
[3/5] 🔗  Linking dependencies...
warning "apexcharts > @rollup/plugin-babel@5.2.1" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning "apexcharts > @rollup/plugin-babel > @rollup/pluginutils@3.1.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
