### PR TITLE
Updates for stencil-apexcharts wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ npm install apexcharts --save
 <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
 ```
 
-## Wrappers for Vue/React/Angular
+## Wrappers for Vue/React/Angular/Stencil
 
 Integrate easily with 3rd party frameworks
 
 - [vue-apexcharts](https://github.com/apexcharts/vue-apexcharts)
 - [react-apexcharts](https://github.com/apexcharts/react-apexcharts)
 - [ng-apexcharts](https://github.com/apexcharts/ng-apexcharts) - Plugin by [Morris Janatzek](https://morrisj.net/)
+- [stencil-apexcharts](https://github.com/apexcharts/stencil-apexcharts)
 
 ### Unofficial Wrappers
 
 Useful links to wrappers other than the popular frameworks mentioned above
 
-- [stencil-apexcharts](https://github.com/mikaelkaron/stencil-apexcharts) - Stencil Component for ApexCharts
 - [apexcharter](https://github.com/dreamRs/apexcharter) - Htmlwidget for ApexCharts
 - [apexcharts.rb](https://github.com/styd/apexcharts.rb) - Ruby wrapper for ApexCharts
 - [larapex-charts](https://github.com/ArielMejiaDev/larapex-charts) - Laravel wrapper for ApexCharts


### PR DESCRIPTION
- Correct link (it's moved to the `apexcharts` org a while ago)
- Moved to the "official" block of wrappers (as it's owned by the `apexcharts` org) - This is just a suggestion