### PR TITLE
feat(TimeScale): show label for every minute on small scale

### DIFF
--- a/src/utils/DateTime.js
+++ b/src/utils/DateTime.js
@@ -159,10 +159,12 @@ class DateTime {
     const tsMin = this.getDate(minX)
     const tsMax = this.getDate(maxX)
 
-    const minD = this.formatDate(tsMin, 'yyyy MM dd HH mm ss').split(' ')
-    const maxD = this.formatDate(tsMax, 'yyyy MM dd HH mm ss').split(' ')
+    const minD = this.formatDate(tsMin, 'yyyy MM dd HH mm ss fff').split(' ')
+    const maxD = this.formatDate(tsMax, 'yyyy MM dd HH mm ss fff').split(' ')
 
     return {
+      minMillisecond: parseInt(minD[6], 10),
+      maxMillisecond: parseInt(maxD[6], 10),
       minSecond: parseInt(minD[5], 10),
       maxSecond: parseInt(maxD[5], 10),
       minMinute: parseInt(minD[4], 10),

--- a/tests/unit/data/sample-data.js
+++ b/tests/unit/data/sample-data.js
@@ -14,7 +14,15 @@ module.exports = {
     ],
     hours: [
       new Date('02/02/2017 01:20 UTC').getTime(),
-      new Date('10/10/2017 21:20 UTC').getTime()
+      new Date('02/02/2017 21:20 UTC').getTime()
+    ],
+    minutes_fives: [
+      new Date('02/02/2017 01:39 UTC').getTime(),
+      new Date('02/02/2017 02:09 UTC').getTime()
+    ],
+    minutes: [
+      new Date('02/02/2017 01:59 UTC').getTime(),
+      new Date('02/02/2017 02:05 UTC').getTime()
     ]
   }
 }

--- a/tests/unit/timescale.spec.js
+++ b/tests/unit/timescale.spec.js
@@ -16,6 +16,13 @@ describe('Generate TimeScale', () => {
     )
 
     expect(generatedTimeScaleYears).toHaveLength(6)
+    generatedTimeScaleYears.forEach((tick) => {
+      if (tick.month === 1) {
+        expect(tick.unit).toBe('year')
+      } else {
+        expect(tick.unit).toBe('month')
+      }
+    })
   })
 
   it('should return timescale ticks for months range in a datetime series', () => {
@@ -31,6 +38,9 @@ describe('Generate TimeScale', () => {
     )
 
     expect(generatedTimeScaleMonths).toHaveLength(9)
+    generatedTimeScaleMonths.forEach((tick) => {
+      expect(tick.unit).toBe('month')
+    })
   })
 
   it('should return timescale ticks for days range in a datetime series', () => {
@@ -46,6 +56,13 @@ describe('Generate TimeScale', () => {
     )
 
     expect(generatedTimeScaleDays).toHaveLength(27)
+    generatedTimeScaleDays.forEach((tick) => {
+      if (tick.day === 1) {
+        expect(tick.unit).toBe('month')
+      } else {
+        expect(tick.unit).toBe('day')
+      }
+    })
   })
 
   it('should return timescale ticks for hours range in a datetime series', () => {
@@ -60,6 +77,113 @@ describe('Generate TimeScale', () => {
       range.hours[1]
     )
 
-    expect(generatedTimeScaleHours).toHaveLength(9)
+    expect(generatedTimeScaleHours).toHaveLength(21)
+    generatedTimeScaleHours.forEach((tick) => {
+      expect(tick.unit).toBe('hour')
+    })
+  })
+
+  it('should return timescale ticks for five-minutes range in a datetime series', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    const generatedTimeScaleMinutes = timeScale.calculateTimeScaleTicks(
+      range.minutes_fives[0],
+      range.minutes_fives[1]
+    )
+
+    expect(generatedTimeScaleMinutes).toEqual([
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 1,
+        minute: 40,
+        value: 40
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 1,
+        minute: 45,
+        value: 45
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 1,
+        minute: 50,
+        value: 50
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 1,
+        minute: 55,
+        value: 55
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 0,
+        value: 0
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 5,
+        value: 5
+      })
+    ])
+  })
+
+  it('should return timescale ticks for single minutes range in a datetime series', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    const generatedTimeScaleMinutes = timeScale.calculateTimeScaleTicks(
+      range.minutes[0],
+      range.minutes[1]
+    )
+
+    expect(generatedTimeScaleMinutes).toEqual([
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 0,
+        value: 0
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 1,
+        value: 1
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 2,
+        value: 2
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 3,
+        value: 3
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 4,
+        value: 4
+      }),
+      expect.objectContaining({
+        unit: 'minute',
+        hour: 2,
+        minute: 5,
+        value: 5
+      })
+    ])
   })
 })


### PR DESCRIPTION
# New Pull Request

Currently smallest labels shown for `datetime` scale is 5 minutes:
https://github.com/apexcharts/apexcharts.js/blob/master/src/modules/TimeScale.js#L223-L227

I kept 5 minutes labels for 15+ minutes ranges and added 1-minute labels for smaller ranges.

![image](https://user-images.githubusercontent.com/7345182/112871372-e16f6e00-90c7-11eb-886a-73a68e2b73af.png)

Fixes #2227

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
