### PR TITLE
Reduce innerHTML usage to improve performance and reduce XSS risk

### DIFF
--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -190,7 +190,7 @@ export default class Toolbar {
     }
     for (let i = 0; i < menuItems.length; i++) {
       this.elMenuItems.push(document.createElement('div'))
-      this.elMenuItems[i].innerHTML = menuItems[i].title
+      this.elMenuItems[i].textContent = menuItems[i].title
       Graphics.setAttrs(this.elMenuItems[i], {
         class: `apexcharts-menu-item ${menuItems[i].name}`,
         title: menuItems[i].title

--- a/src/modules/legend/Legend.js
+++ b/src/modules/legend/Legend.js
@@ -199,7 +199,7 @@ class Legend {
 
       let elLegendText = document.createElement('span')
       elLegendText.classList.add('apexcharts-legend-text')
-      elLegendText.innerHTML = Array.isArray(text) ? text.join(' ') : text
+      elLegendText.textContent = Array.isArray(text) ? text.join(' ') : text
 
       let textColor = w.config.legend.labels.useSeriesColors
         ? w.globals.colors[i]

--- a/src/modules/tooltip/AxesTooltip.js
+++ b/src/modules/tooltip/AxesTooltip.js
@@ -184,7 +184,7 @@ class AxesTooltip {
       const val = w.globals.minYArr[index] + (height - hoverY)
 
       ttCtx.tooltipPosition.moveYCrosshairs(clientY - seriesBound.top)
-      ttCtx.yaxisTooltipText[index].innerHTML = lbFormatter(val)
+      ttCtx.yaxisTooltipText[index].textContent = lbFormatter(val)
       ttCtx.tooltipPosition.moveYAxisTooltip(index)
     }
   }

--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -249,23 +249,23 @@ export default class Labels {
           '.apexcharts-tooltip-title'
         )
       }
-      ttCtx.tooltipTitle.innerHTML = xVal
+      ttCtx.tooltipTitle.textContent = xVal
     }
 
-    // if xaxis tooltip is constructed, we need to replace the innerHTML
+    // if xaxis tooltip is constructed, we need to replace the textContent
     if (ttCtx.blxaxisTooltip) {
-      ttCtx.xaxisTooltipText.innerHTML = xAxisTTVal !== '' ? xAxisTTVal : xVal
+      ttCtx.xaxisTooltipText.textContent = xAxisTTVal !== '' ? xAxisTTVal : xVal
     }
 
     const ttYLabel = ttItems[t].querySelector(
       '.apexcharts-tooltip-text-y-label'
     )
     if (ttYLabel) {
-      ttYLabel.innerHTML = seriesName ? seriesName : ''
+      ttYLabel.textContent = seriesName ? seriesName : ''
     }
     const ttYVal = ttItems[t].querySelector('.apexcharts-tooltip-text-y-value')
     if (ttYVal) {
-      ttYVal.innerHTML = typeof val !== 'undefined' ? val : ''
+      ttYVal.textContent = typeof val !== 'undefined' ? val : ''
     }
 
     if (
@@ -295,14 +295,28 @@ export default class Labels {
 
     if (goalVals.length && w.globals.seriesGoals[t]) {
       const createGoalsHtml = () => {
-        let gLabels = '<div >'
-        let gVals = '<div>'
+        const gLabelsOuter = document.createElement('div');
+        const gValsOuter = document.createElement('div');
         goalVals.forEach((goal, gi) => {
-          gLabels += ` <div style="display: flex"><span class="apexcharts-tooltip-marker" style="background-color: ${goal.attrs.strokeColor}; height: 3px; border-radius: 0; top: 5px;"></span> ${goal.attrs.name}</div>`
-          gVals += `<div>${goal.val}</div>`
+          const gLabel = document.createElement('div');
+          gLabel.style.display = 'flex';
+          const gLabelMarker = document.createElement('span');
+          gLabelMarker.className = 'apexcharts-tooltip-marker';
+          gLabelMarker.style.backgroundColor = goal.attrs.strokeColor;
+          gLabelMarker.style.height = '3px';
+          gLabelMarker.style.borderRadius = '0';
+          gLabelMarker.style.top = '5px';
+          gLabel.appendChild(gLabelMarker);
+          gLabel.appendChild(document.createTextNode(` ${goal.attrs.name}`));
+          gLabelsOuter.appendChild(gLabel);
+          const gVal = document.createElement('div');
+          gVal.textContent = goal.val;
+          gValsOuter.appendChild(gVal);
         })
-        ttGLabel.innerHTML = gLabels + `</div>`
-        ttGVal.innerHTML = gVals + `</div>`
+        ttGLabel.textContent = '';
+        ttGLabel.appendChild(gLabelsOuter);
+        ttGVal.textContent = '';
+        ttGVal.appendChild(gValsOuter);
       }
       if (shared) {
         if (
@@ -311,26 +325,26 @@ export default class Labels {
         ) {
           createGoalsHtml()
         } else {
-          ttGLabel.innerHTML = ''
-          ttGVal.innerHTML = ''
+          ttGLabel.textContent = ''
+          ttGVal.textContent = ''
         }
       } else {
         createGoalsHtml()
       }
     } else {
-      ttGLabel.innerHTML = ''
-      ttGVal.innerHTML = ''
+      ttGLabel.textContent = ''
+      ttGVal.textContent = ''
     }
 
     if (zVal !== null) {
       const ttZLabel = ttItems[t].querySelector(
         '.apexcharts-tooltip-text-z-label'
       )
-      ttZLabel.innerHTML = w.config.tooltip.z.title
+      ttZLabel.textContent = w.config.tooltip.z.title
       const ttZVal = ttItems[t].querySelector(
         '.apexcharts-tooltip-text-z-value'
       )
-      ttZVal.innerHTML = typeof zVal !== 'undefined' ? zVal : ''
+      ttZVal.textContent = typeof zVal !== 'undefined' ? zVal : ''
     }
 
     if (shared && ttItemsChildren[0]) {
@@ -485,7 +499,7 @@ export default class Labels {
     }
 
     // override everything with a custom html tooltip and replace it
-    tooltipEl.innerHTML = fn({
+    tooltipEl.textContent = fn({
       ctx: this.ctx,
       series: w.globals.series,
       seriesIndex: i,

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -600,14 +600,14 @@ export default class Tooltip {
           w
         })
 
-        this.legendLabels[i].innerHTML = text
+        this.legendLabels[i].textContent = text
       }
     } else if (e.type === 'mouseout' || e.type === 'touchend') {
       tooltipEl.classList.remove('apexcharts-active')
       if (w.config.legend.tooltipHoverFormatter) {
         this.legendLabels.forEach((l) => {
           const defaultText = l.getAttribute('data:default-text')
-          l.innerHTML = decodeURIComponent(defaultText)
+          l.textContent = decodeURIComponent(defaultText)
         })
       }
     }
@@ -714,7 +714,7 @@ export default class Tooltip {
     if (w.config.legend.tooltipHoverFormatter) {
       this.legendLabels.forEach((l) => {
         const defaultText = l.getAttribute('data:default-text')
-        l.innerHTML = decodeURIComponent(defaultText)
+        l.textContent = decodeURIComponent(defaultText)
       })
     }
   }
@@ -757,7 +757,7 @@ export default class Tooltip {
       // reset all legend values first
       els.forEach((l) => {
         const legendName = l.getAttribute('data:default-text')
-        l.innerHTML = decodeURIComponent(legendName)
+        l.textContent = decodeURIComponent(legendName)
       })
 
       // for irregular time series
@@ -775,12 +775,12 @@ export default class Tooltip {
         })
 
         if (!shared) {
-          l.innerHTML = lsIndex === capturedSeries ? text : legendName
+          l.textContent = lsIndex === capturedSeries ? text : legendName
           if (capturedSeries === lsIndex) {
             break
           }
         } else {
-          l.innerHTML =
+          l.textContent =
             w.globals.collapsedSeriesIndices.indexOf(lsIndex) < 0
               ? text
               : legendName


### PR DESCRIPTION
# New Pull Request

Changes several `.innerHTML` calls with `.textContent` and `createElement`/`appendChild` calls.
This both sanitizes the input to protect against XSS attacks (like #816) and drastically improves the performance (especially around tooltips).

Fixes #816 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

These changes will break anyone who is currently relying on this unsafe behavior and passing in raw HTML to any of these values.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Unfortunately, the e2e tests don't pass on my system in the unmodified master code (before any of my changes). Since an e2e test would be the appropriate place to test these, and since I can't get the current ones to pass on my system, I did not write new tests. I did manually test the changes, and the e2e tests fail in identical ways both before and after my changes.

These changes do not fix all XSS and performance risks around using innerHTML - Toolbar, PointAnnotations, Legend, and svg all use innerHTML, but they all would need a more substantial update (with a higher risk of impacting more current users) to not rely on innerHTML.