### PR TITLE
Fixes hover issue where synced charts are of different sizes

### DIFF
--- a/samples/source/line/syncing-charts.xml
+++ b/samples/source/line/syncing-charts.xml
@@ -10,6 +10,10 @@
   max-width: 650px;
   margin: 35px auto;
 }
+
+.columns {
+  columns: 2;
+}
 </style>
 
 <scripts>
@@ -94,6 +98,11 @@ function generateDayWiseTimeSeries(baseval, count, yrange) {
   {{ charts['line'] }}
   {{ charts['line2'] }}
   {{ charts['area'] }}
+  <div class="columns">
+    {{ charts['small'] }}
+    {{ charts['small2'] }}
+  </div>
+  
 </div>
 </html>
 
@@ -107,12 +116,7 @@ chart: {
   type: 'line',
   height: 160
 },
-colors: ['#008FFB'],
-yaxis: {
-  labels: {
-    minWidth: 40
-  }
-}
+colors: ['#008FFB']
 </options>
 
 <series>
@@ -135,12 +139,7 @@ chart: {
   type: 'line',
   height: 160
 },
-colors: ['#546E7A'],
-yaxis: {
-  labels: {
-    minWidth: 40
-  }
-}
+colors: ['#546E7A']
 </options>
 
 <series>
@@ -163,12 +162,55 @@ chart: {
   type: 'area',
   height: 160
 },
-colors: ['#00E396'],
-yaxis: {
-  labels: {
-    minWidth: 40
-  }
-}
+colors: ['#00E396']
+</options>
+
+<series>
+[{
+  data: generateDayWiseTimeSeries(new Date('11 Feb 2017').getTime(), 20, {
+    min: 10,
+    max: 60
+  })
+}]
+</series>
+</chart>
+
+<chart>
+<id>small</id>
+
+<options>
+chart: {
+  id: 'ig',
+  group: 'social',
+  type: 'area',
+  height: 160,
+  width: 300
+},
+colors: ['#008FFB']
+</options>
+
+<series>
+[{
+  data: generateDayWiseTimeSeries(new Date('11 Feb 2017').getTime(), 20, {
+    min: 10,
+    max: 60
+  })
+}]
+</series>
+</chart>
+
+<chart>
+<id>small2</id>
+
+<options>
+chart: {
+  id: 'li',
+  group: 'social',
+  type: 'area',
+  height: 160,
+  width: 300
+},
+colors: ['#546E7A']
 </options>
 
 <series>

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -626,7 +626,8 @@ export default class Tooltip {
     let j = capj.j
     let capturedSeries = capj.capturedSeries
 
-    if (capj.hoverX < 0 || capj.hoverX > w.globals.gridWidth) {
+    const bounds = opt.elGrid.getBoundingClientRect()
+    if (capj.hoverX < 0 || capj.hoverX > bounds.width) {
       this.handleMouseOut(opt)
       return
     }


### PR DESCRIPTION
# New Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes hover issues on synced charts where charts: 

* are of different sizes, or
* have different `yAxis.labels` widths, or
* charts have multi y-axes

Instead of each chart using its own grid element to compute the width and height of the hover area, the grid element of the chart where the hover event took place is being used. Now grouped charts will sync and show the correct data points regardless of the size and width of the `yAxis.labels` of the charts themselves. This fix gives rise to the possibility of designing more interesting layouts for synced charts. 

![Animation](https://user-images.githubusercontent.com/11395278/122780583-4396d400-d2af-11eb-9ad4-0f2e1638da6a.gif)

I have updated the sample synced-charts scene to include 2 small charts to highlight this feature.

Fixes #295 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (no need to have the same `yAxis.labels.minWidth` on all charts anymore)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
