### PR TITLE
Fix bugs with collapsed series data on updating options/series

### DIFF
--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -75,6 +75,21 @@ export default class UpdateHelpers {
             // After forgetting lastAxes, we need to restore the new config in initialConfig/initialSeries
             w.globals.initialConfig = Utils.extend({}, w.config)
             w.globals.initialSeries = Utils.clone(w.config.series)
+
+            if (options.series) {
+              // Replace the collapsed series data
+              for (let i = 0; i < w.globals.collapsedSeriesIndices.length; i++) {
+                let series = w.config.series[w.globals.collapsedSeriesIndices[i]]
+                w.globals.collapsedSeries[i].data = w.globals.axisCharts ? series.data.slice() : series
+              }
+              for (let i = 0; i < w.globals.ancillaryCollapsedSeriesIndices.length; i++) {
+                let series = w.config.series[w.globals.ancillaryCollapsedSeriesIndices[i]]
+                w.globals.ancillaryCollapsedSeries[i].data = w.globals.axisCharts ? series.data.slice() : series
+              }
+
+              // Ensure that auto-generated axes are scaled to the visible data
+              ch.series.emptyCollapsedSeries(w.config.series)
+            }
           }
         }
 


### PR DESCRIPTION
Fixes multiple bugs with calling `updateOptions` when one or more series are hidden:
- Y-Axis was not sized appropriately to visible series
- Un-hiding series did not show full data set

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
