### PR TITLE
Inject ApexCharts CSS to shadow root if we're in a shadow DOM context

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -66,6 +66,7 @@ function rollupConfig(opts) {
         preferConst: true
       }),
       postcss({
+        inject: false,
         plugins: []
       }),
       svgo({

--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -13,6 +13,7 @@ import YAxis from './modules/axes/YAxis'
 import InitCtxVariables from './modules/helpers/InitCtxVariables'
 import Destroy from './modules/helpers/Destroy'
 import { addResizeListener, removeResizeListener } from './utils/Resize'
+import apexCSS from './assets/apexcharts.css'
 
 /**
  *
@@ -71,6 +72,28 @@ export default class ApexCharts {
         this.events.fireEvent('beforeMount', [this, this.w])
         window.addEventListener('resize', this.windowResizeHandler)
         addResizeListener(this.el.parentNode, this.parentResizeHandler)
+
+        // Add CSS if not already added
+        if (!this.css) {
+          let rootNode = this.el.getRootNode && this.el.getRootNode()
+          let inShadowRoot = Utils.is('ShadowRoot', rootNode)
+          let doc = this.el.ownerDocument
+          let globalCSS = doc.getElementById('apexcharts-css')
+
+          if (inShadowRoot || !globalCSS) {
+            this.css = document.createElement('style')
+            this.css.id = 'apexcharts-css'
+            this.css.textContent = apexCSS
+
+            if (inShadowRoot) {
+              // We are in Shadow DOM, add to shadow root
+              rootNode.prepend(this.css)
+            } else {
+              // Add to <head> of element's document
+              doc.head.appendChild(this.css)
+            }
+          }
+        }
 
         let graphData = this.create(this.w.config.series, {})
         if (!graphData) return resolve(this)

--- a/src/modules/helpers/InitCtxVariables.js
+++ b/src/modules/helpers/InitCtxVariables.js
@@ -30,8 +30,6 @@ import 'svg.draggable.js'
 import 'svg.select.js'
 import 'svg.resize.js'
 
-import '../../assets/apexcharts.css'
-
 // global Apex object which user can use to override chart's defaults globally
 if (typeof window.Apex === 'undefined') {
   window.Apex = {}

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -4,7 +4,7 @@
 
 class Utils {
   static bind(fn, me) {
-    return function() {
+    return function () {
       return fn.apply(me, arguments)
     }
   }
@@ -13,6 +13,11 @@ class Utils {
     return (
       item && typeof item === 'object' && !Array.isArray(item) && item != null
     )
+  }
+
+  // Type checking that works across different window objects
+  static is(type, val) {
+    return Object.prototype.toString.call(val) === '[object ' + type + ']';
   }
 
   static listToArray(list) {
@@ -28,8 +33,8 @@ class Utils {
   // credit: http://stackoverflow.com/questions/27936772/deep-object-merging-in-es6-es7#answer-34749873
   static extend(target, source) {
     if (typeof Object.assign !== 'function') {
-      ;(function() {
-        Object.assign = function(target) {
+      ; (function () {
+        Object.assign = function (target) {
           'use strict'
           // We must check against these specific cases.
           if (target === undefined || target === null) {
@@ -88,16 +93,16 @@ class Utils {
   }
 
   static clone(source) {
-    if (Object.prototype.toString.call(source) === '[object Array]') {
+    if (Utils.is('Array', source)) {
       let cloneResult = []
       for (let i = 0; i < source.length; i++) {
         cloneResult[i] = this.clone(source[i])
       }
       return cloneResult
-    } else if (Object.prototype.toString.call(source) === '[object Null]') {
+    } else if (Utils.is('Null', source)) {
       // fixes an issue where null values were converted to {}
       return null
-    } else if (Object.prototype.toString.call(source) === '[object Date]') {
+    } else if (Utils.is('Date', source)) {
       return source
     } else if (typeof source === 'object') {
       let cloneResult = {}
@@ -218,9 +223,9 @@ class Utils {
     )
     return rgb && rgb.length === 4
       ? '#' +
-          ('0' + parseInt(rgb[1], 10).toString(16)).slice(-2) +
-          ('0' + parseInt(rgb[2], 10).toString(16)).slice(-2) +
-          ('0' + parseInt(rgb[3], 10).toString(16)).slice(-2)
+      ('0' + parseInt(rgb[1], 10).toString(16)).slice(-2) +
+      ('0' + parseInt(rgb[2], 10).toString(16)).slice(-2) +
+      ('0' + parseInt(rgb[3], 10).toString(16)).slice(-2)
       : ''
   }
 


### PR DESCRIPTION
# New Pull Request

Previously, all ApexCharts CSS was injected in the `<head>` of the document ApexCharts was included in, through [StyleInject](https://github.com/egoist/style-inject/blob/master/src/index.js) that was being called by [`rollup-plugin-postcss`](https://github.com/egoist/rollup-plugin-postcss).

This PR disables the automatic injection, and instead injects it manually. We first check if we're in a Shadow DOM context, and append the CSS to the shadow root if so. Otherwise, we check if the CSS has already been added to the current document, and insert it if not.

While the primary goal of this PR was to fix the Shadow DOM problem, it introduces a few other improvements:
- Since the injection is now context-aware, even for non-shadow contexts, we inject in the chart element's document, not the document the ApexCharts library was included on. While in most cases these are the same, they are not when the library is included in one document, and the chart is in another (e.g. an iframe).
- With this change, if ApexCharts are included, but no charts are actually drawn on the current page, this won't inject any CSS, whereas previously just including the Apex Charts module produced side effects (injected CSS).
- I also added an `Util.is()` helper to perform type-checking that works across different window objects, and applied it on existing code that was already using this method without a helper.
- The two unrelated changes in Utils.js (L7, L36-37 and L226-228) are to apply the current Prettier rules (I guess code was changed there but Prettier was not run).

Fixes #238

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
