### PR TITLE
Added Seconds to X Axis Datetime Formatter

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -977,6 +977,7 @@ type ApexXAxis = {
       day?: string
       hour?: string
       minute?: string
+      second?: string
     }
   }
   group?: {


### PR DESCRIPTION
# New Pull Request

Adds Seconds to X Axis Datetime Formatter to allow displaying time with seconds when showing graph over a small amount of time. Updates this Datetime Formatter to match the other Datetime Formatters in the project.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
