### PR TITLE
fix: ApexOptions type semicolon

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -63,7 +63,7 @@ declare module ApexCharts {
     colors?: any[]
     dataLabels?: ApexDataLabels
     fill?: ApexFill
-    forecastDataPoints?: ApexForecastDataPoints;
+    forecastDataPoints?: ApexForecastDataPoints
     grid?: ApexGrid
     labels?: string[]
     legend?: ApexLegend


### PR DESCRIPTION
# New Pull Request

Remove extra semicolon in ApexOptions type

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
