### PR TITLE
Hide charts automatically at start

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -108,6 +108,9 @@ export default class ApexCharts {
             }
 
             this.events.fireEvent('mounted', [this, this.w])
+
+            this._hideHiddenAtStart()
+
             resolve(graphData)
           })
           .catch((e) => {
@@ -775,5 +778,14 @@ export default class ApexCharts {
     }
 
     redraw && this._windowResize()
+  }
+
+  _hideHiddenAtStart() {
+    let series = this.series;
+    this.w.config.series.forEach((ser) => {
+      if(ser.hiddenAtStart && ser.name) {
+        series.hideSeries(ser.name)
+      }
+    });
   }
 }


### PR DESCRIPTION
# New Pull Request

This pull automatically collapses charts that have the 'hiddenAtStart' value set to true in the series definitions. Although it does render the series, the series is then automatically hidden. It would be pretty difficult to do without processing the data as the original issue described. Maybe better to have the title in the legend, but with no data in it. Once selected you would then have to reprocess all the data to sort out the autoscaling.

I needed this for I project I am working on, so you are welcome to it, however it doesn't fix this raised issue as described.

https://github.com/apexcharts/apexcharts.js/issues/4102

Fixes #4102

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
