### PR TITLE
Better barHeight scaling.

### DIFF
--- a/src/modules/CoreUtils.js
+++ b/src/modules/CoreUtils.js
@@ -211,8 +211,7 @@ class CoreUtils {
   getCalculatedRatios() {
     let gl = this.w.globals
 
-    let 
-    = []
+    let y = []
     let invertedYRatio = 0
     let xRatio = 0
     let initialXRatio = 0

--- a/src/modules/CoreUtils.js
+++ b/src/modules/CoreUtils.js
@@ -211,7 +211,7 @@ class CoreUtils {
   getCalculatedRatios() {
     let gl = this.w.globals
 
-    let y = []
+    let yRatio = []
     let invertedYRatio = 0
     let xRatio = 0
     let initialXRatio = 0

--- a/src/modules/CoreUtils.js
+++ b/src/modules/CoreUtils.js
@@ -211,7 +211,8 @@ class CoreUtils {
   getCalculatedRatios() {
     let gl = this.w.globals
 
-    let yRatio = []
+    let 
+    = []
     let invertedYRatio = 0
     let xRatio = 0
     let initialXRatio = 0
@@ -235,7 +236,7 @@ class CoreUtils {
 
     // multiple y axis
     for (let i = 0; i < gl.yRange.length; i++) {
-      yRatio.push(gl.yRange[i] / gl.gridHeight)
+      yRatio.push(gl.yRange[i] / (gl.gridHeight + this.w.config.dataLabels.offsetY))
     }
 
     xRatio = gl.xRange / gl.gridWidth


### PR DESCRIPTION
I've added the dataLabel offsetY to the yRatio calculation. My project is using apexcharts for a vertical bar chart and experienced some spacing issues with the dataLabels, which were placed on top of the bars with a negative y-offset. For the highest entries in the data range the offset couldn't be applied since there was no space.
