### PR TITLE
fix: detect positioning for leftmost values

### DIFF
--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -69,21 +69,11 @@ export default class Utils {
 
     let capturedSeries = null
     let closest = null
-    let seriesXValArr = []
-    let seriesYValArr = []
 
-    //add extra values to show markers for the first points. Included both axes to avoid incorrect positioning of the marker
-    w.globals.seriesXvalues.forEach((value) => {
-      seriesXValArr.push([value[0] + 0.000001].concat(value))
-    })
-    w.globals.seriesYvalues.forEach((value) => {
-      seriesYValArr.push([value[0] + 0.000001].concat(value))
-    })
-
-    seriesXValArr = seriesXValArr.map((seriesXVal) => {
+    let seriesXValArr = seriesXValArr.map((seriesXVal) => {
       return seriesXVal.filter((s) => Utilities.isNumber(s))
     })
-    seriesYValArr = seriesYValArr.map((seriesYVal) => {
+    let seriesYValArr = seriesYValArr.map((seriesYVal) => {
       return seriesYVal.filter((s) => Utilities.isNumber(s))
     })
 
@@ -155,7 +145,7 @@ export default class Utils {
     Xarrays.forEach((arrX) => {
       arrX.forEach((x, iX) => {
         const newDiff = Math.abs(hoverX - x)
-        if (newDiff < diffX) {
+        if (newDiff <= diffX) {
           diffX = newDiff
           j = iX
         }
@@ -170,7 +160,7 @@ export default class Utils {
 
       Yarrays.forEach((arrY, iAY) => {
         const newDiff = Math.abs(hoverY - arrY[j])
-        if (newDiff < diffY) {
+        if (newDiff <= diffY) {
           diffY = newDiff
           currIndex = iAY
         }


### PR DESCRIPTION
# New Pull Request

This is related to #3798. The problem here is that we add a new control points that will always be closest to user's cursor position that first ones.

Fixes #3798

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
