### PR TITLE
Fixed positioning of a tooltip in multi-series chart

### DIFF
--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -72,19 +72,18 @@ export default class Utils {
     let seriesXValArr = []
     let seriesYValArr = []
 
-    for (let s = 0; s < w.globals.seriesXvalues.length; s++) {
-      seriesXValArr.push(
-        [w.globals.seriesXvalues[s][0] - 0.000001].concat(
-          w.globals.seriesXvalues[s]
-        )
-      )
-    }
-
-    seriesXValArr = seriesXValArr.map((seriesXVal) => {
-      return seriesXVal.filter((s) => s)
+    //add extra values to show markers for the first points. Included both axes to avoid incorrect positioning of the marker
+    w.globals.seriesXvalues.forEach(value => {
+      seriesXValArr.push([value[0] + 0.000001].concat(value))
+    })
+    w.globals.seriesYvalues.forEach(value => {
+      seriesYValArr.push([value[0] + 0.000001].concat(value))
     })
 
-    seriesYValArr = w.globals.seriesYvalues.map((seriesYVal) => {
+    seriesXValArr = seriesXValArr.map((seriesXVal) => {
+      return seriesXVal.filter((s) => Utilities.isNumber(s))
+    })
+    seriesYValArr = seriesYValArr.map((seriesYVal) => {
       return seriesYVal.filter((s) => Utilities.isNumber(s))
     })
 
@@ -149,28 +148,34 @@ export default class Utils {
       currIndex = 0
     }
 
-    let currY = Yarrays[activeIndex][0]
     let currX = Xarrays[activeIndex][0]
-
     let diffX = Math.abs(hoverX - currX)
-    let diffY = Math.abs(hoverY - currY)
-    let diff = diffY + diffX
 
-    Yarrays.map((arrY, arrIndex) => {
-      arrY.map((y, innerIndex) => {
-        let newdiffY = Math.abs(hoverY - Yarrays[arrIndex][innerIndex])
-        let newdiffX = Math.abs(hoverX - Xarrays[arrIndex][innerIndex])
-        let newdiff = newdiffX + newdiffY
-
-        if (newdiff < diff) {
-          diff = newdiff
-          diffX = newdiffX
-          diffY = newdiffY
-          currIndex = arrIndex
-          j = innerIndex
+    // find nearest point on x-axis
+    Xarrays.forEach((arrX) => {
+      arrX.forEach((x, iX) => {
+        const newDiff = Math.abs(hoverX - x)
+        if (newDiff < diffX) {
+          diffX = newDiff
+          j = iX
         }
       })
     })
+
+    if (j !== -1) {
+      // find nearest graph on y-axis relevanted to nearest point on x-axis
+      let currY = Yarrays[activeIndex][j]
+      let diffY = Math.abs(hoverY - currY)
+      currIndex = activeIndex
+
+      Yarrays.forEach((arrY, iAY) => {
+        const newDiff = Math.abs(hoverY - arrY[j])
+        if (newDiff < diffY) {
+          diffY = newDiff;
+          currIndex = iAY;
+        }
+      });
+    }
 
     return {
       index: currIndex,


### PR DESCRIPTION
# New Pull Request

There was two causes:
- shifting one of arrays because of added extra point 0.000001 only for one axis. Fixed by adding the extra point to another one (needed to show the first marker);
- closestInMultiArray function worked well but not as expected. In case if a cursor is closer to a point on another x-axis which has a blue color, we will see active blue marker even if green graph seems to be closer on y-axis. So firstly, we should find the closest point on x-axis and than choose wich graph is closer on y-axis.

Fixes  #689

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
