### PR TITLE
Add bar labels feature to radialBar

### DIFF
--- a/samples/react/radialBar/circle-custom-angle.html
+++ b/samples/react/radialBar/circle-custom-angle.html
@@ -9,17 +9,17 @@
     <link href="../../assets/styles.css" rel="stylesheet" />
 
     <style>
-      
+
         #chart {
       padding: 0;
       max-width: 650px;
       margin: 35px auto;
     }
-    
+
     .apexcharts-legend text {
       font-weight: 900;
     }
-      
+
     </style>
 
     <script>
@@ -37,14 +37,14 @@
         )
     </script>
 
-    
+
     <script src="https://cdn.jsdelivr.net/npm/react@16.12/umd/react.production.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/react-dom@16.12/umd/react-dom.production.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prop-types@15.7.2/prop-types.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
     <script src="../../../dist/apexcharts.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/react-apexcharts@1.3.6/dist/react-apexcharts.iife.min.js"></script>
-    
+
 
     <script>
       // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
@@ -56,11 +56,11 @@
       };
     </script>
 
-    
+
   </head>
 
   <body>
-    
+
     <div id="app"></div>
 
     <div id="html">
@@ -75,7 +75,6 @@
           super(props);
 
           this.state = {
-          
             series: [76, 67, 61, 90],
             options: {
               chart: {
@@ -93,6 +92,15 @@
                     background: 'transparent',
                     image: undefined,
                   },
+                  barLabels: {
+                    enabled: true,
+                    useSeriesColors: true,
+                    margin: 8,
+                    fontSize: '16px',
+                    formatter: function(seriesName, opts) {
+                      return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
+                    },
+                  },
                   dataLabels: {
                     name: {
                       show: false,
@@ -105,41 +113,23 @@
               },
               colors: ['#1ab7ea', '#0084ff', '#39539E', '#0077B5'],
               labels: ['Vimeo', 'Messenger', 'Facebook', 'LinkedIn'],
-              legend: {
-                show: true,
-                floating: true,
-                fontSize: '16px',
-                position: 'left',
-                offsetX: 160,
-                offsetY: 15,
-                labels: {
-                  useSeriesColors: true,
-                },
-                markers: {
-                  size: 0
-                },
-                formatter: function(seriesName, opts) {
-                  return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
-                },
-                itemMargin: {
-                  vertical: 3
-                }
-              },
               responsive: [{
                 breakpoint: 480,
                 options: {
-                  legend: {
-                      show: false
+                  plotOptions: {
+                    radialBar: {
+                      barLabels: {
+                        enabled: false
+                      }
+                    }
                   }
                 }
               }]
             },
-          
-          
           };
         }
 
-      
+
 
         render() {
           return (
@@ -157,6 +147,6 @@
       ReactDOM.render(React.createElement(ApexChart), domContainer);
     </script>
 
-    
+
   </body>
 </html>

--- a/samples/source/radialBar/circle-custom-angle.xml
+++ b/samples/source/radialBar/circle-custom-angle.xml
@@ -29,6 +29,15 @@ plotOptions: {
       background: 'transparent',
       image: undefined,
     },
+    barLabels: {
+      enabled: true,
+      useSeriesColors: true,
+      margin: 8,
+      fontSize: '16px',
+      formatter: function(seriesName, opts) {
+        return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
+      },
+    },
     dataLabels: {
       name: {
         show: false,
@@ -41,31 +50,15 @@ plotOptions: {
 },
 colors: ['#1ab7ea', '#0084ff', '#39539E', '#0077B5'],
 labels: ['Vimeo', 'Messenger', 'Facebook', 'LinkedIn'],
-legend: {
-  show: true,
-  floating: true,
-  fontSize: '16px',
-  position: 'left',
-  offsetX: 160,
-  offsetY: 15,
-  labels: {
-    useSeriesColors: true,
-  },
-  markers: {
-    size: 0
-  },
-  formatter: function(seriesName, opts) {
-    return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
-  },
-  itemMargin: {
-    vertical: 3
-  }
-},
 responsive: [{
   breakpoint: 480,
   options: {
-    legend: {
-        show: false
+    plotOptions: {
+      radialBar: {
+        barLabels: {
+          enabled: false
+        }
+      }
     }
   }
 }]

--- a/samples/vanilla-js/radialBar/circle-custom-angle.html
+++ b/samples/vanilla-js/radialBar/circle-custom-angle.html
@@ -9,17 +9,17 @@
     <link href="../../assets/styles.css" rel="stylesheet" />
 
     <style>
-      
+
         #chart {
       padding: 0;
       max-width: 650px;
       margin: 35px auto;
     }
-    
+
     .apexcharts-legend text {
       font-weight: 900;
     }
-      
+
     </style>
 
     <script>
@@ -37,9 +37,9 @@
         )
     </script>
 
-    
+
     <script src="../../../dist/apexcharts.js"></script>
-    
+
 
     <script>
       // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
@@ -51,79 +51,72 @@
       };
     </script>
 
-    
+
   </head>
 
   <body>
      <div id="chart"></div>
 
     <script>
-      
+
         var options = {
           series: [76, 67, 61, 90],
           chart: {
-          height: 390,
-          type: 'radialBar',
-        },
-        plotOptions: {
-          radialBar: {
-            offsetY: 0,
-            startAngle: 0,
-            endAngle: 270,
-            hollow: {
-              margin: 5,
-              size: '30%',
-              background: 'transparent',
-              image: undefined,
-            },
-            dataLabels: {
-              name: {
-                show: false,
+            height: 390,
+            type: 'radialBar',
+          },
+          plotOptions: {
+            radialBar: {
+              offsetY: 0,
+              startAngle: 0,
+              endAngle: 270,
+              hollow: {
+                margin: 5,
+                size: '30%',
+                background: 'transparent',
+                image: undefined,
               },
-              value: {
-                show: false,
+              barLabels: {
+                enabled: true,
+                useSeriesColors: true,
+                margin: 8,
+                fontSize: '16px',
+                formatter: function(seriesName, opts) {
+                  return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
+                },
+              },
+              dataLabels: {
+                name: {
+                  show: false,
+                },
+                value: {
+                  show: false,
+                }
               }
             }
-          }
-        },
-        colors: ['#1ab7ea', '#0084ff', '#39539E', '#0077B5'],
-        labels: ['Vimeo', 'Messenger', 'Facebook', 'LinkedIn'],
-        legend: {
-          show: true,
-          floating: true,
-          fontSize: '16px',
-          position: 'left',
-          offsetX: 160,
-          offsetY: 15,
-          labels: {
-            useSeriesColors: true,
           },
-          markers: {
-            size: 0
-          },
-          formatter: function(seriesName, opts) {
-            return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
-          },
-          itemMargin: {
-            vertical: 3
-          }
-        },
-        responsive: [{
-          breakpoint: 480,
-          options: {
-            legend: {
-                show: false
+          colors: ['#1ab7ea', '#0084ff', '#39539E', '#0077B5'],
+          labels: ['Vimeo', 'Messenger', 'Facebook', 'LinkedIn'],
+          responsive: [{
+            breakpoint: 480,
+            options: {
+              plotOptions: {
+                radialBar: {
+                  barLabels: {
+                    enabled: false
+                  }
+                }
+              }
             }
-          }
-        }]
+          }]
         };
 
         var chart = new ApexCharts(document.querySelector("#chart"), options);
         chart.render();
-      
-      
+
+
     </script>
 
-    
+
   </body>
 </html>

--- a/samples/vue/radialBar/circle-custom-angle.html
+++ b/samples/vue/radialBar/circle-custom-angle.html
@@ -9,17 +9,17 @@
     <link href="../../assets/styles.css" rel="stylesheet" />
 
     <style>
-      
+
         #chart {
       padding: 0;
       max-width: 650px;
       margin: 35px auto;
     }
-    
+
     .apexcharts-legend text {
       font-weight: 900;
     }
-      
+
     </style>
 
     <script>
@@ -37,11 +37,11 @@
         )
     </script>
 
-    
+
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
     <script src="../../../dist/apexcharts.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue-apexcharts"></script>
-    
+
 
     <script>
       // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
@@ -53,11 +53,11 @@
       };
     </script>
 
-    
+
   </head>
 
   <body>
-    
+
     <div id="app">
       <div id="chart">
       <apexchart type="radialBar" height="390" :options="chartOptions" :series="series"></apexchart>
@@ -78,7 +78,6 @@
           apexchart: VueApexCharts,
         },
         data: {
-          
           series: [76, 67, 61, 90],
           chartOptions: {
             chart: {
@@ -96,6 +95,15 @@
                   background: 'transparent',
                   image: undefined,
                 },
+                barLabels: {
+                  enabled: true,
+                  useSeriesColors: true,
+                  margin: 8,
+                  fontSize: '16px',
+                  formatter: function(seriesName, opts) {
+                    return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
+                  },
+                },
                 dataLabels: {
                   name: {
                     show: false,
@@ -108,41 +116,22 @@
             },
             colors: ['#1ab7ea', '#0084ff', '#39539E', '#0077B5'],
             labels: ['Vimeo', 'Messenger', 'Facebook', 'LinkedIn'],
-            legend: {
-              show: true,
-              floating: true,
-              fontSize: '16px',
-              position: 'left',
-              offsetX: 160,
-              offsetY: 15,
-              labels: {
-                useSeriesColors: true,
-              },
-              markers: {
-                size: 0
-              },
-              formatter: function(seriesName, opts) {
-                return seriesName + ":  " + opts.w.globals.series[opts.seriesIndex]
-              },
-              itemMargin: {
-                vertical: 3
-              }
-            },
             responsive: [{
               breakpoint: 480,
               options: {
-                legend: {
-                    show: false
+                plotOptions: {
+                  radialBar: {
+                    barLabels: {
+                      enabled: false
+                    }
+                  }
                 }
               }
             }]
           },
-          
-          
         },
-        
       })
     </script>
-    
+
   </body>
 </html>

--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -542,61 +542,64 @@
   animation-timing-function: ease
 }
 
-.apexcharts-legend {	
-  display: flex;	
-  overflow: auto;	
-  padding: 0 10px;	
-}	
-.apexcharts-legend.apx-legend-position-bottom, .apexcharts-legend.apx-legend-position-top {	
-  flex-wrap: wrap	
-}	
-.apexcharts-legend.apx-legend-position-right, .apexcharts-legend.apx-legend-position-left {	
-  flex-direction: column;	
-  bottom: 0;	
-}	
-.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-left, .apexcharts-legend.apx-legend-position-top.apexcharts-align-left, .apexcharts-legend.apx-legend-position-right, .apexcharts-legend.apx-legend-position-left {	
-  justify-content: flex-start;	
-}	
-.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-center, .apexcharts-legend.apx-legend-position-top.apexcharts-align-center {	
-  justify-content: center;  	
-}	
-.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-right, .apexcharts-legend.apx-legend-position-top.apexcharts-align-right {	
-  justify-content: flex-end;	
-}	
-.apexcharts-legend-series {	
-  cursor: pointer;	
-  line-height: normal;	
-}	
-.apexcharts-legend.apx-legend-position-bottom .apexcharts-legend-series, .apexcharts-legend.apx-legend-position-top .apexcharts-legend-series{	
-  display: flex;	
-  align-items: center;	
-}	
-.apexcharts-legend-text {	
-  position: relative;	
-  font-size: 14px;	
-}	
-.apexcharts-legend-text *, .apexcharts-legend-marker * {	
-  pointer-events: none;	
-}	
-.apexcharts-legend-marker {	
-  position: relative;	
-  display: inline-block;	
-  cursor: pointer;	
-  margin-right: 3px;	
+.apexcharts-legend {
+  display: flex;
+  overflow: auto;
+  padding: 0 10px;
+}
+.apexcharts-legend.apx-legend-position-bottom, .apexcharts-legend.apx-legend-position-top {
+  flex-wrap: wrap
+}
+.apexcharts-legend.apx-legend-position-right, .apexcharts-legend.apx-legend-position-left {
+  flex-direction: column;
+  bottom: 0;
+}
+.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-left, .apexcharts-legend.apx-legend-position-top.apexcharts-align-left, .apexcharts-legend.apx-legend-position-right, .apexcharts-legend.apx-legend-position-left {
+  justify-content: flex-start;
+}
+.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-center, .apexcharts-legend.apx-legend-position-top.apexcharts-align-center {
+  justify-content: center;
+}
+.apexcharts-legend.apx-legend-position-bottom.apexcharts-align-right, .apexcharts-legend.apx-legend-position-top.apexcharts-align-right {
+  justify-content: flex-end;
+}
+.apexcharts-legend-series {
+  cursor: pointer;
+  line-height: normal;
+}
+.apexcharts-legend.apx-legend-position-bottom .apexcharts-legend-series, .apexcharts-legend.apx-legend-position-top .apexcharts-legend-series{
+  display: flex;
+  align-items: center;
+}
+.apexcharts-legend-text {
+  position: relative;
+  font-size: 14px;
+}
+.apexcharts-legend-text *, .apexcharts-legend-marker * {
+  pointer-events: none;
+}
+.apexcharts-legend-marker {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  margin-right: 3px;
   border-style: solid;
-}	
-  
-.apexcharts-legend.apexcharts-align-right .apexcharts-legend-series, .apexcharts-legend.apexcharts-align-left .apexcharts-legend-series{	
-  display: inline-block;	
-}	
-.apexcharts-legend-series.apexcharts-no-click {	
-  cursor: auto;	
-}	
-.apexcharts-legend .apexcharts-hidden-zero-series, .apexcharts-legend .apexcharts-hidden-null-series {	
-  display: none !important;	
-}	
-.apexcharts-inactive-legend {	
-  opacity: 0.45;	
+}
+
+.apexcharts-legend.apexcharts-align-right .apexcharts-legend-series, .apexcharts-legend.apexcharts-align-left .apexcharts-legend-series{
+  display: inline-block;
+}
+.apexcharts-radialbar-label {
+  cursor: pointer;
+}
+.apexcharts-legend-series.apexcharts-no-click,.apexcharts-radialbar-label.apexcharts-no-click {
+  cursor: auto;
+}
+.apexcharts-legend .apexcharts-hidden-zero-series, .apexcharts-legend .apexcharts-hidden-null-series {
+  display: none !important;
+}
+.apexcharts-inactive-legend {
+  opacity: 0.45;
 }
 
 .apexcharts-annotation-rect,.apexcharts-area-series .apexcharts-area,.apexcharts-area-series .apexcharts-series-markers .apexcharts-marker.no-pointer-events,.apexcharts-gridline,.apexcharts-line,.apexcharts-line-series .apexcharts-series-markers .apexcharts-marker.no-pointer-events,.apexcharts-point-annotation-label,.apexcharts-radar-series path,.apexcharts-radar-series polygon,.apexcharts-toolbar svg,.apexcharts-tooltip .apexcharts-marker,.apexcharts-xaxis-annotation-label,.apexcharts-yaxis-annotation-label,.apexcharts-zoom-rect {

--- a/src/charts/Radial.js
+++ b/src/charts/Radial.js
@@ -259,14 +259,6 @@ class Radial extends Pie {
       }
     }
 
-    let barLabelFormatter = this.barLabels.formatter;
-
-    if (!barLabelFormatter) {
-      barLabelFormatter = function (val) {
-        return val
-      }
-    }
-
     let reverseLoop = false
     if (w.config.plotOptions.radialBar.inverseOrder) {
       reverseLoop = true
@@ -370,7 +362,7 @@ class Radial extends Pie {
           opts.size,
           startAngle
         )
-        let text = barLabelFormatter(w.globals.seriesNames[i], { seriesIndex: i, w })
+        let text = this.barLabels.formatter(w.globals.seriesNames[i], { seriesIndex: i, w })
         let classes = ['apexcharts-radialbar-label'];
         if (!this.barLabels.onClick) {
           classes.push('apexcharts-no-click')

--- a/src/charts/Radial.js
+++ b/src/charts/Radial.js
@@ -259,7 +259,7 @@ class Radial extends Pie {
       }
     }
 
-    let barLabelFormatter = w.config.plotOptions.radialBar.barLabels.formatter;
+    let barLabelFormatter = this.barLabels.formatter;
 
     if (!barLabelFormatter) {
       barLabelFormatter = function (val) {
@@ -376,7 +376,7 @@ class Radial extends Pie {
           classes.push('apexcharts-no-click')
         }
 
-        let textColor = w.config.plotOptions.radialBar.barLabels.useSeriesColors
+        let textColor = this.barLabels.useSeriesColors
           ? w.globals.colors[i]
           : w.config.chart.foreColor
 
@@ -392,9 +392,9 @@ class Radial extends Pie {
           text,
           textAnchor: 'end',
           dominantBaseline: 'middle',
-          fontFamily: w.config.plotOptions.radialBar.barLabels.fontFamily,
-          fontWeight: w.config.plotOptions.radialBar.barLabels.fontWeight,
-          fontSize: w.config.plotOptions.radialBar.barLabels.fontSize,
+          fontFamily: this.barLabels.fontFamily,
+          fontWeight: this.barLabels.fontWeight,
+          fontSize: this.barLabels.fontSize,
           foreColor: textColor,
           cssClass: classes.join(' ')
         })

--- a/src/modules/Graphics.js
+++ b/src/modules/Graphics.js
@@ -659,7 +659,8 @@ class Graphics {
     opacity,
     maxWidth,
     cssClass = '',
-    isPlainText = true
+    isPlainText = true,
+    dominantBaseline = 'auto'
   }) {
     let w = this.w
 
@@ -714,7 +715,7 @@ class Graphics {
       x,
       y,
       'text-anchor': textAnchor,
-      'dominant-baseline': 'auto',
+      'dominant-baseline': dominantBaseline,
       'font-size': fontSize,
       'font-family': fontFamily,
       'font-weight': fontWeight,

--- a/src/modules/settings/Defaults.js
+++ b/src/modules/settings/Defaults.js
@@ -991,6 +991,10 @@ export default class Defaults {
           show: false
         }
       },
+      barLabels: {
+        enabled: false,
+        margin: 8
+      },
       fill: {
         gradient: {
           shade: 'dark',

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -527,6 +527,13 @@ export default class Options {
               opacity: 0.5
             }
           },
+          barLabels: {
+            enabled: false,
+            margin: 5,
+            formatter(val) {
+              return val
+            }
+          },
           dataLabels: {
             show: true,
             name: {

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -713,7 +713,7 @@ type ApexPlotOptions = {
       fontWeight?: string | number
       fontSize?: string
       formatter?: (barName: string, opts?: any) => string
-      onClick: (barName: string, opts?: any) => void
+      onClick?: (barName: string, opts?: any) => void
     }
     dataLabels?: {
       show?: boolean

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -705,6 +705,16 @@ type ApexPlotOptions = {
       margin?: number
       dropShadow?: ApexDropShadow
     }
+    barLabels?: {
+      enabled?: boolean
+      margin?: number
+      useSeriesColors?: boolean
+      fontFamily?: string
+      fontWeight?: string | number
+      fontSize?: string
+      formatter?: (barName: string, opts?: any) => string
+      onClick: (barName: string, opts?: any) => void
+    }
     dataLabels?: {
       show?: boolean
       name?: {


### PR DESCRIPTION
This PR adds a new feature to `radialBar` charts to add labels to the individual bars. It's controlled by `plotOptions.radialBar.barLabels`.

It will take the series names as labels by default, but they can be customized using a `formatter` function.

Additionally, it updates the `circle-custom-angle` samples to use this feature to be more responsive. (We tried using the code from that very sample to make a chart and were unsuccessful in making it responsive - text was just all over the place)

This is how that example looks now:

![grafik](https://user-images.githubusercontent.com/5854687/227487909-4468f1d9-b654-47c4-b6f5-e3de639cff31.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

I would appreciate help with the tests as they don't seem to run at all locally (like, even without any changes from me, they crash).

The feature should be covered by the changed `circle-custom-angle` sample though.