### PR TITLE
Added type to colorStops in ApexFill

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -744,6 +744,12 @@ type ApexPlotOptions = {
   }
 }
 
+type ApexColorStop = {
+  offset: number
+  color: string
+  opacity: number
+}
+
 type ApexFill = {
   colors?: any[]
   opacity?: number | number[]
@@ -757,7 +763,7 @@ type ApexFill = {
     opacityFrom?: number | number[]
     opacityTo?: number | number[]
     stops?: number[],
-    colorStops?: any[]
+    colorStops?: ApexColorStop[][] | ApexColorStop[]
   }
   image?: {
     src?: string | string[]


### PR DESCRIPTION
# New Pull Request
The documentation shows that `colorStops` is an array of objects but the types have them as `any`.

Would be nice to have the types here when overriding the stops of a gradient.

Docs:https://apexcharts.com/docs/options/fill/

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
