### PR TITLE
Fix for #1629, adds BOM to CSV export

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -162,7 +162,7 @@ class Exports {
 
     let columns = []
     let rows = []
-    let result = 'data:text/csv;charset=utf-8,'
+    let result = 'data:text/csv;charset=utf-8,\uFEFF'
 
     const isTimeStamp = (num) => {
       return w.config.xaxis.type === 'datetime' && String(num).length >= 10


### PR DESCRIPTION
# Adds BOM to CSV export

The exported CSV-file is missing a byte order mark (BOM). This causes Excel to misinterpret the file and gets the encoding wrong. This PR adds a BOM to the beginning of the CSV-file.

Fixes #1629

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
