### PR TITLE
FIX: Fixed y axis formatter not working when range contains zero

### DIFF
--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -360,7 +360,7 @@ class RangeBar extends Bar {
       seriesName = yLbTitleFormatter(seriesName, opts)
     }
 
-    if (y1 && y2) {
+    if (Number.isFinite(y1) && Number.isFinite(y2)) {
       start = y1
       end = y2
 


### PR DESCRIPTION
# New Pull Request

When using a ranged bar chart and having a point in the series where either y1 or y2 is zero, apexcharts wouldn't use the formatter. This caused half of the bars in our chart to use the default formatter even though we had given our own in the options.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
