### PR TITLE
Yaxis log changes

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -183,22 +183,40 @@ export default class Range {
   }
 
   logarithmicScale(yMin, yMax, base) {
+    // Basic validation to avoid for loop starting at -inf.
+    if (yMax <= 0) yMax = Math.max(yMin, base)
+    if (yMin <= 0) yMin = Math.min(yMax, base)
+
     const logs = []
 
-    const ticks = Math.ceil(Math.log(yMax) / Math.log(base)) + 1 // Get powers of base up to our max, and then one more
+    // Get the logarithmic range.
+    const logMax = Math.log(yMax) / Math.log(base)
+    const logMin = Math.log(yMin) / Math.log(base)
 
-    for (let i = 0; i < ticks; i++) {
-      logs.push(Math.pow(base, i))
+    // Get the exact logarithmic range.
+    // (This is the exact number of multiples of the base there are between yMin and yMax).
+    const logRange = logMax - logMin
+
+    // Round the logarithmic range to get the number of ticks we will create.
+    // If the chosen min/max values are multiples of each other WRT the base, this will be neat.
+    // If the chosen min/max aren't, we will at least still provide USEFUL ticks.
+    const ticks = Math.round(logRange)
+
+    // Get the logarithmic spacing between ticks.
+    const logTickSpacing = logRange / ticks
+
+    // Create as many ticks as there is range in the logs.
+    for (let i = 0, logTick = logMin; i < ticks; i++, logTick += logTickSpacing) {
+      logs.push(Math.pow(base, logTick))
     }
 
-    if (yMin === 0) {
-      logs.unshift(yMin)
-    }
+    // Add a final tick at the yMax.
+    logs.push(Math.pow(base, logMax))
 
     return {
       result: logs,
-      niceMin: logs[0],
-      niceMax: logs[logs.length - 1]
+      niceMin: yMin,
+      niceMax: yMax
     }
   }
 

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -161,6 +161,26 @@ export default class Range {
     }
   }
 
+  logarithmicScaleNice(yMin, yMax, base) {
+    const logs = []
+
+    const ticks = Math.ceil(Math.log(yMax) / Math.log(base)) + 1 // Get powers of base up to our max, and then one more
+
+    for (let i = 0; i < ticks; i++) {
+      logs.push(Math.pow(base, i))
+    }
+
+    if (yMin === 0) {
+      logs.unshift(yMin)
+    }
+
+    return {
+      result: logs,
+      niceMin: logs[0],
+      niceMax: logs[logs.length - 1]
+    }
+  }
+
   logarithmicScale(yMin, yMax, base) {
     const logs = []
 
@@ -169,7 +189,7 @@ export default class Range {
     for (let i = 0; i < ticks; i++) {
       logs.push(Math.pow(base, i))
     }
-    
+
     if (yMin === 0) {
       logs.unshift(yMin)
     }
@@ -218,6 +238,9 @@ export default class Range {
     if (y.logarithmic && diff > 5) {
       gl.allSeriesCollapsed = false
       gl.yAxisScale[index] = this.logarithmicScale(minY, maxY, y.logBase)
+      gl.yAxisScale[index] = y.forceNiceScale
+        ? this.logarithmicScaleNice(minY, maxY, y.logBase)
+        : this.logarithmicScale(minY, maxY, y.logBase)
     } else {
       if (maxY === -Number.MAX_VALUE || !Utils.isNumber(maxY)) {
         // no data in the chart. Either all series collapsed or user passed a blank array

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -162,16 +162,17 @@ export default class Range {
   }
 
   logarithmicScaleNice(yMin, yMax, base) {
+    // Basic validation to avoid for loop starting at -inf.
+    if (yMax <= 0) yMax = Math.max(yMin, base)
+    if (yMin <= 0) yMin = Math.min(yMax, base)
+
     const logs = []
 
-    const ticks = Math.ceil(Math.log(yMax) / Math.log(base)) + 1 // Get powers of base up to our max, and then one more
+    const logMax = Math.ceil(Math.log(yMax) / Math.log(base) + 1) // Get powers of base for our max and min
+    const logMin = Math.floor(Math.log(yMin) / Math.log(base))
 
-    for (let i = 0; i < ticks; i++) {
+    for (let i = logMin; i < logMax; i++) {
       logs.push(Math.pow(base, i))
-    }
-
-    if (yMin === 0) {
-      logs.unshift(yMin)
     }
 
     return {


### PR DESCRIPTION
# New Pull Request

Proposed changes that would address my feature request [`#3125`](https://github.com/apexcharts/apexcharts.js/issues/3125).
A logarithmic y-axis now uses the given `min` value. If `forceNiceScale` is true, 'nice' values are used above and below the given min/max values (similar to current behavior). If `forceNiceScale` is false, the given min/max values are retained and a useful logarithmic scale is created between them.

Marked as breaking as it would technically change the default behavior of log scales (though if `forceNiceScale` were to default to `true` with logarithmic scales, it would be quite similar to current behavior.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

The "multiple-scales" test fails with my changes. However, this appears to be because the `yMin` value that is passed to the scaling functions is incorrect (it's `-Number.MAX_VALUE` instead of the lowest data point).

I think this could be an issue with how `getMinYMaxY` in Range.js is handling multiple y-axes, as it doesn't do this if the other axis is removed from the test cases.

If the `yMin` value were correctly the lowest value in the data, the tests would still fail but this would be 'correct behaviour' and I would propose updating the tests, for example with `forceNiceScale` as true and providing a min value.