### PR TITLE
Added support for series specific border radius on bar chart

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -381,12 +381,23 @@ export default class Helpers {
    **/
   getRoundedBars(w, opts, series, i, j) {
     let graphics = new Graphics(this.barCtx.ctx)
-    let radius = w.config.plotOptions.bar.borderRadius
+    let radius = 0
+
+    const borderRadius = w.config.plotOptions.bar.borderRadius
+    const borderRadiusIsArray = Array.isArray(borderRadius)
+    if (borderRadiusIsArray) {
+      const radiusIndex =
+        i > borderRadius.length - 1 ? borderRadius.length - 1 : i
+      radius = borderRadius[radiusIndex]
+    } else {
+      radius = borderRadius
+    }
 
     if (
       w.config.chart.stacked &&
       series.length > 1 &&
-      i !== this.barCtx.radiusOnSeriesNumber
+      i !== this.barCtx.radiusOnSeriesNumber &&
+      !borderRadiusIsArray
     ) {
       radius = 0
     }

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -487,7 +487,7 @@ type ApexPlotOptions = {
     columnWidth?: string
     barHeight?: string
     distributed?: boolean
-    borderRadius?: number
+    borderRadius?: number | number[]
     rangeBarOverlap?: boolean
     rangeBarGroupRows?: boolean
     colors?: {


### PR DESCRIPTION
# New Pull Request

`plotOptions.bar.borderRadius` now excepts both a number and a number array.

This PR is a combination of a bug fix and a new feature.  By allowing `plotOptions.bar.borderRadius` to accept both a `number` and a `number[]`, developers can now apply a border radius to a specific series in their chart.

Fixes #2592

The `borderRadius` property now behaves as follows:

`borderRadius: 5` - when setting the border radius to a number, there is **no change in behavior**. All series will receive the same border radius value. Unless it's a stacked bar chart. In that case all series would have a border radius of 0 except for the last series in the stacked bar chart.

`borderRadius: [5, 10, 5, 3]` - when setting the border radius to an array, the border radius value will be applied to each series according to the index of the series. In this example, if there are 4 series, then the border radius would be applied in the order in which it is defined. `Series 0 = Radius 5`, `Series 1 = Radius 10`, `Series 2 = Radius 5`, `Series 3 = Radius 3`. This is specifically important when dealing with a stacked series bar chart. By default, all series in a stacked series bar chart would be forced to have a radius of 0 except for the last series index which would then have a border radius value set. With this new feature, this will force all series, even a stacked bar series, to have a border radius set.

`borderRadius: [5]` - when setting the border radius to a array with a single value, then all series will receive the same border radius value. This is specifically important when dealing with a stacked series bar chart. By default, all series in a stacked series bar chart would be forced to have a radius of 0 except for the last series index which would then have a border radius value set. With this new feature, this will force all series, even a stacked bar series, to have a border radius set.

In the case where there are more series than border radius values in the array, the last value in the borderRadius array will be applied to all remaining series.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
