### PR TITLE
fix: fixed autoScaleY for all zero values in array

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -564,8 +564,10 @@ export default class Range {
         min *= min < 0 ? 1.1 : 0.9
         max *= max < 0 ? 0.9 : 1.1
 
-        if (min === 0) min -= -1
-        if (max === 0) max += 1
+        if (min === 0 && max === 0) {
+          min = -1
+          max = 1
+        }
 
         if (max < 0 && max < initialMax) {
           max = initialMax

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -564,6 +564,9 @@ export default class Range {
         min *= min < 0 ? 1.1 : 0.9
         max *= max < 0 ? 0.9 : 1.1
 
+        if (min === 0) min -= -1
+        if (max === 0) max += 1
+
         if (max < 0 && max < initialMax) {
           max = initialMax
         }


### PR DESCRIPTION
# New Pull Request

My fix contain the solution at autoScaleYaxis that for all zero values in a series not show line chart


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
