### PR TITLE
Fix failure to render when the chart element is a child of a shadow root

### DIFF
--- a/src/utils/Resize.js
+++ b/src/utils/Resize.js
@@ -6,14 +6,16 @@ let ros = new WeakMap() // Map callbacks to ResizeObserver instances for easy re
 export function addResizeListener(el, fn) {
   let called = false
 
-  const elRect = el.getBoundingClientRect()
-  if (el.style.display === 'none' || elRect.width === 0) {
-    // if elRect.width=0, the chart is not rendered at all
-    // (it has either display none or hidden in a different tab)
-    // fixes https://github.com/apexcharts/apexcharts.js/issues/2825
-    // fixes https://github.com/apexcharts/apexcharts.js/issues/2991
-    // fixes https://github.com/apexcharts/apexcharts.js/issues/2992
-    called = true
+  if (el.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
+    const elRect = el.getBoundingClientRect()
+    if (el.style.display === 'none' || elRect.width === 0) {
+      // if elRect.width=0, the chart is not rendered at all
+      // (it has either display none or hidden in a different tab)
+      // fixes https://github.com/apexcharts/apexcharts.js/issues/2825
+      // fixes https://github.com/apexcharts/apexcharts.js/issues/2991
+      // fixes https://github.com/apexcharts/apexcharts.js/issues/2992
+      called = true
+    }
   }
 
   let ro = new ResizeObserver((r) => {


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

# New Pull Request

When the element passed to ApexCharts is a child of a ShadowRoot, the resize helper attempts to get the dimensions and display type of its parent. Since the parent is the ShadowRoot, both of those attempts fail. The same would happen for any DOCUMENT_FRAGMENT_NODE node type.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
