### PR TITLE
dimensions/YAxis: correct label/title rotation for computing Y-axis width

### DIFF
--- a/src/modules/dimensions/YAxis.js
+++ b/src/modules/dimensions/YAxis.js
@@ -64,13 +64,25 @@ export default class DimYAxis {
         }
 
         let graphics = new Graphics(this.dCtx.ctx)
-        let rect = graphics.getTextRects(val, yaxe.labels.style.fontSize)
+
+        let rotateStr = 'rotate(' + yaxe.labels.rotate + ' 0 0)'
+        let rect = graphics.getTextRects(
+          val,
+          yaxe.labels.style.fontSize,
+          yaxe.title.style.fontFamily,
+          rotateStr,
+          false
+        )
+
         let arrLabelrect = rect
 
         if (val !== valArr) {
           arrLabelrect = graphics.getTextRects(
             valArr,
-            yaxe.labels.style.fontSize
+            yaxe.labels.style.fontSize,
+            yaxe.title.style.fontFamily,
+            rotateStr,
+            false
           )
         }
 
@@ -107,11 +119,12 @@ export default class DimYAxis {
     w.config.yaxis.map((yaxe, index) => {
       if (yaxe.show && yaxe.title.text !== undefined) {
         let graphics = new Graphics(this.dCtx.ctx)
+        let rotateStr = 'rotate(' + yaxe.title.rotate + ' 0 0)'
         let rect = graphics.getTextRects(
           yaxe.title.text,
           yaxe.title.style.fontSize,
           yaxe.title.style.fontFamily,
-          'rotate(-90 0 0)',
+          rotateStr,
           false
         )
 

--- a/src/modules/dimensions/YAxis.js
+++ b/src/modules/dimensions/YAxis.js
@@ -65,11 +65,11 @@ export default class DimYAxis {
 
         let graphics = new Graphics(this.dCtx.ctx)
 
-        let rotateStr = 'rotate(' + yaxe.labels.rotate + ' 0 0)'
+        let rotateStr = 'rotate('.concat(yaxe.labels.rotate, ' 0 0)')
         let rect = graphics.getTextRects(
           val,
           yaxe.labels.style.fontSize,
-          yaxe.title.style.fontFamily,
+          yaxe.labels.style.fontFamily,
           rotateStr,
           false
         )
@@ -80,7 +80,7 @@ export default class DimYAxis {
           arrLabelrect = graphics.getTextRects(
             valArr,
             yaxe.labels.style.fontSize,
-            yaxe.title.style.fontFamily,
+            yaxe.labels.style.fontFamily,
             rotateStr,
             false
           )
@@ -119,7 +119,7 @@ export default class DimYAxis {
     w.config.yaxis.map((yaxe, index) => {
       if (yaxe.show && yaxe.title.text !== undefined) {
         let graphics = new Graphics(this.dCtx.ctx)
-        let rotateStr = 'rotate(' + yaxe.title.rotate + ' 0 0)'
+        let rotateStr = 'rotate('.concat(yaxe.title.rotate, ' 0 0)')
         let rect = graphics.getTextRects(
           yaxe.title.text,
           yaxe.title.style.fontSize,


### PR DESCRIPTION
# YAxis width corrected
Using multiple Y-axis (6) there were visible problems with spaces between them.
yaxis[i].labels.rotate and yaxis[i].title.rotate were not properly used when computing the bounding boxes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
