### PR TITLE
feat: Add sub-groups in xAxis labels

### DIFF
--- a/samples/source/bar/bar-with-group-labels.xml
+++ b/samples/source/bar/bar-with-group-labels.xml
@@ -1,0 +1,63 @@
+<title>Bar with Group Labels</title>
+<chart>
+    <options>
+chart: {
+  type: 'bar',
+  height: 380
+},
+plotOptions: {
+  bar: {
+    barHeight: '100%',
+    distributed: true,
+    horizontal: true,
+    dataLabels: {
+      position: 'bottom'
+    },
+  }
+},
+colors: ['#33b2df', '#546E7A', '#d4526e', '#13d8aa', '#A5978B', '#2b908f', '#f9a3a4', '#90ee7e',
+  '#f48024', '#69d2e7'
+],
+xaxis: {
+  categories: ['South Korea', 'Canada', 'United Kingdom', 'Netherlands', 'Italy', 'France', 'Japan',
+    'United States', 'China', 'India'
+  ],
+  group: {
+      groups: [{ title: "Test", cols: 3 }, { title: "Test1", cols: 2 }, { title: "Test2", cols: 4 }]
+  }
+},
+yaxis: {
+  labels: {
+    show: false
+  }
+},
+title: {
+    text: 'Custom DataLabels',
+    align: 'center',
+    floating: true
+},
+subtitle: {
+    text: 'Category Names as DataLabels inside bars',
+    align: 'center',
+},
+tooltip: {
+  theme: 'dark',
+  x: {
+    show: false
+  },
+  y: {
+    title: {
+      formatter: function () {
+        return ''
+      }
+    }
+  }
+}
+</options>
+
+    <series>
+[{
+  data: [400, 430, 448, 470, 540, 580, 690, 1100, 1200, 1380]
+}]
+</series>
+</chart>

--- a/samples/vanilla-js/bar/bar-with-group-labels.html
+++ b/samples/vanilla-js/bar/bar-with-group-labels.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Bar with Custom DataLabels</title>
+
+  <link href="../../assets/styles.css" rel="stylesheet" />
+
+  <style>
+    #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+  </style>
+
+  <script>
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+      )
+  </script>
+
+
+  <script src="../../../dist/apexcharts.js"></script>
+
+
+  <script>
+    // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+    // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+    var _seed = 42;
+    Math.random = function () {
+      _seed = _seed * 16807 % 2147483647;
+      return (_seed - 1) / 2147483646;
+    };
+  </script>
+
+
+</head>
+
+<body>
+  <div id="chart"></div>
+
+  <script>
+
+    var options = {
+      series: [{
+        data: [400, 430, 448, 470, 540, 580, 690, 1100, 1200, 1380]
+      }],
+      chart: {
+        type: 'bar',
+        height: 380
+      },
+      plotOptions: {
+        bar: {
+          barHeight: '100%',
+          distributed: true,
+          horizontal: true,
+          dataLabels: {
+            position: 'bottom'
+          },
+        }
+      },
+      colors: ['#33b2df', '#546E7A', '#d4526e', '#13d8aa', '#A5978B', '#2b908f', '#f9a3a4', '#90ee7e',
+        '#f48024', '#69d2e7'
+      ],
+      xaxis: {
+        categories: ['South Korea', 'Canada', 'United Kingdom', 'Netherlands', 'Italy', 'France', 'Japan',
+          'United States', 'China', 'India'
+        ],
+        group: {
+          groups: [{ title: "Test", cols: 3 }, { title: "Test1", cols: 2 }, { title: "Test2", cols: 4 }]
+        }
+      },
+      yaxis: {
+        labels: {
+          show: false
+        }
+      },
+      title: {
+        text: 'Custom DataLabels',
+        align: 'center',
+        floating: true
+      },
+      subtitle: {
+        text: 'Category Names as DataLabels inside bars',
+        align: 'center',
+      },
+      tooltip: {
+        theme: 'dark',
+        x: {
+          show: false
+        },
+        y: {
+          title: {
+            formatter: function () {
+              return ''
+            }
+          }
+        }
+      }
+    };
+
+    var chart = new ApexCharts(document.querySelector("#chart"), options);
+    chart.render();
+
+
+  </script>
+
+
+</body>
+
+</html>

