### PR TITLE
fix: don't render markers outside graph area

### DIFF
--- a/src/modules/Markers.js
+++ b/src/modules/Markers.js
@@ -68,6 +68,15 @@ export default class Markers {
 
     if (Array.isArray(p.x)) {
       for (let q = 0; q < p.x.length; q++) {
+        if (
+          p.x[q] < 0 ||
+          p.x[q] > w.globals.gridWidth ||
+          p.y[q] < 0 ||
+          p.y[q] > w.globals.gridHeight
+        ) {
+          continue
+        }
+
         let dataPointIndex = j
 
         // a small hack as we have 2 points for the first val to connect it


### PR DESCRIPTION
# New Pull Request

Markers renders outside graph area, which is not so nice.
![image](https://user-images.githubusercontent.com/4822023/222437665-8d4fcc92-0ff4-4728-96e5-06997079affc.png)

Codepen that demonstrate the bug: https://codepen.io/leinonen/pen/xxaqmrX

Fixes #3320, #3562

Avoid rendering markers that are outside the graph area.
![image](https://user-images.githubusercontent.com/4822023/222437344-f5949351-0f12-47ad-87e7-7aabcd5fa9a1.png)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

