### PR TITLE
do not corrupt yaxis on zooming in brush graph

### DIFF
--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -626,27 +626,12 @@ export default class Core {
             yaxis = scale.autoScaleY(targetChart, yaxis, e)
           }
 
-          const multipleYaxis = targetChart.w.config.yaxis.reduce(
-            (acc, curr, index) => {
-              return [
-                ...acc,
-                {
-                  ...targetChart.w.config.yaxis[index],
-                  min: yaxis[0].min,
-                  max: yaxis[0].max
-                }
-              ]
-            },
-            []
-          )
-
           targetChart.ctx.updateHelpers._updateOptions(
             {
               xaxis: {
                 min: e.xaxis.min,
                 max: e.xaxis.max
               },
-              yaxis: multipleYaxis
             },
             false,
             false,


### PR DESCRIPTION
# New Pull Request

On changing the selection in a brush chart, the target axis are adjusted. In addition to restricting the x-axis, the y-axis of the target chart is overwritten by the brush chart. This leads to unexpected behaviour if using multiple y-axes or multiple series sharing the same y-axis in the target chart.
This fix removes this behaviour.

This fixes https://github.com/RomRider/apexcharts-card/issues/269, https://github.com/RomRider/apexcharts-card/issues/436, https://github.com/RomRider/apexcharts-card/issues/441 and likely improves https://github.com/apexcharts/apexcharts.js/issues/801, https://github.com/apexcharts/apexcharts.js/issues/1294.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
