### PR TITLE
Fix wrong tooltip position in charts when used inside shadow dom

### DIFF
--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -14,9 +14,14 @@ class Intersect {
     this.ttCtx = tooltipContext
   }
 
+  // if initialTarget has been set, use it, otherwise fallback to target attribute
+  getTarget = (e) => {
+    return e.initialTarget || e.target
+  }
+
   // a helper function to get an element's attribute value
   getAttr(e, attr) {
-    return parseFloat(e.target.getAttribute(attr))
+    return parseFloat(this.getTarget(e).getAttribute(attr))
   }
 
   // handle tooltip for heatmaps and treemaps
@@ -24,7 +29,7 @@ class Intersect {
     const ttCtx = this.ttCtx
     const w = this.w
 
-    if (e.target.classList.contains(`apexcharts-${type}-rect`)) {
+    if (this.getTarget(e).classList.contains(`apexcharts-${type}-rect`)) {
       let i = this.getAttr(e, 'i')
       let j = this.getAttr(e, 'j')
       let cx = this.getAttr(e, 'cx')
@@ -80,7 +85,7 @@ class Intersect {
 
     let i
     let j
-    if (e.target.classList.contains('apexcharts-marker')) {
+    if (this.getTarget(e).classList.contains('apexcharts-marker')) {
       let cx = parseInt(opt.paths.getAttribute('cx'), 10)
       let cy = parseInt(opt.paths.getAttribute('cy'), 10)
       let val = parseFloat(opt.paths.getAttribute('val'))
@@ -264,7 +269,7 @@ class Intersect {
     let barWidth = 0
     let barHeight = 0
 
-    const cl = e.initialTarget.classList
+    const cl = this.getTarget(e).classList
 
     if (
       cl.contains('apexcharts-bar-area') ||
@@ -272,7 +277,7 @@ class Intersect {
       cl.contains('apexcharts-boxPlot-area') ||
       cl.contains('apexcharts-rangebar-area')
     ) {
-      let bar = e.initialTarget
+      let bar = this.getTarget(e)
       let barRect = bar.getBoundingClientRect()
 
       let seriesBound = opt.elGrid.getBoundingClientRect()

--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -264,7 +264,7 @@ class Intersect {
     let barWidth = 0
     let barHeight = 0
 
-    const cl = e.target.classList
+    const cl = e.initialTarget.classList
 
     if (
       cl.contains('apexcharts-bar-area') ||
@@ -272,7 +272,7 @@ class Intersect {
       cl.contains('apexcharts-boxPlot-area') ||
       cl.contains('apexcharts-rangebar-area')
     ) {
-      let bar = e.target
+      let bar = e.initialTarget
       let barRect = bar.getBoundingClientRect()
 
       let seriesBound = opt.elGrid.getBoundingClientRect()

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -362,6 +362,10 @@ export default class Tooltip {
 
     const targetDelay = 100
     const timeSinceLastUpdate = Date.now() - this.lastHoverTime
+
+    // Save the target, as it can be overwritten during setTimeout (see event retargeting in the case of shadow dom)
+    e.initialTarget = e.target
+
     if (timeSinceLastUpdate >= targetDelay) {
       // The tooltip was last updated over 100ms ago - redraw it even if the user is still moving their
       // mouse so they get some feedback that their moves are being registered

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -363,7 +363,8 @@ export default class Tooltip {
     const targetDelay = 100
     const timeSinceLastUpdate = Date.now() - this.lastHoverTime
 
-    // Save the target, as it can be overwritten during setTimeout (see event retargeting in the case of shadow dom)
+    // Save the target, as it could be overwritten e.g in the case of event bubbling from shadow dom (see "shadow dom event retargeting)
+    // No standard propertie supported at the moment by all browsers
     e.initialTarget = e.target
 
     if (timeSinceLastUpdate >= targetDelay) {


### PR DESCRIPTION
# New Pull Request

Tooltip is not correctly positioned on  charts when apex is inside shadow dom, due to event retargeting.

# Solution 

Use of a custom attribute (called initialTarget) to store the event target, as no standard attribute yet exists in the event spec (with chrome we could uses composedPath[], but not with mozilla, which used originalTarget)


Fixes #3237 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
