### PR TITLE
[bugfix]: set Null values to 0 when cnf.chart.stacked 

### DIFF
--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -673,7 +673,7 @@ export default class Data {
     }
 
     // set Null values to 0 in all series when user hides/shows some series
-    if (cnf.chart.type === 'bar' && cnf.chart.stacked) {
+    if (cnf.chart.stacked) {
       const series = new Series(this.ctx)
       gl.series = series.setNullSeriesToZeroValues(gl.series)
     }


### PR DESCRIPTION
# New Pull Request

I removed the condition for the chart.type to be exclusively 'bar', otherwise when we mix types, we get undefined instead of 0 on stacked bars

Before:
![issue](https://user-images.githubusercontent.com/2815177/236694509-1ee9bb07-9825-4303-b9a8-b61aec96d074.png)
After: 
![resolution](https://user-images.githubusercontent.com/2815177/236694515-323ec8ff-f08b-4c6c-b3a0-9ac172424c32.png)

Fixes #3811 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
