### PR TITLE
Feature/bg gradient

### DIFF
--- a/samples/react/column/column-gradient-background.html
+++ b/samples/react/column/column-gradient-background.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Basic Column - Grouped</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      #chart {
+        max-width: 650px;
+        margin: 35px auto;
+      }
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/react@16.12/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@16.12/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prop-types@15.7.2/prop-types.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-apexcharts@1.3.6/dist/react-apexcharts.iife.min.js"></script>
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42
+      Math.random = function() {
+        _seed = (_seed * 16807) % 2147483647
+        return (_seed - 1) / 2147483646
+      }
+    </script>
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <div id="html">
+      &lt;div id=&quot;chart&quot;&gt; &lt;ReactApexChart
+      options={this.state.options} series={this.state.series}
+      type=&quot;bar&quot; height={350} /&gt; &lt;/div&gt;
+    </div>
+
+    <script type="text/babel">
+      class ApexChart extends React.Component {
+        constructor(props) {
+          super(props)
+
+          this.state = {
+            series: [
+              {
+                name: 'Net Profit',
+                data: [44, 55, 57, 56, 61, 58, 63, 60, 66]
+              },
+              {
+                name: 'Revenue',
+                data: [76, 85, 101, 98, 87, 105, 91, 114, 94]
+              },
+              {
+                name: 'Free Cash Flow',
+                data: [35, 41, 36, 26, 45, 48, 52, 53, 41]
+              }
+            ],
+            options: {
+              chart: {
+                type: 'bar',
+                height: 350
+              },
+              plotOptions: {
+                bar: {
+                  horizontal: false,
+                  columnWidth: '55%',
+                  endingShape: 'rounded'
+                }
+              },
+              dataLabels: {
+                enabled: false
+              },
+              stroke: {
+                show: true,
+                width: 2,
+                colors: ['transparent']
+              },
+              xaxis: {
+                categories: [
+                  'Feb',
+                  'Mar',
+                  'Apr',
+                  'May',
+                  'Jun',
+                  'Jul',
+                  'Aug',
+                  'Sep',
+                  'Oct'
+                ]
+              },
+              yaxis: {
+                title: {
+                  text: '$ (thousands)'
+                }
+              },
+              fill: {
+                opacity: 1
+              },
+              grid: {
+                fill: {
+                  type: 'gradient',
+                  gradient: {
+                    shade: 'dark',
+                    gradientToColors: ['#FDD835'],
+                    shadeIntensity: 1,
+                    type: 'horizontal',
+                    opacityFrom: 1,
+                    opacityTo: 1,
+                    stops: [0, 100, 100, 100]
+                  }
+                }
+              },
+              tooltip: {
+                y: {
+                  formatter: function(val) {
+                    return '$ ' + val + ' thousands'
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        render() {
+          return (
+            <div>
+              <div id="chart">
+                <ReactApexChart
+                  options={this.state.options}
+                  series={this.state.series}
+                  type="bar"
+                  height={350}
+                />
+              </div>
+              <div id="html-dist"></div>
+            </div>
+          )
+        }
+      }
+
+      const domContainer = document.querySelector('#app')
+      ReactDOM.render(React.createElement(ApexChart), domContainer)
+    </script>
+  </body>
+</html>

--- a/src/modules/Fill.js
+++ b/src/modules/Fill.js
@@ -304,7 +304,9 @@ class Fill {
     let graphics = new Graphics(this.ctx)
     let utils = new Utils()
 
-    let type = cnf.fill.gradient.type
+    let type = Array.isArray(cnf.fill.gradient.type)
+      ? cnf.fill.gradient.type[i]
+      : cnf.fill.gradient.type
     let gradientFrom = fillColor
     let gradientTo
     let opacityFrom =

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -720,7 +720,7 @@ type ApexFill = {
   type?: string | string[]
   gradient?: {
     shade?: string
-    type?: string
+    type?: string | string[]
     shadeIntensity?: number
     gradientToColors?: string[]
     inverseColors?: boolean

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1151,6 +1151,7 @@ type ApexGrid = {
   borderColor?: string
   strokeDashArray?: number
   position?: 'front' | 'back'
+  fill?: ApexFill
   xaxis?: {
     lines?: {
       show?: boolean


### PR DESCRIPTION
# New Pull Request

Added `fill` support inside the grid area. This allows us to use the same `ApexFill` config options inside the grid to show gradients, images, or patterns. Also added the support to pass an array of strings into `fill.gradient.type` for multiple grid directions

<img width="656" alt="Screenshot 2022-04-12 at 1 13 51 PM" src="https://user-images.githubusercontent.com/50226353/162913816-f406efea-f1f2-441d-b1c1-a8c9d25c65af.png">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
