### PR TITLE
Add fill.gradient.colorStops declaration

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -708,7 +708,8 @@ type ApexFill = {
     inverseColors?: boolean
     opacityFrom?: number
     opacityTo?: number
-    stops?: number[]
+    stops?: number[],
+    colorStops?: any[]
   }
   image?: {
     src?: string | string[]


### PR DESCRIPTION
# New Pull Request

Add `ApexFill.gradient.colorStops` property on the typescript declaration.
https://apexcharts.com/docs/options/fill/#colorStops

Fixes #2656 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
