### PR TITLE
Handle CSV export of the datetime multi-series with variable X-axes

### DIFF
--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -183,8 +183,17 @@ export default class Toolbar {
       },
     ]
 
-    if (!this.w.globals.allSeriesHasEqualX) {
+    if (
+      !this.w.globals.allSeriesHasEqualX &&
+      !(
+        this.w.globals.axisCharts &&
+        this.w.config.xaxis.type === 'datetime' &&
+        !this.w.config.xaxis.categories.length &&
+        !this.w.config.labels.length
+      )
+    ) {
       // if it is a multi series, and all series have variable x values, export CSV won't work
+      // unless it is a simple datetime chart
       menuItems.splice(2, 1)
     }
     for (let i = 0; i < menuItems.length; i++) {

--- a/tests/unit/download-csv.spec.js
+++ b/tests/unit/download-csv.spec.js
@@ -181,6 +181,72 @@ describe('Export Csv', () => {
       expect.stringContaining('.csv')
     )
   })
+  it("export csv from simple line chart with two unequal datetime series should call triggerDownload with csv encoded file data", () => {
+    var options = {
+      chart: {
+        type: "line"
+      },
+      series: [{
+        name: 'series1',
+        data: [["2000-01-01T00:00:00.000", 1]]
+      }, {
+        name: 'series2',
+        data: [["2000-01-02T00:00:00.000", 1]]
+      }],
+      xaxis: {
+          type: 'datetime',
+      },
+    };
+    const csvData = "category,series1,series2\n" +
+      "Sat Jan 01 2000,1,\n" +
+      "Sun Jan 02 2000,,1"
+    const chart = createChartWithOptions(options)
+    const exports = new Exports(chart.ctx)
+    jest.spyOn(Exports.prototype,'triggerDownload')
+    exports.exportToCSV(chart.w.config.series,'fileName')
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledTimes(1)
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(csvData)),
+      expect.toBeUndefined,
+      expect.stringContaining('.csv')
+    )
+  })
+  it("export csv from simple line chart with two unequal datetime x y series should call triggerDownload with csv encoded file data", () => {
+    var options = {
+      chart: {
+        type: "line"
+      },
+      series: [{
+        name: 'series1',
+        data: [{
+          x: "2000-01-01T00:00:00.000",
+          y: 1
+        }]
+      }, {
+        name: 'series2',
+        data: [{
+          x: "2000-01-02T00:00:00.000",
+          y: 1
+        }]
+      }],
+      xaxis: {
+          type: 'datetime',
+      },
+    };
+    const csvData = "category,series1,series2\n" +
+      "Sat Jan 01 2000,1,\n" +
+      "Sun Jan 02 2000,,1"
+    const chart = createChartWithOptions(options)
+    const exports = new Exports(chart.ctx)
+    jest.spyOn(Exports.prototype,'triggerDownload')
+    exports.exportToCSV(chart.w.config.series,'fileName')
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledTimes(1)
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(csvData)),
+      expect.toBeUndefined,
+      expect.stringContaining('.csv')
+    )
+  })
   it("export csv from simple spline area chart with two series should call triggerDownload with csv encoded file data", () => {
     var options = {
       series: [{


### PR DESCRIPTION
This change introduces CSV export of the datetime series with unequal X-axes. I know it is non-trivial to export data as CSV in the case of multi-series with variable X values, but it is still possible, at least for datetime series. It's an important and long-awaited input (given the issue referred below), and it also seems quite reasonable, since such data is seamlessly displayed on the timeline, thus should be available for export even with empty cells.

Fixes #1568

## Type of change:

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
