### PR TITLE
Added type of string array to brush targets.

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -150,6 +150,7 @@ type ApexChart = {
     enabled?: boolean
     autoScaleYaxis?: boolean
     target?: string
+    targets?: string[]
   }
   id?: string
   group?: string


### PR DESCRIPTION
# New Pull Request

When using Typescript (react-apexcharts in my case) there is no posibillity to target multiple charts with brush. This PR should fix it. 

*that's my first PR on Github ever, also first contribution to someone's package, so if I've done something wrong please correct me.

Fixes #3917  (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