--- a/samples/vue/bar/bar-with-group-labels.html
+++ b/samples/vue/bar/bar-with-group-labels.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Bar with Custom DataLabels</title>
+
+  <link href="../../assets/styles.css" rel="stylesheet" />
+
+  <style>
+    #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+  </style>
+
+  <script>
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+      )
+    window.Promise ||
+      document.write(
+        '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+      )
+  </script>
+
+
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
+  <script src="../../../dist/apexcharts.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-apexcharts"></script>
+
+
+  <script>
+    // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+    // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+    var _seed = 42;
+    Math.random = function () {
+      _seed = _seed * 16807 % 2147483647;
+      return (_seed - 1) / 2147483646;
+    };
+  </script>
+
+
+</head>
+
+<body>
+
+  <div id="app">
+    <div id="chart">
+      <apexchart type="bar" height="380" :options="chartOptions" :series="series"></apexchart>
+    </div>
+  </div>
+
+  <!-- Below element is just for displaying source code. it is not required. DO NOT USE -->
+  <div id="html">
+    &lt;div id=&quot;chart&quot;&gt;
+    &lt;apexchart type=&quot;bar&quot; height=&quot;380&quot; :options=&quot;chartOptions&quot;
+    :series=&quot;series&quot;&gt;&lt;/apexchart&gt;
+    &lt;/div&gt;
+  </div>
+
+  <script>
+    new Vue({
+      el: '#app',
+      components: {
+        apexchart: VueApexCharts,
+      },
+      data: {
+
+        series: [{
+          data: [400, 430, 448, 470, 540, 580, 690, 1100, 1200, 1380]
+        }],
+        chartOptions: {
+          chart: {
+            type: 'bar',
+            height: 380
+          },
+          plotOptions: {
+            bar: {
+              barHeight: '100%',
+              distributed: true,
+              horizontal: true,
+              dataLabels: {
+                position: 'bottom'
+              },
+            }
+          },
+          colors: ['#33b2df', '#546E7A', '#d4526e', '#13d8aa', '#A5978B', '#2b908f', '#f9a3a4', '#90ee7e',
+            '#f48024', '#69d2e7'
+          ],
+          xaxis: {
+            categories: ['South Korea', 'Canada', 'United Kingdom', 'Netherlands', 'Italy', 'France', 'Japan',
+              'United States', 'China', 'India'
+            ],
+            group: {
+              groups: [{ title: "Test", cols: 3 }, { title: "Test1", cols: 2 }, { title: "Test2", cols: 4 }]
+            }
+          },
+          yaxis: {
+            labels: {
+              show: false
+            }
+          },
+          title: {
+            text: 'Custom DataLabels',
+            align: 'center',
+            floating: true
+          },
+          subtitle: {
+            text: 'Category Names as DataLabels inside bars',
+            align: 'center',
+          },
+          tooltip: {
+            theme: 'dark',
+            x: {
+              show: false
+            },
+            y: {
+              title: {
+                formatter: function () {
+                  return ''
+                }
+              }
+            }
+          }
+        }
+
+
+      },
+
+    })
+  </script>
+
+</body>
+
+</html>

--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -395,6 +395,11 @@ export default class Data {
 
     gl.isRangeBar = cnf.chart.type === 'rangeBar' && gl.isBarHorizontal
 
+    gl.hasGroups = typeof (cnf.xaxis.group) !== 'undefined' && typeof (cnf.xaxis.group.groups) !== 'undefined' && cnf.xaxis.group.groups.length > 0
+    if (gl.hasGroups) {
+      gl.groups = cnf.xaxis.group.groups;
+    }
+
     const handleDates = () => {
       for (let j = 0; j < xlabels.length; j++) {
         if (typeof xlabels[j] === 'string') {
@@ -607,8 +612,8 @@ export default class Data {
       labelArr = gl.axisCharts
         ? []
         : gl.series.map((gls, glsi) => {
-            return glsi + 1
-          })
+          return glsi + 1
+        })
       for (let i = 0; i < ser.length; i++) {
         gl.seriesX.push(labelArr)
       }

--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -395,7 +395,7 @@ export default class Data {
 
     gl.isRangeBar = cnf.chart.type === 'rangeBar' && gl.isBarHorizontal
 
-    gl.hasGroups = typeof (cnf.xaxis.group) !== 'undefined' && typeof (cnf.xaxis.group.groups) !== 'undefined' && cnf.xaxis.group.groups.length > 0
+    gl.hasGroups = cnf.xaxis.type === 'category' && typeof (cnf.xaxis.group) !== 'undefined' && typeof (cnf.xaxis.group.groups) !== 'undefined' && cnf.xaxis.group.groups.length > 0
     if (gl.hasGroups) {
       gl.groups = cnf.xaxis.group.groups;
     }

--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -185,8 +185,22 @@ class Grid {
       if (w.config.grid.xaxis.lines.show) {
         this._drawGridLine({ x1, y1, x2, y2, parent })
       }
+      let y_2 = 0;
+      if (w.globals.hasGroups && (typeof w.config.xaxis.tickAmount === 'undefined' || w.config.xaxis.tickAmount === 'dataPoints') && w.config.xaxis.tickPlacement === 'between') {
+        const groups = w.globals.groups;
+        if (groups) {
+          let gacc = 0;
+          for (let gi = 0; gacc < i && gi < groups.length; gi++) {
+            gacc += groups[gi].cols;
+          }
+          if (gacc === i) {
+            y_2 = w.globals.xAxisLabelsHeight * 0.6;
+          }
+        }
+      }
+
       let xAxis = new XAxis(this.ctx)
-      xAxis.drawXaxisTicks(x1, this.elg)
+      xAxis.drawXaxisTicks(x1, y_2, this.elg)
     }
   }
 
@@ -360,7 +374,7 @@ class Grid {
         }
 
         let xAxis = new XAxis(this.ctx)
-        xAxis.drawXaxisTicks(x1, this.elg)
+        xAxis.drawXaxisTicks(x1, 0, this.elg)
         x1 = x1 + w.globals.gridWidth / xCount + 0.3
         x2 = x1
       }
@@ -479,8 +493,8 @@ class Grid {
     ) {
       const xc =
         !w.globals.isBarHorizontal &&
-        (w.config.xaxis.type === 'category' ||
-          w.config.xaxis.convertedCatToNumeric)
+          (w.config.xaxis.type === 'category' ||
+            w.config.xaxis.convertedCatToNumeric)
           ? xCount - 1
           : xCount
       let x1 = w.globals.padHorizontal

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -88,7 +88,7 @@ export default class XAxis {
       for (let i = 0; i < labelsGroup.length; i++) {
         labels.push(labelsGroup[i].title)
       }
-      this.drawXAxisLabelGroup(false, graphics, elXaxisTexts, labels, w.globals.isXNumeric, (i, colWidth) => labelsGroup[i].cols * colWidth)
+      this.drawXAxisLabelGroup(false, graphics, elXaxisTexts, labels, false, (i, colWidth) => labelsGroup[i].cols * colWidth)
     }
 
     if (w.config.xaxis.title.text !== undefined) {

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -203,7 +203,7 @@ export default class XAxis {
       }
 
       if (!isLeafGroup) {
-        offsetYCorrection = offsetYCorrection - parseFloat(xaxisFontSize) + w.globals.xAxisLabelsHeight / 2
+        offsetYCorrection = offsetYCorrection + parseFloat(xaxisFontSize) + (w.globals.xAxisLabelsHeight - w.globals.xAxisGroupLabelsHeight)
       }
 
       const isCategoryTickAmounts =

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -88,7 +88,17 @@ export default class XAxis {
       for (let i = 0; i < labelsGroup.length; i++) {
         labels.push(labelsGroup[i].title)
       }
-      this.drawXAxisLabelGroup(false, graphics, elXaxisTexts, labels, false, (i, colWidth) => labelsGroup[i].cols * colWidth)
+
+      let overwriteStyles = {}
+      if (w.config.xaxis.group.style) {
+        overwriteStyles.xaxisFontSize = w.config.xaxis.group.style.fontSize
+        overwriteStyles.xaxisFontFamily = w.config.xaxis.group.style.fontFamily
+        overwriteStyles.xaxisForeColors = w.config.xaxis.group.style.colors
+        overwriteStyles.fontWeight = w.config.xaxis.group.style.fontWeight
+        overwriteStyles.cssClass = w.config.xaxis.group.style.cssClass
+      }
+
+      this.drawXAxisLabelGroup(false, graphics, elXaxisTexts, labels, false, (i, colWidth) => labelsGroup[i].cols * colWidth, overwriteStyles)
     }
 
     if (w.config.xaxis.title.text !== undefined) {
@@ -136,10 +146,17 @@ export default class XAxis {
     return elXaxis
   }
 
-  drawXAxisLabelGroup(isLeafGroup, graphics, elXaxisTexts, labels, isXNumeric, colWidthCb) {
+  drawXAxisLabelGroup(isLeafGroup, graphics, elXaxisTexts, labels, isXNumeric, colWidthCb, overwriteStyles = {}) {
     let drawnLabels = []
     let drawnLabelsRects = []
     let w = this.w
+
+
+    const xaxisFontSize = overwriteStyles.xaxisFontSize || this.xaxisFontSize
+    const xaxisFontFamily = overwriteStyles.xaxisFontFamily || this.xaxisFontFamily
+    const xaxisForeColors = overwriteStyles.xaxisForeColors || this.xaxisForeColors
+    const fontWeight = overwriteStyles.fontWeight || w.config.xaxis.labels.style.fontWeight
+    const cssClass = overwriteStyles.cssClass || w.config.xaxis.labels.style.cssClass
 
     let colWidth
 
@@ -177,7 +194,7 @@ export default class XAxis {
         x,
         i,
         drawnLabels,
-        this.xaxisFontSize
+        xaxisFontSize
       )
 
       let offsetYCorrection = 28
@@ -186,7 +203,7 @@ export default class XAxis {
       }
 
       if (!isLeafGroup) {
-        offsetYCorrection = offsetYCorrection - parseFloat(this.xaxisFontSize) + w.globals.xAxisLabelsHeight / 2
+        offsetYCorrection = offsetYCorrection - parseFloat(xaxisFontSize) + w.globals.xAxisLabelsHeight / 2
       }
 
       const isCategoryTickAmounts =
@@ -208,8 +225,8 @@ export default class XAxis {
 
       const getCatForeColor = () => {
         return w.config.xaxis.convertedCatToNumeric
-          ? this.xaxisForeColors[w.globals.minX + i - 1]
-          : this.xaxisForeColors[i]
+          ? xaxisForeColors[w.globals.minX + i - 1]
+          : xaxisForeColors[i]
       }
 
       if (isLeafGroup && label.text) {
@@ -230,15 +247,15 @@ export default class XAxis {
           textAnchor: 'middle',
           fontWeight: label.isBold
             ? 600
-            : w.config.xaxis.labels.style.fontWeight,
-          fontSize: this.xaxisFontSize,
-          fontFamily: this.xaxisFontFamily,
-          foreColor: Array.isArray(this.xaxisForeColors)
+            : fontWeight,
+          fontSize: xaxisFontSize,
+          fontFamily: xaxisFontFamily,
+          foreColor: Array.isArray(xaxisForeColors)
             ? getCatForeColor()
-            : this.xaxisForeColors,
+            : xaxisForeColors,
           isPlainText: false,
           cssClass:
-            (isLeafGroup ? 'apexcharts-xaxis-label ' : 'apexcharts-xaxis-group-label') + w.config.xaxis.labels.style.cssClass
+            (isLeafGroup ? 'apexcharts-xaxis-label ' : 'apexcharts-xaxis-group-label ') + cssClass
         })
         elXaxisTexts.add(elText)
 

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -224,7 +224,7 @@ export default class XAxis {
       }
 
       const getCatForeColor = () => {
-        return w.config.xaxis.convertedCatToNumeric
+        return isLeafGroup && w.config.xaxis.convertedCatToNumeric
           ? xaxisForeColors[w.globals.minX + i - 1]
           : xaxisForeColors[i]
       }

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -147,32 +147,33 @@ export default class XAxis {
     let xPos = w.globals.padHorizontal
 
     let labelsLen = labels.length
+    let datapoints = w.globals.dataPoints
 
     if (isXNumeric) {
-      let len = labelsLen > 1 ? labelsLen - 1 : labelsLen
+      let len = datapoints > 1 ? datapoints - 1 : datapoints
       colWidth = w.globals.gridWidth / len
       xPos = xPos + colWidthCb(0, colWidth) / 2 + w.config.xaxis.labels.offsetX
     } else {
-      colWidth = w.globals.gridWidth / labels.length
+      colWidth = w.globals.gridWidth / datapoints
       xPos = xPos + colWidthCb(0, colWidth) + w.config.xaxis.labels.offsetX
     }
 
 
     for (let i = 0; i <= labelsLen - 1; i++) {
-      let x = xPos - colWidth / 2 + w.config.xaxis.labels.offsetX
+      let x = xPos - colWidthCb(i, colWidth) / 2 + w.config.xaxis.labels.offsetX
 
       if (
         i === 0 &&
         labelsLen === 1 &&
         colWidth / 2 === xPos &&
-        w.globals.dataPoints === 1
+        datapoints === 1
       ) {
         // single datapoint
         x = w.globals.gridWidth / 2
       }
       let label = this.axesUtils.getLabel(
         labels,
-        w.globals.timescaleLabels,
+        [],
         x,
         i,
         drawnLabels,

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -97,9 +97,10 @@ export default class Dimensions {
     this.yAxisWidth = this.dimYAxis.getTotalYAxisWidth()
 
     let xaxisLabelCoords = this.dimXAxis.getxAxisLabelsCoords()
+    let xaxisGroupLabelCoords = this.dimXAxis.getxAxisGroupLabelsCoords()
     let xtitleCoords = this.dimXAxis.getxAxisTitleCoords()
 
-    this.conditionalChecksForAxisCoords(xaxisLabelCoords, xtitleCoords)
+    this.conditionalChecksForAxisCoords(xaxisLabelCoords, xtitleCoords, xaxisGroupLabelCoords)
 
     gl.translateXAxisY = w.globals.rotateXLabels ? this.xAxisHeight / 8 : -4
     gl.translateXAxisX =
@@ -121,6 +122,7 @@ export default class Dimensions {
     let yAxisWidth = this.yAxisWidth
     let xAxisHeight = this.xAxisHeight
     gl.xAxisLabelsHeight = this.xAxisHeight - xtitleCoords.height
+    gl.xAxisGroupLabelsHeight = gl.xAxisLabelsHeight - xaxisLabelCoords.height
     gl.xAxisLabelsWidth = this.xAxisWidth
     gl.xAxisHeight = this.xAxisHeight
     let translateY = 10
@@ -259,12 +261,12 @@ export default class Dimensions {
     }
   }
 
-  conditionalChecksForAxisCoords(xaxisLabelCoords, xtitleCoords) {
+  conditionalChecksForAxisCoords(xaxisLabelCoords, xtitleCoords, xaxisGroupLabelCoords) {
     const w = this.w
 
     const xAxisNum = (w.globals.hasGroups ? 2 : 1)
 
-    const baseXAxisHeight = xAxisNum * xaxisLabelCoords.height + xtitleCoords.height
+    const baseXAxisHeight = xaxisGroupLabelCoords.height + xaxisLabelCoords.height + xtitleCoords.height
     const xAxisHeightMultiplicate = w.globals.isMultiLineX
       ? 1.2
       : w.globals.LINE_HEIGHT_RATIO

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -104,8 +104,8 @@ export default class Dimensions {
     gl.translateXAxisY = w.globals.rotateXLabels ? this.xAxisHeight / 8 : -4
     gl.translateXAxisX =
       w.globals.rotateXLabels &&
-      w.globals.isXNumeric &&
-      w.config.xaxis.labels.rotate <= -45
+        w.globals.isXNumeric &&
+        w.config.xaxis.labels.rotate <= -45
         ? -this.xAxisWidth / 4
         : 0
 
@@ -208,8 +208,8 @@ export default class Dimensions {
 
     const type =
       cnf.chart.type === 'pie' ||
-      cnf.chart.type === 'polarArea' ||
-      cnf.chart.type === 'donut'
+        cnf.chart.type === 'polarArea' ||
+        cnf.chart.type === 'donut'
         ? 'pie'
         : 'radialBar'
 
@@ -262,7 +262,9 @@ export default class Dimensions {
   conditionalChecksForAxisCoords(xaxisLabelCoords, xtitleCoords) {
     const w = this.w
 
-    const baseXAxisHeight = xaxisLabelCoords.height + xtitleCoords.height
+    const xAxisNum = (w.globals.hasGroups ? 2 : 1)
+
+    const baseXAxisHeight = xAxisNum * xaxisLabelCoords.height + xtitleCoords.height
     const xAxisHeightMultiplicate = w.globals.isMultiLineX
       ? 1.2
       : w.globals.LINE_HEIGHT_RATIO
@@ -273,7 +275,7 @@ export default class Dimensions {
 
     this.xAxisHeight =
       baseXAxisHeight * xAxisHeightMultiplicate +
-      rotatedXAxisOffset +
+      xAxisNum * rotatedXAxisOffset +
       additionalOffset
 
     this.xAxisWidth = xaxisLabelCoords.width

--- a/src/modules/dimensions/XAxis.js
+++ b/src/modules/dimensions/XAxis.js
@@ -35,7 +35,7 @@ export default class DimXAxis {
       this.dCtx.lgWidthForSideLegends =
         (w.config.legend.position === 'left' ||
           w.config.legend.position === 'right') &&
-        !w.config.legend.floating
+          !w.config.legend.floating
           ? this.dCtx.lgRect.width
           : 0
 
@@ -105,10 +105,10 @@ export default class DimXAxis {
       if (
         (rect.width * xaxisLabels.length >
           w.globals.svgWidth -
-            this.dCtx.lgWidthForSideLegends -
-            this.dCtx.yAxisWidth -
-            this.dCtx.gridPad.left -
-            this.dCtx.gridPad.right &&
+          this.dCtx.lgWidthForSideLegends -
+          this.dCtx.yAxisWidth -
+          this.dCtx.gridPad.left -
+          this.dCtx.gridPad.right &&
           w.config.xaxis.labels.rotate !== 0) ||
         w.config.xaxis.labels.rotateAlways
       ) {
@@ -141,6 +141,105 @@ export default class DimXAxis {
         w.globals.rotateXLabels = false
       }
     }
+
+    if (!w.config.xaxis.labels.show) {
+      rect = {
+        width: 0,
+        height: 0
+      }
+    }
+
+    return {
+      width: rect.width,
+      height: rect.height
+    }
+  }
+
+  /**
+   * Get X Axis Label Group height
+   * @memberof Dimensions
+   * @return {{width, height}}
+   */
+  getxAxisGroupLabelsCoords() {
+    let w = this.w
+
+    if (!w.globals.hasGroups) {
+      return { width: 0, height: 0 }
+    }
+
+    const fontSize = w.config.xaxis.group.style.fontSize || w.config.xaxis.labels.style.fontSize
+    const fontFamily = w.config.xaxis.group.style.fontFamily || w.config.xaxis.labels.style.fontFamily
+
+    let xaxisLabels = w.globals.groups.map(g => g.title)
+
+    let rect
+
+    // prevent changing xaxisLabels to avoid issues in multi-yaxes - fix #522
+    let val = Utils.getLargestStringFromArr(xaxisLabels)
+    let valArr = this.dCtx.dimHelpers.getLargestStringFromMultiArr(
+      val,
+      xaxisLabels
+    )
+
+    let graphics = new Graphics(this.dCtx.ctx)
+    let xLabelrect = graphics.getTextRects(
+      val,
+      fontSize
+    )
+    let xArrLabelrect = xLabelrect
+    if (val !== valArr) {
+      xArrLabelrect = graphics.getTextRects(
+        valArr,
+        fontSize
+      )
+    }
+
+    rect = {
+      width:
+        xLabelrect.width >= xArrLabelrect.width
+          ? xLabelrect.width
+          : xArrLabelrect.width,
+      height:
+        xLabelrect.height >= xArrLabelrect.height
+          ? xLabelrect.height
+          : xArrLabelrect.height
+    }
+
+    if (
+      (rect.width * xaxisLabels.length >
+        w.globals.svgWidth -
+        this.dCtx.lgWidthForSideLegends -
+        this.dCtx.yAxisWidth -
+        this.dCtx.gridPad.left -
+        this.dCtx.gridPad.right &&
+        w.config.xaxis.labels.rotate !== 0) ||
+      w.config.xaxis.labels.rotateAlways
+    ) {
+      const getRotatedTextRects = (text) => {
+        return graphics.getTextRects(
+          text,
+          fontSize,
+          fontFamily,
+          `rotate(${w.config.xaxis.labels.rotate} 0 0)`,
+          false
+        )
+      }
+      xLabelrect = getRotatedTextRects(val)
+      if (val !== valArr) {
+        xArrLabelrect = getRotatedTextRects(valArr)
+      }
+
+      rect.height =
+        (xLabelrect.height > xArrLabelrect.height
+          ? xLabelrect.height
+          : xArrLabelrect.height) / 1.5
+      rect.width =
+        xLabelrect.width > xArrLabelrect.width
+          ? xLabelrect.width
+          : xArrLabelrect.width
+    }
+
+
 
     if (!w.config.xaxis.labels.show) {
       rect = {
@@ -268,10 +367,10 @@ export default class DimXAxis {
         if (
           firstLabelPosition <
           -((!yaxe.show || yaxe.floating) &&
-          (cnf.chart.type === 'bar' ||
-            cnf.chart.type === 'candlestick' ||
-            cnf.chart.type === 'rangeBar' ||
-            cnf.chart.type === 'boxPlot')
+            (cnf.chart.type === 'bar' ||
+              cnf.chart.type === 'candlestick' ||
+              cnf.chart.type === 'rangeBar' ||
+              cnf.chart.type === 'boxPlot')
             ? lbWidth / 1.75
             : 10)
         ) {

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -197,6 +197,7 @@ export default class Globals {
       ttZFormatter: undefined,
       LINE_HEIGHT_RATIO: 1.618,
       xAxisLabelsHeight: 0,
+      xAxisGroupLabelsHeight: 0,
       xAxisLabelsWidth: 0,
       yAxisLabelsWidth: 0,
       scaleX: 1,

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -26,6 +26,8 @@ export default class Globals {
     gl.seriesYvalues = [] // we will need this when deciding which series
     // user hovered on
     gl.labels = []
+    gl.hasGroups = false
+    gl.groups = []
     gl.categoryLabels = []
     gl.timescaleLabels = []
     gl.noLabelsProvided = false

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -962,6 +962,16 @@ type ApexXAxis = {
       day?: string
       hour?: string
       minute?: string
+    },
+    group?: {
+      groups: { title: string, cols: number }[],
+      style?:  {
+        colors?: string | string[]
+        fontSize?: string
+        fontFamily?: string
+        fontWeight?: string | number
+        cssClass?: string
+      }
     }
   }
   axisBorder?: {


### PR DESCRIPTION
# New Pull Request

Added sub-groups for xAxis. This allows for 1 level of groupping in the xAxis and is something offered by other apps like excel.

To achieve this the model is the following: 

```
 {
    chart: {
        type: 'bar',
    },
    series: [{
        name: 'sales',
        data: [30, 40, 45, 50, 49, 60, 70, 91, 125, 10]
    }],
    xaxis: {
        categories: [12, 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 10],
        group: {
            groups: [{ title: "Test", cols: 3 }, { title: "Test1", cols: 2 }, { title: "Test2", cols: 4 },],
        },
        title: {
            text: "AAA"
        }
    }
}
```

The fact that you can specify the number of columns each group takes gives a lot of flexibility to do any combination you want

![4mcy30p1](https://user-images.githubusercontent.com/32216320/154473701-114c406d-c740-451c-8bd8-ee8d6e620ac1.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
