### PR TITLE
Export ESM build via `module` package.json field

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -36,6 +36,13 @@ const builds = {
     env: 'production',
     banner
   },
+  'web-esm-dev': {
+    entry: resolvePath('src/apexcharts.js'),
+    dest: resolvePath('dist/apexcharts.esm.js'),
+    format: 'es',
+    env: 'development',
+    banner
+  },
   'web-umd-dev': {
     entry: resolvePath('src/apexcharts.js'),
     dest: resolvePath('dist/apexcharts.js'),

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/apexcharts/apexcharts.js.git"
   },
   "main": "dist/apexcharts.common.js",
+  "module": "dist/apexcharts.esm.js",
   "unpkg": "dist/apexcharts.js",
   "jsdelivr": "dist/apexcharts.js",
   "typings": "types/apexcharts.d.ts",
@@ -20,6 +21,7 @@
   "scripts": {
     "dev": "rollup -w -c build/config.js --environment TARGET:web-umd-dev",
     "dev:cjs": "rollup -w -c build/config.js --environment TARGET:web-cjs",
+    "dev:esm": "rollup -w -c build/config.js --environment TARGET:web-esm-dev",
     "bundle": "node build/build.js",
     "build": "npm run bundle && webpack",
     "build:umd": "rollup -w -c build/config.js --environment TARGET:web-umd-dev",


### PR DESCRIPTION
# Export ESM build via `module` package.json field

Use `module` package.json field to make ESM build available to bundlers.

Added new npm script `dev:esm` for generating a development ESM build.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
