### PR TITLE
use new options while updating yaxis min max for stackType

### DIFF
--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -218,8 +218,7 @@ export default class UpdateHelpers {
   }
 
   forceYAxisUpdate(options) {
-    const w = this.w
-    if (w.config.chart.stacked && w.config.chart.stackType === '100%') {
+    if (options.chart && options.chart.stacked && options.chart.stackType === '100%') {
       if (Array.isArray(options.yaxis)) {
         options.yaxis.forEach((yaxe, index) => {
           options.yaxis[index].min = 0


### PR DESCRIPTION
# New Pull Request

we should use new options for updating min/max yaxis when updating StackType to 100%

[Fixes # 3208](https://github.com/apexcharts/apexcharts.js/issues/3208)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
