### PR TITLE
Declaring correct type for track background in radial bar

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -693,7 +693,7 @@ type ApexPlotOptions = {
       show?: boolean
       startAngle?: number
       endAngle?: number
-      background?: string
+      background?: string | string[]
       strokeWidth?: string
       opacity?: number
       margin?: number


### PR DESCRIPTION
# Declaring correct type for track background in radial bar

The type of track background in radial bar has been changed to fit the [following specification](https://apexcharts.com/docs/options/plotoptions/radialbar/#trackBackground) in the documentation. In the description it says: "Color of the track. If you want different color for each track, you can pass an array of colors.", and indeed it works as described, but the typescript declaration of this property is inconsistent, as it doesn't  accept an array of strings. I noticed this problem when using the chart in a project I work on, and had to appeal to "ts-ignore" to solve it.

I haven't found any issue related to this problem, but I think it makes sense to solve it now.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
