### PR TITLE
Forcing the DataLabel to be drawn only within the boundaries of the c…

### DIFF
--- a/src/modules/DataLabels.js
+++ b/src/modules/DataLabels.js
@@ -33,6 +33,9 @@ class DataLabels {
     let width = textRects.width
     let height = textRects.height
 
+    if (y < 0) y = 0
+    if (y > w.globals.gridHeight + height) y = w.globals.gridHeight + height / 2
+
     // first value in series, so push an empty array
     if (typeof w.globals.dataLabelsRects[i] === 'undefined')
       w.globals.dataLabelsRects[i] = []


### PR DESCRIPTION
…hart area #2287

# New Pull Request

In the case when the data labels go beyond the vertical boundaries of the plot area, we press them to the border of the plot area

Fixes #2287

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
