### PR TITLE
Prevent stuck tooltip for line & candlestick charts

### DIFF
--- a/src/charts/BoxCandleStick.js
+++ b/src/charts/BoxCandleStick.js
@@ -11,9 +11,10 @@ import Utils from '../utils/Utils'
  **/
 
 class BoxCandleStick extends Bar {
-  draw(series, seriesIndex) {
+  draw(series, ctype, seriesIndex) {
     let w = this.w
     let graphics = new Graphics(this.ctx)
+    let type = w.globals.comboCharts ? ctype : w.config.chart.type
     let fill = new Fill(this.ctx)
 
     this.candlestickOptions = this.w.config.plotOptions.candlestick
@@ -28,7 +29,7 @@ class BoxCandleStick extends Bar {
     this.barHelpers.initVariables(series)
 
     let ret = graphics.group({
-      class: `apexcharts-${w.config.chart.type}-series apexcharts-plot-series`
+      class: `apexcharts-${type}-series apexcharts-plot-series`
     })
 
     for (let i = 0; i < series.length; i++) {

--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -263,11 +263,11 @@ export default class Core {
       }
       if (candlestickSeries.series.length > 0) {
         elGraph.push(
-          boxCandlestick.draw(candlestickSeries.series, candlestickSeries.i)
+          boxCandlestick.draw(candlestickSeries.series, 'candlestick', candlestickSeries.i)
         )
       }
       if (boxplotSeries.series.length > 0) {
-        elGraph.push(boxCandlestick.draw(boxplotSeries.series, boxplotSeries.i))
+        elGraph.push(boxCandlestick.draw(boxplotSeries.series, 'boxPlot', boxplotSeries.i))
       }
       if (rangeBarSeries.series.length > 0) {
         elGraph.push(
@@ -306,11 +306,11 @@ export default class Core {
           break
         case 'candlestick':
           let candleStick = new BoxCandleStick(this.ctx, xyRatios)
-          elGraph = candleStick.draw(gl.series)
+          elGraph = candleStick.draw(gl.series, 'candlestick')
           break
         case 'boxPlot':
           let boxPlot = new BoxCandleStick(this.ctx, xyRatios)
-          elGraph = boxPlot.draw(gl.series)
+          elGraph = boxPlot.draw(gl.series, 'boxPlot')
           break
         case 'rangeBar':
           elGraph = this.ctx.rangeBar.draw(gl.series)

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -357,7 +357,7 @@ export default class Position {
     }
   }
 
-  moveStickyTooltipOverBars(j) {
+  moveStickyTooltipOverBars(j, capturedSeries) {
     const w = this.w
     const ttCtx = this.ttCtx
 
@@ -377,6 +377,15 @@ export default class Position {
     let jBar = w.globals.dom.baseEl.querySelector(
       `.apexcharts-bar-series .apexcharts-series[rel='${i}'] path[j='${j}'], .apexcharts-candlestick-series .apexcharts-series[rel='${i}'] path[j='${j}'], .apexcharts-boxPlot-series .apexcharts-series[rel='${i}'] path[j='${j}'], .apexcharts-rangebar-series .apexcharts-series[rel='${i}'] path[j='${j}']`
     )
+    if (!jBar && typeof capturedSeries == 'number') {
+      // Try with captured series index
+      jBar = w.globals.dom.baseEl.querySelector(
+        `.apexcharts-bar-series .apexcharts-series[data\\:realIndex='${capturedSeries}'] path[j='${j}'],
+        .apexcharts-candlestick-series .apexcharts-series[data\\:realIndex='${capturedSeries}'] path[j='${j}'],
+        .apexcharts-boxPlot-series .apexcharts-series[data\\:realIndex='${capturedSeries}'] path[j='${j}'],
+        .apexcharts-rangebar-series .apexcharts-series[data\\:realIndex='${capturedSeries}'] path[j='${j}']`
+      );
+    }
 
     let bcx = jBar ? parseFloat(jBar.getAttribute('cx')) : 0
     let bcy = jBar ? parseFloat(jBar.getAttribute('cy')) : 0
@@ -386,9 +395,9 @@ export default class Position {
     const elGrid = ttCtx.getElGrid()
     let seriesBound = elGrid.getBoundingClientRect()
 
-    const isBoxOrCandle =
+    const isBoxOrCandle = jBar && (
       jBar.classList.contains('apexcharts-candlestick-area') ||
-      jBar.classList.contains('apexcharts-boxPlot-area')
+      jBar.classList.contains('apexcharts-boxPlot-area'))
     if (w.globals.isXNumeric) {
       if (jBar && !isBoxOrCandle) {
         bcx = bcx - (barLen % 2 !== 0 ? bw / 2 : 0)

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -669,6 +669,9 @@ export default class Tooltip {
     let j = capj.j
     let capturedSeries = capj.capturedSeries
 
+    if (w.globals.collapsedSeriesIndices.includes(capturedSeries))
+      capturedSeries = null
+
     const bounds = opt.elGrid.getBoundingClientRect()
     if (capj.hoverX < 0 || capj.hoverX > bounds.width) {
       this.handleMouseOut(opt)
@@ -681,7 +684,8 @@ export default class Tooltip {
       // couldn't capture any series. check if shared X is same,
       // if yes, draw a grouped tooltip
       if (this.tooltipUtil.isXoverlap(j) || w.globals.isBarHorizontal) {
-        this.create(e, this, 0, j, opt.ttItems)
+        const firstVisibleSeries = w.globals.series.findIndex((s,i) => !w.globals.collapsedSeriesIndices.includes(i))
+        this.create(e, this, firstVisibleSeries, j, opt.ttItems)
       }
     }
   }
@@ -708,7 +712,8 @@ export default class Tooltip {
       }
     } else {
       if (this.tooltipUtil.isXoverlap(j)) {
-        this.create(e, this, 0, j, opt.ttItems)
+        const firstVisibleSeries = w.globals.series.findIndex((s,i) => !w.globals.collapsedSeriesIndices.includes(i));
+        this.create(e, this, firstVisibleSeries, j, opt.ttItems)
       }
     }
   }
@@ -788,7 +793,7 @@ export default class Tooltip {
 
     if (shared === null) shared = this.tConfig.shared
 
-    const hasMarkers = this.tooltipUtil.hasMarkers()
+    const hasMarkers = this.tooltipUtil.hasMarkers(capturedSeries)
 
     const bars = this.tooltipUtil.getElBars()
 
@@ -847,7 +852,7 @@ export default class Tooltip {
         }
       }
 
-      if (this.tooltipUtil.hasBars()) {
+      else if (this.tooltipUtil.hasBars()) {
         this.barSeriesHeight = this.tooltipUtil.getBarsHeight(bars)
         if (this.barSeriesHeight > 0) {
           // hover state, activate snap filter
@@ -859,7 +864,7 @@ export default class Tooltip {
           // de-activate first
           this.deactivateHoverFilter()
 
-          this.tooltipPosition.moveStickyTooltipOverBars(j)
+          this.tooltipPosition.moveStickyTooltipOverBars(j, capturedSeries)
 
           for (let b = 0; b < paths.length; b++) {
             graphics.pathMouseEnter(paths[b])
@@ -875,7 +880,7 @@ export default class Tooltip {
       })
 
       if (this.tooltipUtil.hasBars()) {
-        ttCtx.tooltipPosition.moveStickyTooltipOverBars(j)
+        ttCtx.tooltipPosition.moveStickyTooltipOverBars(j, capturedSeries)
       }
 
       if (hasMarkers) {

--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -280,7 +280,12 @@ export default class Utils {
     return totalHeight
   }
 
-  getElMarkers() {
+  getElMarkers(capturedSeries) {
+    if (typeof capturedSeries == 'number') {
+      return this.w.globals.dom.baseEl.querySelectorAll(
+        `.apexcharts-series[data\\:realIndex='${capturedSeries}'] .apexcharts-series-markers`
+      )
+    }
     return this.w.globals.dom.baseEl.querySelectorAll(
       ' .apexcharts-series-markers'
     )
@@ -308,8 +313,8 @@ export default class Utils {
     return markers
   }
 
-  hasMarkers() {
-    const markers = this.getElMarkers()
+  hasMarkers(capturedSeries) {
+    const markers = this.getElMarkers(capturedSeries)
     return markers.length > 0
   }
 


### PR DESCRIPTION
# Prevent tooltip stuck for line & candlestick charts

Prevent tooltip being stuck for mixed line & candlestick charts when first series type is candlestick and all other (line) series are hidden.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
