### PR TITLE
REF: Do not hardcode rangebar tooltip

### DIFF
--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -371,7 +371,7 @@ class RangeBar extends Bar {
       }
 
       if (typeof yLbFormatter === 'function') {
-        ylabel = yLbFormatter(ylabel, { ...opts, ...{ start, end } })
+        ylabel = yLbFormatter(ylabel, opts)
       }
     }
 

--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -353,7 +353,9 @@ class RangeBar extends Bar {
     const opts = {
       w,
       seriesIndex,
-      dataPointIndex
+      dataPointIndex,
+      start,
+      end
     }
 
     if (typeof yLbTitleFormatter === 'function') {
@@ -369,7 +371,7 @@ class RangeBar extends Bar {
       }
 
       if (typeof yLbFormatter === 'function') {
-        ylabel = yLbFormatter(ylabel, opts)
+        ylabel = yLbFormatter(ylabel, { ...opts, ...{ start, end } })
       }
     }
 
@@ -410,12 +412,7 @@ class RangeBar extends Bar {
       '</span></div>' +
       '<div> <span class="category">' +
       ylabel +
-      ' </span> <span class="value start-value">' +
-      start +
-      '</span> <span class="separator">-</span> <span class="value end-value">' +
-      end +
-      '</span></div>' +
-      '</div>'
+      '</span></div></div>'
     )
   }
 }


### PR DESCRIPTION
Hey,
currently the "RangeBar" tooltip has hardcoded HTML elements in it that show the range of the bar in numbers. A user cannot change these outputs as they cannot be overridden at the moment.

This change removes the hardcoded start and end values from the tooltip of the "RangeBar" and instead gives them as options to the y-label tooltip formatter to allow users to customize the output.

## Type of change

Please delete options that are not relevant.

- [x] Refactor
