### PR TITLE
Fixed a bug with shading a heatmap while using reverseNegativeShade option

### DIFF
--- a/src/charts/common/treemap/Helpers.js
+++ b/src/charts/common/treemap/Helpers.js
@@ -36,7 +36,7 @@ export default class TreemapHelpers {
       if (w.config.plotOptions[chartType].reverseNegativeShade) {
         if (colorProps.percent < 0) {
           colorShadePercent =
-            (colorProps.percent / 100) * (shadeIntensity * 1.25)
+            (1 + colorProps.percent / 100) * (shadeIntensity * 1.25)
         } else {
           colorShadePercent =
             (1 - colorProps.percent / 100) * (shadeIntensity * 1.25)


### PR DESCRIPTION
# New Pull Request

Between versions 3.15.5 and 3.15.6 the reverseNegativeShade option of the heatmap chart has stopped working.
This was due to an existing feature being deleted. My fix just restored the deleted calculation.

I've took some screenshots showing the before and after of the fix by using simple data with random values between -1 and 1

### Before fix
![before fix](https://user-images.githubusercontent.com/8151381/113895159-5d0ca180-97d1-11eb-993b-0b3321af9f98.png)


### After fix
![after fix](https://user-images.githubusercontent.com/8151381/113895165-5e3dce80-97d1-11eb-8ab9-b1d3d5a8f0f7.png)


Fixes https://github.com/apexcharts/apexcharts.js/issues/1704 (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
