### PR TITLE
minWidth doesn't always work

### DIFF
--- a/src/modules/dimensions/YAxis.js
+++ b/src/modules/dimensions/YAxis.js
@@ -24,6 +24,10 @@ export default class DimYAxis {
 
     w.config.yaxis.map((yaxe, index) => {
       const yS = w.globals.yAxisScale[index]
+      let yAxisMinWidth = 0;
+      if (!axesUtils.isYAxisHidden(index) && yaxe.labels.show && yaxe.labels.minWidth != undefined)
+        yAxisMinWidth = yaxe.labels.minWidth;
+      
       if (
         !axesUtils.isYAxisHidden(index) &&
         yaxe.labels.show &&
@@ -87,9 +91,12 @@ export default class DimYAxis {
 
         ret.push({
           width:
-            (arrLabelrect.width > rect.width
-              ? arrLabelrect.width
-              : rect.width) + labelPad,
+            (yAxisMinWidth > arrLabelrect.width || yAxisMinWidth > rect.width
+              ? yAxisMinWidth
+              : (arrLabelrect.width > rect.width
+                ? arrLabelrect.width
+                : rect.width)
+            ) + labelPad,
           height:
             arrLabelrect.height > rect.height
               ? arrLabelrect.height


### PR DESCRIPTION
minWidth doesn't always work if the formatter has been set.

## Codepen
Take a look at this example
https://codepen.io/github-rj/pen/vYxZbXg

# New Pull Request
minWidth doesn't always work when the formatter has been set. I suggest comparing Label's minWidth to arrLabelrect.width and rect.width. If minWidth is greater than arrLabelrect.width or rect.width, this is used as the width of the label. 




## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
