### PR TITLE
Add title element for Y-axis labels

### DIFF
--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -309,7 +309,9 @@ export default class XAxis {
         elYaxisTexts.add(elLabel)
 
         let elTooltipTitle = document.createElementNS(w.globals.SVGNS, 'title')
-        elTooltipTitle.textContent = label.text
+        elTooltipTitle.textContent = Array.isArray(label)
+          ? label.join(' ')
+          : label
         elLabel.node.appendChild(elTooltipTitle)
 
         if (w.config.yaxis[realIndex].labels.rotate !== 0) {

--- a/src/modules/axes/YAxis.js
+++ b/src/modules/axes/YAxis.js
@@ -104,6 +104,10 @@ export default class YAxis {
         }
         elYaxisTexts.add(label)
 
+        let elTooltipTitle = document.createElementNS(w.globals.SVGNS, 'title')
+        elTooltipTitle.textContent = Array.isArray(val) ? val.join(' ') : val
+        label.node.appendChild(elTooltipTitle)
+
         if (w.config.yaxis[realIndex].labels.rotate !== 0) {
           let firstabelRotatingCenter = graphics.rotateAroundCenter(
             firstLabel.node


### PR DESCRIPTION
# New Pull Request

Title element was not added to the text element for Y-axis label. This resulted in the full-text tooltip did not show when hovering over the text of the label

Fixes #2281 (Maybe something else)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
