### PR TITLE
feat(TimeScale): added seconds scale

### DIFF
--- a/samples/playground/options.js
+++ b/samples/playground/options.js
@@ -3855,6 +3855,16 @@ export const optionsPattern = {
                   title: 'Format specifier for the hour of day',
                   type: String,
                   default: 'HH:mm'
+                },
+                minute: {
+                  title: 'Format specifier for the minute',
+                  type: String,
+                  default: 'HH:mm:ss'
+                },
+                second: {
+                  title: 'Format specifier for the second',
+                  type: String,
+                  default: 'HH:mm:ss'
                 }
               }
             }

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -940,7 +940,8 @@ export default class Options {
             month: "MMM 'yy",
             day: 'dd MMM',
             hour: 'HH:mm',
-            minute: 'HH:mm:ss'
+            minute: 'HH:mm:ss',
+            second: 'HH:mm:ss'
           }
         },
         axisBorder: {

--- a/tests/unit/data/sample-data.js
+++ b/tests/unit/data/sample-data.js
@@ -23,6 +23,18 @@ module.exports = {
     minutes: [
       new Date('02/02/2017 01:59 UTC').getTime(),
       new Date('02/02/2017 02:05 UTC').getTime()
+    ],
+    seconds_tens: [
+      new Date('02/02/2017 01:59:00 UTC').getTime(),
+      new Date('02/02/2017 02:00:25 UTC').getTime()
+    ],
+    seconds_fives: [
+      new Date('02/02/2017 01:59:43 UTC').getTime(),
+      new Date('02/02/2017 02:00:17 UTC').getTime()
+    ],
+    seconds: [
+      new Date('02/02/2017 01:59:58 UTC').getTime(),
+      new Date('02/02/2017 02:00:05 UTC').getTime()
     ]
   }
 }

--- a/tests/unit/timescale.spec.js
+++ b/tests/unit/timescale.spec.js
@@ -186,4 +186,295 @@ describe('Generate TimeScale', () => {
       })
     ])
   })
+
+  it('should return timescale ticks for ten seconds range in a datetime series', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    const generatedTimeScaleMinutes = timeScale.calculateTimeScaleTicks(
+      range.seconds_tens[0],
+      range.seconds_tens[1]
+    )
+
+    expect(generatedTimeScaleMinutes).toEqual([
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 10,
+        value: 10
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 20,
+        value: 20
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 30,
+        value: 30
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 40,
+        value: 40
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 50,
+        value: 50
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 0,
+        value: 0
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 10,
+        value: 10
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 20,
+        value: 20
+      })
+    ])
+  })
+
+  it('should return timescale ticks for five seconds range in a datetime series', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    const generatedTimeScaleMinutes = timeScale.calculateTimeScaleTicks(
+      range.seconds_fives[0],
+      range.seconds_fives[1]
+    )
+
+    expect(generatedTimeScaleMinutes).toEqual([
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 45,
+        value: 45
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 50,
+        value: 50
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 55,
+        value: 55
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 0,
+        value: 0
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 5,
+        value: 5
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 10,
+        value: 10
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 15,
+        value: 15
+      })
+    ])
+  })
+
+  it('should return timescale ticks for single seconds range in a datetime series', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    const generatedTimeScaleMinutes = timeScale.calculateTimeScaleTicks(
+      range.seconds[0],
+      range.seconds[1]
+    )
+
+    expect(generatedTimeScaleMinutes).toEqual([
+      expect.objectContaining({
+        unit: 'second',
+        hour: 1,
+        minute: 59,
+        second: 59,
+        value: 59
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 0,
+        value: 0
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 1,
+        value: 1
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 2,
+        value: 2
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 3,
+        value: 3
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 4,
+        value: 4
+      }),
+      expect.objectContaining({
+        unit: 'second',
+        hour: 2,
+        minute: 0,
+        second: 5,
+        value: 5
+      })
+    ])
+  })
+})
+
+describe('createRawDateString', () => {
+  const chart = createChart('line', [
+    {
+      data: [0, 1]
+    }
+  ])
+  const timeScale = new TimeScale(chart)
+
+  it('should create month string', () => {
+    expect(
+      timeScale.createRawDateString(
+        {
+          unit: 'month',
+          year: 2020,
+          month: 2,
+          value: 2
+        },
+        '2'
+      )
+    ).toBe('2020-02-01T00:00:00.000Z')
+  })
+
+  it('should create day string', () => {
+    expect(
+      timeScale.createRawDateString(
+        {
+          unit: 'day',
+          year: 2020,
+          month: 1,
+          day: 2,
+          value: 2
+        },
+        '2'
+      )
+    ).toBe('2020-01-02T00:00:00.000Z')
+  })
+
+  it('should create hour string', () => {
+    expect(
+      timeScale.createRawDateString(
+        {
+          unit: 'hour',
+          year: 2020,
+          month: 1,
+          day: 1,
+          hour: 2,
+          value: 2
+        },
+        '2'
+      )
+    ).toBe('2020-01-01T02:00:00.000Z')
+  })
+
+  it('should create minute string', () => {
+    expect(
+      timeScale.createRawDateString(
+        {
+          unit: 'minute',
+          year: 2020,
+          month: 1,
+          day: 1,
+          hour: 1,
+          minute: 59,
+          value: 59
+        },
+        '59'
+      )
+    ).toBe('2020-01-01T01:59:00.000Z')
+  })
+
+  it('should create second string', () => {
+    expect(
+      timeScale.createRawDateString(
+        {
+          unit: 'second',
+          year: 2020,
+          month: 1,
+          day: 1,
+          hour: 1,
+          minute: 1,
+          second: 59,
+          value: 59
+        },
+        '59'
+      )
+    ).toBe('2020-01-01T01:01:59.000Z')
+  })
 })


### PR DESCRIPTION
# New Pull Request

Added ability to show labels for seconds on `datetime` scale:
* for intervals from 1 to 5 minutes — every 10 seconds
* for intervals from 20 seconds to 1 minute — every 5 seconds
* less than 20 seconds — every second

![image](https://user-images.githubusercontent.com/7345182/112995657-1df8a380-9174-11eb-97ee-46490b5e66fd.png)
![image](https://user-images.githubusercontent.com/7345182/112995715-2b159280-9174-11eb-8e69-c60caa9bb32f.png)

Fixes #2278

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
