### PR TITLE
fix y-axis title position in horizontal bar charts when labels are long

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -249,6 +249,12 @@ export default class ApexCharts {
       if (elgrid !== null) {
         xAxis.xAxisLabelCorrections(elgrid.xAxisTickWidth)
         yaxis.setYAxisTextAlignments()
+
+        w.config.yaxis.map((yaxe, index) => {
+          if (w.globals.ignoreYAxisIndexes.indexOf(index) === -1) {
+            yaxis.yAxisTitleRotate(index, yaxe.opposite)
+          }
+        })
       }
 
       if (w.config.annotations.position === 'back') {

--- a/src/modules/Graphics.js
+++ b/src/modules/Graphics.js
@@ -774,9 +774,9 @@ class Graphics {
     textObj.textContent = textString
     if (textString.length > 0) {
       // ellipsis is needed
-      if (textObj.getComputedTextLength() >= width / 0.8) {
+      if (textObj.getComputedTextLength() >= width / 0.9) {
         for (let x = textString.length - 3; x > 0; x -= 3) {
-          if (textObj.getSubStringLength(0, x) <= width / 0.8) {
+          if (textObj.getSubStringLength(0, x) <= width / 0.9) {
             textObj.textContent = textString.substring(0, x) + '...'
             return
           }


### PR DESCRIPTION
# New Pull Request

Changing the position error of the title of horizontal graphs

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
