### PR TITLE
Feat: trimmed treemap labels

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -598,6 +598,7 @@ type ApexPlotOptions = {
     distributed?: boolean
     reverseNegativeShade?: boolean
     useFillColorAsStroke?: boolean
+    dataLabels?: { format?: 'scale' | 'truncate' }
     colorScale?: {
       inverse?: boolean
       ranges?: {


### PR DESCRIPTION
# New Pull Request

FIxes #3914 

If accepted, this PR will: 
- Add dataLabels field to treemap plotOptions: `dataLabels?: { format?: 'scale' | 'truncate' }`
- Add new method that will truncate label text after formatter has been applied, based on config
- Utilize existing methods/utils such as `getTextBasedOnMaxWidth` and `rotateToFitLabel`
- Update `rotateToFitLabel` to improve vertical alignment and appearance of larger truncated labels

### Motivation and Context

Treemaps with dynamic label lengths can easily become unreadable when they are long with the current fontSize scaling method. Users should have access to a config option where a label uses a consistent font size and will automatically trim/truncate itself to fit within its rect.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Examples:

### Current behavior (scaling font-size with long labels):

![long_labels](https://github.com/apexcharts/apexcharts.js/assets/89360691/9bcfc3bd-c1e9-4c89-9227-2cb37e2a86d9)

### New behavior with truncated labels:

![truncated](https://github.com/apexcharts/apexcharts.js/assets/89360691/44eb34db-ba26-49b3-be03-f2c391906fb1)
