### PR TITLE
Fix #2964 - Stacked Area chart: Markers of data points disordered and…

### DIFF
--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -297,8 +297,11 @@ export default class Utils {
     markersWraps.sort((a, b) => {
       return Number(b.getAttribute('data:realIndex')) <
         Number(a.getAttribute('data:realIndex'))
-        ? 0
-        : -1
+        ? 1
+        : Number(b.getAttribute('data:realIndex')) >
+          Number(a.getAttribute('data:realIndex'))
+        ? -1
+        : 0
     })
 
     let markers = []


### PR DESCRIPTION
… at the wrong layer in Firefox

# New Pull Request

This fix orders markers in stacked area charts properly in both Firefox and Chrome. This was tested with the MVE from @Zsar (I also tried it for unstacked and with more series entries) and the project where we noticed the issue. However I am uncertain on the effect on other charts so this should be checked as well.

Fixes #2964

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
