### PR TITLE
When no scale is specified in getSvgString() treat as 1

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -47,6 +47,9 @@ class Exports {
   }
 
   getSvgString(scale) {
+    if (scale == undefined) {
+        scale = 1; // if no scale is specified, don't scale...
+    }
     let svgString = this.w.globals.dom.Paper.svg()
     // in case the scale is different than 1, the svg needs to be rescaled
     if (scale !== 1) {


### PR DESCRIPTION
# New Pull Request

Fix JS error when no scale is specified... Just set it to 1.

Fixes # (issue)
https://github.com/apexcharts/apexcharts.js/issues/3144

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

(I haven't added any tests but it's a very basic simple change)
