### PR TITLE
Annotation in wrong position

### DIFF
--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -37,13 +37,30 @@ export default class PointAnnotations {
     } else {
       x = (anno.x - w.globals.minX) / (w.globals.xRange / w.globals.gridWidth)
     }
+    
+    // count series assign to the same axis
+    let duplicateSeriesName = [];
+    let countDuplicateSeriesName = 0;
+    for (let i = 0; i <= anno.seriesIndex; i++) {
+      var serieName = w.config.yaxis[i].seriesName;
+      if (serieName != undefined)
+        for (let j = i + 1; j <= anno.seriesIndex; j++) {
+          if (w.config.yaxis[j].seriesName == serieName && duplicateSeriesName.indexOf(serieName) == -1) {
+            countDuplicateSeriesName++;
+            duplicateSeriesName.push(serieName);
+          }
+        }
+    }
+    
     let yPos
     if (w.config.yaxis[anno.yAxisIndex].logarithmic) {
       const coreUtils = new CoreUtils(this.annoCtx.ctx)
       annoY = coreUtils.getLogVal(annoY, anno.yAxisIndex)
       yPos = annoY / w.globals.yLogRatio[anno.yAxisIndex]
     } else {
-      yPos = (annoY - w.globals.minYArr[anno.seriesIndex]) / (w.globals.yRange[anno.seriesIndex] / w.globals.gridHeight)
+     // calculate the right position in array for this yAxisIndex
+      let actualSerieIndex = anno.yAxisIndex + countDuplicateSeriesName;
+      yPos = (annoY - w.globals.minYArr[actualSerieIndex]) / (w.globals.yRange[actualSerieIndex] / w.globals.gridHeight)
     }
 
     y =
@@ -66,7 +83,7 @@ export default class PointAnnotations {
 
     let optsPoints = {
       pSize: anno.marker.size,
-      pointStrokeWidth: anno.marker.strokeWidth,
+      pWidth: anno.marker.strokeWidth,
       pointFillColor: anno.marker.fillColor,
       pointStrokeColor: anno.marker.strokeColor,
       shape: anno.marker.shape,

--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -43,9 +43,7 @@ export default class PointAnnotations {
       annoY = coreUtils.getLogVal(annoY, anno.yAxisIndex)
       yPos = annoY / w.globals.yLogRatio[anno.yAxisIndex]
     } else {
-      yPos =
-        (annoY - w.globals.minYArr[anno.yAxisIndex]) /
-        (w.globals.yRange[anno.yAxisIndex] / w.globals.gridHeight)
+      yPos = (annoY - w.globals.minYArr[anno.seriesIndex]) / (w.globals.yRange[anno.seriesIndex] / w.globals.gridHeight)
     }
 
     y =

--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -83,7 +83,7 @@ export default class PointAnnotations {
 
     let optsPoints = {
       pSize: anno.marker.size,
-      pWidth: anno.marker.strokeWidth,
+      pointStrokeWidth: anno.marker.strokeWidth,
       pointFillColor: anno.marker.fillColor,
       pointStrokeColor: anno.marker.strokeColor,
       shape: anno.marker.shape,


### PR DESCRIPTION
Annotation point is displayed in the wrong position when many series are associated with the same axis

## Codepen
https://codepen.io/github-rj/pen/KKVGWLg?editors=0010

# New Pull Request
I will explain the problem using an example.

In this example, I have four series:
- serie-1 and serie-2 have axis 0.
- serie-3 has axis 1.
- **_serie-4 has axis 2_**.

I want to have a annotations point on serie 4.

```
 annotations: {
    points: [
      {
        x: 1595226611882,
        y: 69,
        yAxisIndex: 2,
        seriesIndex: 3,
        label: {
          text: "Point Annotation (XY)"
        }
      }
    ]
```
I always thought that seriesIndex has to be 4, but after reading the code I realize that serieIndex has to be 3( if I'm wrong please correct me). I set yAxisIndex to 2 and seriesIndex to 3.

The yAxisIndex was used to calculate the y position (index of array). I think this can be seriesIndex instead of yAxisIndex, because if two or more than two series are assigned to the same axis then yAxisIndex is not the same as seriesIndex. and position are calculated with the minYArr and yRange of another(wrong) serie.

or alternative solution : the actual index in the array for the yAxisIndex must be calculated

Fixes #1786

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
