### PR TITLE
#3483 Fix x-axis tick alignment

### DIFF
--- a/src/modules/TimeScale.js
+++ b/src/modules/TimeScale.js
@@ -659,10 +659,7 @@ class TimeScale {
       }
 
       let year = this._getYear(currentYear, month, yrCounter)
-      pos =
-        hour === 0 && i === 0
-          ? remainingMins * minutesWidthOnXAxis
-          : 60 * minutesWidthOnXAxis + pos
+      pos = 60 * minutesWidthOnXAxis + pos
       let val = hour === 0 ? date : hour
       this.timeScaleArray.push({
         position: pos,

--- a/tests/unit/timescale.spec.js
+++ b/tests/unit/timescale.spec.js
@@ -388,6 +388,34 @@ describe('Generate TimeScale', () => {
       })
     ])
   })
+
+  it('should generate an hour timescale with no overlapping ticks', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1]
+      }
+    ])
+    const timeScale = new TimeScale(chart)
+    timeScale.generateHourScale({
+      firstVal: {
+        minSecond: 0,
+        minMinute: 30,
+        minHour: 22
+      },
+      currentDate: 22,
+      currentMonth: 11,
+      currentYear: 2022,
+      minutesWidthOnXAxis: 0.4,
+      numberOfHours: 24
+    })
+
+    const generatedScale = timeScale.timeScaleArray
+    for (let i = 0; i < generatedScale.length - 1; i++) {
+      expect(generatedScale[i].position).not.toEqual(
+        generatedScale[i + 1].position
+      )
+    }
+  })
 })
 
 describe('createRawDateString', () => {


### PR DESCRIPTION
# Fix x-axis tick alignment

Fixes #3483. The underlying issue was that some x-axis ticks would end up in the wrong position, overlapping in some cases and being deleted by the code to ensure ticks don't overlap. This seems to be because the first tick on the x-axis has its position adjusted in two places: first by setting and adjusting `firstTickPosition` according to `remainingMins` on line 620, and then again inside the loop - which I remove in this change.

I've also added a unit test which fails under the old code. This test makes sure that the `generateHourScale` function generates x axis ticks which do not overlap under the conditions seen in #3483.

Before:
<img width="624" alt="Screenshot of chart before changes" src="https://user-images.githubusercontent.com/22012327/203224995-83aaa45a-9b49-425f-9860-cecd9ecee34e.png">

After:
<img width="621" alt="Screenshot of chart after changes, with the x axis aligned to the data" src="https://user-images.githubusercontent.com/22012327/203225021-128671a2-49ad-4fd4-887f-f1be18afd603.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~ - no comments needed for this change IMO, happy to add some if requested
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
