### PR TITLE
(type fix) Allow string for marker colour

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -800,7 +800,7 @@ type ApexDiscretePoint = {
 
 type ApexMarkers = {
   size?: number | number[]
-  colors?: string[]
+  colors?: string | string[]
   strokeColors?: string | string[]
   strokeWidth?: number | number[]
   strokeOpacity?: number | number[]


### PR DESCRIPTION
As documented (https://apexcharts.com/docs/options/markers/) marker colors may be a single Color, but currently Typescript users get a type error when trying to do so.

```typescript
markers: {
  size: 3,
  colors: "#000000" as unknown as string[], // only string[] is allowed, but string works fine
}
```
is currently needed as a workaround

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
