### PR TITLE
Add top position for tooltip

### DIFF
--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -176,6 +176,16 @@ export default class Position {
 
     let x = parseFloat(cx) + pointR + 5
     let y = parseFloat(cy) + pointR / 2 // - tooltipRect.ttHeight / 2
+    let offsetX = 0
+    let offsetY = 0
+
+    if (w.config.tooltip.absolute && w.config.tooltip.absolute.offsetX) {
+      offsetX = w.config.tooltip.absolute.offsetX || 0
+    }
+
+    if (w.config.tooltip.absolute && w.config.tooltip.absolute.offsetY) {
+      offsetY = w.config.tooltip.absolute.offsetY || 0
+    }
 
     if (x > w.globals.gridWidth / 2) {
       x = x - tooltipRect.ttWidth - pointR - 10
@@ -189,7 +199,17 @@ export default class Position {
       x = -20
     }
 
-    if (w.config.tooltip.followCursor) {
+    if (
+      w.config.tooltip.absolute &&
+      w.config.tooltip.absolute.position === 'top'
+    ) {
+      x = parseFloat(cx) - tooltipRect.ttWidth / 2
+      y =
+        parseFloat(cy) -
+        pointR / 2 -
+        tooltipRect.ttHeight +
+        w.globals.translateY
+    } else if (w.config.tooltip.followCursor) {
       const elGrid = ttCtx.getElGrid()
       const seriesBound = elGrid.getBoundingClientRect()
       y =
@@ -212,8 +232,8 @@ export default class Position {
     if (!isNaN(x)) {
       x = x + w.globals.translateX
 
-      tooltipEl.style.left = x + 'px'
-      tooltipEl.style.top = y + 'px'
+      tooltipEl.style.left = (x + offsetX).toString() + 'px'
+      tooltipEl.style.top = (y + offsetY).toString() + 'px'
     }
   }
 

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -919,6 +919,11 @@ type ApexTooltipY = {
  */
 type ApexTooltip = {
   enabled?: boolean
+  absolute: {
+    position?: 'side' | 'top',
+    offsetX?: number,
+    offsetY?: number,
+  }
   enabledOnSeries?: undefined | number[]
   shared?: boolean
   followCursor?: boolean


### PR DESCRIPTION

# New Pull Request

Add a new option "position" for tooltip to place the tooltip on top of the point instead of the side. I mirrored `fixed` for the options : 

```js
{
  // ...
  tooltip: {
    absolute: {
      position: 'top',
      offsetY: -13,
    }
  }
}
```

Fixes #3257

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
