### PR TITLE
missing locale types in ApexLocale.options.toolbar

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -467,6 +467,9 @@ type ApexLocale = {
       zoomOut?: string
       pan?: string
       reset?: string
+			exportToSVG?: string
+			exportToPNG?: string
+			exportToCSV: string
     }
   }
 }


### PR DESCRIPTION
# type definition for ApexLocale -> options -> toolbar

The following type definitions were missing:
```
exportToSVG?: string
exportToPNG?: string
exportToCSV: string
```

Fixes #2563

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
