### PR TITLE
Fixes yaxis annotations at the very top edge of the graph that are displayed at the wrong y-coordinate

### DIFF
--- a/src/modules/annotations/YAxisAnnotations.js
+++ b/src/modules/annotations/YAxisAnnotations.js
@@ -63,7 +63,7 @@ export default class YAnnotations {
 
     let elText = this.annoCtx.graphics.drawText({
       x: textX + anno.label.offsetX,
-      y: (y2 || y1) + anno.label.offsetY - 3,
+      y: (y2 != null ? y2 : y1) + anno.label.offsetY - 3,
       text,
       textAnchor: anno.label.textAnchor,
       fontSize: anno.label.style.fontSize,


### PR DESCRIPTION
# New Pull Request

Fixes #2770

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
