### PR TITLE
Export csv based on selection

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -218,8 +218,9 @@ class Exports {
               w
             })
           } else {
+            // Fix for Issue #2333
             cat = axesUtils.getLabel(
-              w.globals.labels,
+              w.config.chart.toolbar.export.csv.exportSelection ? w.globals.labels : w.globals.categoryLabels,
               w.globals.timescaleLabels,
               0,
               i
@@ -307,6 +308,15 @@ class Exports {
 
           if (columns.length) {
             rows.push(columns.join(columnDelimiter))
+          }
+
+          // Fix for Issue #2333
+          if (w.config.chart.toolbar.export.csv.exportSelection) {
+            rows.map((e, i) => {
+              if (e.indexOf(',') === 0) {
+                rows.splice(i, 1);
+              }
+            })
           }
         }
       }

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -349,6 +349,7 @@ export default class Options {
               columnDelimiter: ',',
               headerCategory: 'category',
               headerValue: 'value',
+              exportSelection: true, // Fix for Issue #2333
               dateFormatter(timestamp) {
                 return new Date(timestamp).toDateString()
               }


### PR DESCRIPTION
Fixes an issue when exporting CSV the file contains all timeseries information. Adding a new 'exportSelection' boolean value to the export object, this change will export the data based on selection. If this is set to true then the data in the file will only contain the selected values, if set to false it will contain all values and labels. 

Fixes #2333 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
