### PR TITLE
Fix bug when Y-axis value below 1 in logarithmic scale chart

### DIFF
--- a/src/modules/CoreUtils.js
+++ b/src/modules/CoreUtils.js
@@ -327,6 +327,7 @@ class CoreUtils {
         ? 0 // make sure we dont calculate log of 0
         : this.getBaseLog(b, w.globals.maxYArr[yIndex])
     const number_of_height_levels = max_log_val - min_log_val
+    if (d < 1) return d / number_of_height_levels
     const log_height_value = this.getBaseLog(b, d) - min_log_val
     return log_height_value / number_of_height_levels
   }


### PR DESCRIPTION
# New Pull Request

I've recently created a PR:  https://github.com/apexcharts/apexcharts.js/pull/3027  to fix a bug in logarithmic scale chart that height of bars isn't aligned with the values given to them:   https://github.com/apexcharts/apexcharts.js/issues/2909 .

However, I found that In my fix, when using logarithmic scale with y-axis value is lower then 1 , then the calculation of the height of this bar is wrong.

This PR is in order to fix this bug.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
