### PR TITLE
Line: added fillTo start option for inverted area

### DIFF
--- a/samples/react/area/basic-area-inverted.html
+++ b/samples/react/area/basic-area-inverted.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Basic Area</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      #chart {
+        max-width: 650px;
+        margin: 35px auto;
+      }
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/react@16.12/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@16.12/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prop-types@15.7.2/prop-types.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-apexcharts@1.3.6/dist/react-apexcharts.iife.min.js"></script>
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42
+      Math.random = function() {
+        _seed = (_seed * 16807) % 2147483647
+        return (_seed - 1) / 2147483646
+      }
+    </script>
+
+    <script src="../../assets/stock-prices.js"></script>
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <div id="html">
+      &lt;div id=&quot;chart&quot;&gt; &lt;ReactApexChart
+      options={this.state.options} series={this.state.series}
+      type=&quot;area&quot; height={350} /&gt; &lt;/div&gt;
+    </div>
+
+    <script type="text/babel">
+      class ApexChart extends React.Component {
+        constructor(props) {
+          super(props)
+
+          this.state = {
+            series: [
+              {
+                name: 'STOCK ABC',
+                data: series.monthDataSeries1.prices
+              }
+            ],
+            options: {
+              chart: {
+                type: 'area',
+                height: 350,
+                zoom: {
+                  enabled: false
+                }
+              },
+              dataLabels: {
+                enabled: false
+              },
+              stroke: {
+                curve: 'straight'
+              },
+
+              title: {
+                text: 'Fundamental Analysis of Stocks',
+                align: 'left'
+              },
+              subtitle: {
+                text: 'Price Movements',
+                align: 'left'
+              },
+              labels: series.monthDataSeries1.dates,
+              xaxis: {
+                type: 'datetime'
+              },
+              yaxis: {
+                opposite: true
+              },
+              legend: {
+                horizontalAlign: 'left'
+              },
+              plotOptions: {
+                area: {
+                  fillTo: 'start'
+                }
+              }
+            }
+          }
+        }
+
+        render() {
+          return (
+            <div>
+              <div id="chart">
+                <ReactApexChart
+                  options={this.state.options}
+                  series={this.state.series}
+                  type="area"
+                  height={350}
+                />
+              </div>
+              <div id="html-dist"></div>
+            </div>
+          )
+        }
+      }
+
+      const domContainer = document.querySelector('#app')
+      ReactDOM.render(React.createElement(ApexChart), domContainer)
+    </script>
+  </body>
+</html>

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -182,6 +182,10 @@ class Line {
       this.areaBottomY = w.globals.gridHeight
     }
 
+    if (w.config.plotOptions.area.fillTo === 'start') {
+      this.areaBottomY = 0
+    }
+
     this.categoryAxisCorrection = this.xDivision / 2
 
     // el to which series will be drawn

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -498,7 +498,7 @@ type ApexLocale = {
  */
 type ApexPlotOptions = {
   area?: {
-    fillTo?: 'origin' | 'end'
+    fillTo?: 'origin' | 'end' | 'start'
   }
   bar?: {
     horizontal?: boolean


### PR DESCRIPTION
# New Pull Request

Added support to invert the area chart with `fillTo: "start"`

<img width="656" alt="Screenshot 2022-04-12 at 1 28 47 PM" src="https://user-images.githubusercontent.com/50226353/162916714-20c6cae4-005a-4d3f-b01b-c3b9ff39598c.png">

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
