### PR TITLE
Add a null check to prevent errors on Safari mobile

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -130,11 +130,15 @@ export default class ZoomPanSelection extends Toolbar {
     }
 
     const tc = e.target.classList
+    let pc
+    if (e.target.parentNode && e.target.parentNode !== null) {
+      pc = e.target.parentNode.classList
+    }
     const falsePositives =
       tc.contains('apexcharts-selection-rect') ||
       tc.contains('apexcharts-legend-marker') ||
       tc.contains('apexcharts-legend-text') ||
-      e.target.parentNode.classList.contains('apexcharts-toolbar')
+      (pc && pc.contains('apexcharts-toolbar'))
 
     if (falsePositives) return
 


### PR DESCRIPTION
# New Pull Request

On Safari mobile, when a user tap-holds a graph and scrolls the page, the graph evaluates if a zoom/pan should occur and fails because `e.target.parentNode` is `null`. This PR adds a check before accessing `classList` on the `parentNode`.

The exact error message I have seen occur is `TypeError: Cannot read property 'classList' of null` which indicates that `parentNode` is `null`.

Fixes #1856

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
