### PR TITLE
minXDiff must be computed using the sorted array

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -440,7 +440,7 @@ class Range {
 
         seriesX.forEach((s, j) => {
           if (j > 0) {
-            let xDiff = s - gl.seriesX[i][j - 1]
+            let xDiff = s - seriesX[j - 1]
             if (xDiff > 0) {
               gl.minXDiff = Math.min(xDiff, gl.minXDiff)
             }

--- a/tests/unit/bar-chart.spec.js
+++ b/tests/unit/bar-chart.spec.js
@@ -1,0 +1,22 @@
+import Range from '../../src/modules/Range.js'
+import { createChartWithOptions } from './utils/utils.js'
+
+describe('Bar chart', () => {
+  it('columns should not overlap because of wrong minXDiff value', () => {
+    const chart = createChartWithOptions({
+      series: [
+        {
+          data: [[1, 1], [4, 4], [3, 3]]
+        }
+      ],
+      chart: {
+        type: 'bar',
+      },
+    })
+
+    const range = new Range(chart)
+    range.setXRange()
+
+    expect(range.w.globals.minXDiff).toEqual(1)
+  })
+})


### PR DESCRIPTION
# New Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

`minXDiff` must be computed using the sorted array instead of the original array.

Fixes #2140

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
