### PR TITLE
Fix legend labels hover between dot and text

### DIFF
--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -44,6 +44,11 @@
   opacity: .2
 }
 
+.apexcharts-legend-text {
+  padding-left: 15px;
+  margin-left: -15px;
+}
+
 .apexcharts-series-collapsed {
   opacity: 0
 }


### PR DESCRIPTION
Labels of series with a `:hover` effect have a tiny (`3px`) area between the dot and the text in which the `:hover` effect is discontinued (not hovered). 
This PR fixes the issue, without any regression.

Supported by all browsers.

Example chart showcasing the bug: https://apexcharts.com/react-chart-demos/heatmap-charts/color-range/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
