### PR TITLE
Fixed a label marker color for 'pattern' fill type

### DIFF
--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -126,8 +126,15 @@ export default class Labels {
             })
           }
         } else {
-          if (e && e.target && e.target.getAttribute('fill')) {
-            pColor = e.target.getAttribute('fill')
+          // get a color from a hover area (if it's a line pattern then get from a first line)
+          const targetFill = e?.target?.getAttribute('fill');
+          if (targetFill) {
+            pColor = (targetFill.indexOf("url") !== -1) ? (
+              document
+                .querySelector(targetFill.substr(4).slice(0, -1))
+                .querySelector("line")
+                .getAttribute("stroke")
+            ) : targetFill;
           }
           val = getValBySeriesIndex(i)
           if (hasGoalValues(i) && Array.isArray(w.globals.seriesGoals[i][j])) {
@@ -200,14 +207,14 @@ export default class Labels {
       if (w.globals.yLabelFormatters[0]) {
         yLbFormatter = w.globals.yLabelFormatters[0]
       } else {
-        yLbFormatter = function(label) {
+        yLbFormatter = function (label) {
           return label
         }
       }
     }
 
     if (typeof yLbTitleFormatter !== 'function') {
-      yLbTitleFormatter = function(label) {
+      yLbTitleFormatter = function (label) {
         return label
       }
     }

--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -132,7 +132,7 @@ export default class Labels {
             pColor = (targetFill.indexOf("url") !== -1) ? (
               document
                 .querySelector(targetFill.substr(4).slice(0, -1))
-                .querySelector("line")
+                .childNodes[0]
                 .getAttribute("stroke")
             ) : targetFill;
           }


### PR DESCRIPTION
# New Pull Request

The main cause of the issue was irrelevant value for backgroundColor for the markers inside tooltip (pColor): if fill type was "pattern", we had 'url(#patternId)' instead some color. This solution works for each of pattern style.

Fixes #2668

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
