### PR TITLE
add a toggle for a bubble chart's zscaling

### DIFF
--- a/src/charts/Scatter.js
+++ b/src/charts/Scatter.js
@@ -50,9 +50,13 @@ export default class Scatter {
 
         if (zRatio !== Infinity) {
           // means we have a bubble
-          finishRadius = w.globals.seriesZ[realIndex][dataPointIndex] / zRatio
-
           const bubble = w.config.plotOptions.bubble
+          finishRadius = w.globals.seriesZ[realIndex][dataPointIndex]
+
+          if (bubble.zScaling) {
+            finishRadius /= zRatio
+          }
+
           if (bubble.minBubbleRadius && finishRadius < bubble.minBubbleRadius) {
             finishRadius = bubble.minBubbleRadius
           }

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -438,6 +438,7 @@ export default class Options {
           }
         },
         bubble: {
+          zScaling: true,
           minBubbleRadius: undefined,
           maxBubbleRadius: undefined
         },

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -549,6 +549,7 @@ type ApexPlotOptions = {
     }
   }
   bubble?: {
+    zScaling?: boolean
     minBubbleRadius?: number
     maxBubbleRadius?: number
   }


### PR DESCRIPTION
# New Pull Request

If you're using a bubble chart with a very small zRange the zRatio calculation makes all the bubbles gigantic. This just adds a very simple plotOption to disable the zRatio scaling. The option defaults to true, keeping existing functionality, thus any existing charts won't be affected.

I'm working on a project that has dynamic data that can range from a zRange of 0.2 to 100+, with z values between [5.0 - 5.2] my bubbles were scaling to [984.38 - 1023.75].

Before:
![apexchart_bubbles_before](https://user-images.githubusercontent.com/7011359/196571931-801e8acb-a343-4217-9fb4-e078453d9813.png)

After:
![apexchart_bubbles_after](https://user-images.githubusercontent.com/7011359/196571930-768bfd40-2f79-4435-87ef-ad8d5d9f890d.png)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
