### PR TITLE
feat: allow stack bar only

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -490,6 +490,15 @@ class Line {
     }
 
     let y2 = y
+
+    let stackSeries =
+      w.config.chart.stacked &&
+      (!this.w.config.chart.stackOnlyBar ||
+        (this.w.config.series[realIndex] &&
+          this.w.config.series[realIndex].type &&
+          (this.w.config.series[realIndex].type === 'bar' ||
+            this.w.config.series[realIndex].type === '')))
+
     for (let j = 0; j < iterations; j++) {
       const isNull =
         typeof series[i][j + 1] === 'undefined' || series[i][j + 1] === null
@@ -505,7 +514,7 @@ class Line {
         x = x + this.xDivision
       }
 
-      if (w.config.chart.stacked) {
+      if (stackSeries) {
         if (
           i > 0 &&
           w.globals.collapsedSeries.length < w.config.series.length - 1

--- a/src/charts/common/line/Helpers.js
+++ b/src/charts/common/line/Helpers.js
@@ -104,8 +104,10 @@ export default class Helpers {
 
   determineFirstPrevY({ i, series, prevY, lineYPosition }) {
     let w = this.w
+    let stackSeries = w.config.chart.stacked && (!w.config.chart.stackOnlyBar || (series[i] && series[i].type && series[i].type === 'bar'));
+
     if (typeof series[i]?.[0] !== 'undefined') {
-      if (w.config.chart.stacked) {
+      if (stackSeries) {
         if (i > 0) {
           // 1st y value of previous series
           lineYPosition = this.lineCtx.prevSeriesY[i - 1][0]
@@ -126,7 +128,7 @@ export default class Helpers {
     } else {
       // the first value in the current series is null
       if (
-        w.config.chart.stacked &&
+        stackSeries &&
         i > 0 &&
         typeof series[i][0] === 'undefined'
       ) {

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -549,12 +549,18 @@ class Range {
             stackedPoss[group][j] = 0
             stackedNegs[group][j] = 0
           }
+          let stackSeries =
+            !this.w.config.chart.stackOnlyBar ||
+            (gl.series[i] && gl.series[i].type && gl.series[i].type === 'bar')
 
-          if (gl.series[i][j] !== null && Utils.isNumber(gl.series[i][j])) {
-            gl.series[i][j] > 0
-              ? (stackedPoss[group][j] += parseFloat(gl.series[i][j]) + 0.0001)
-              : (stackedNegs[group][j] += parseFloat(gl.series[i][j]))
+          if (stackSeries) {
+            if (gl.series[i][j] !== null && Utils.isNumber(gl.series[i][j])) {
+              gl.series[i][j] > 0
+                ? (stackedPoss[group][j] += parseFloat(gl.series[i][j]) + 0.0001)
+                : (stackedNegs[group][j] += parseFloat(gl.series[i][j]))
+            }
           }
+
         }
       })
     })

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -344,6 +344,7 @@ export default class Options {
           target: undefined,
         },
         stacked: false,
+        stackOnlyBar: true, // mixed chart with stacked bars and line series - incorrect line draw #907
         stackType: 'normal',
         toolbar: {
           show: true,
@@ -921,6 +922,7 @@ export default class Options {
         enabled: true,
         enabledOnSeries: undefined,
         shared: true,
+        hideEmptyShared: true,
         followCursor: false, // when disabled, the tooltip will show on top of the series instead of mouse position
         intersect: false, // when enabled, tooltip will only show when user directly hovers over point
         inverseOrder: false,

--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -359,6 +359,17 @@ export default class Labels {
 
     if (shared && ttItemsChildren[0]) {
       // hide when no Val or series collapsed
+      if (w.config.tooltip.hideEmptyShared) {
+        let ttItemMarker = ttItems[t].querySelector('.apexcharts-tooltip-marker');
+        let ttItemText = ttItems[t].querySelector('.apexcharts-tooltip-text');
+        if (parseFloat(val) == 0) {
+          ttItemMarker.style.display = 'none';
+          ttItemText.style.display = 'none';
+        } else {
+          ttItemMarker.style.display = 'block';
+          ttItemText.style.display = 'block';
+        }
+      }
       if (
         typeof val === 'undefined' ||
         val === null ||


### PR DESCRIPTION
# New Pull Request

When adding multiple lines to an existing stack bar chart, the lines are also stacked rather than being expressed independently. That is, where line series 1 has a value of 10 and line series 2 has a value of 5 series 2 will be plotted at 15, not 5.

New Options:
chart.stackOnlyBar = true
tooltip.hideEmptyShared = true

Fixes #907 & #2076

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
