### PR TITLE
fix: wrong mapping an index to the length of array

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -209,7 +209,7 @@ export default class Helpers {
       activeSeriesIndex === i
     ) {
       if (j >= this.barCtx.barOptions.colors.backgroundBarColors.length) {
-        j -= this.barCtx.barOptions.colors.backgroundBarColors.length
+        j %= this.barCtx.barOptions.colors.backgroundBarColors.length
       }
 
       let bcolor = this.barCtx.barOptions.colors.backgroundBarColors[j]


### PR DESCRIPTION
Fixes #2957 

## Type of change

When drawing bars and trying to find `backgroundBarColor` for the current value, if the index `j` is greater than the given `backgroundBarColors` array, it is being reduced by the length of the array. However, this is not sufficient to map a value to the range of an array (think of an example of j being 4, and the array containing a single value). The mod of the index should be calculated and updated.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
