### PR TITLE
Fix/4111 skipped second tick xaxis

### DIFF
--- a/src/modules/TimeScale.js
+++ b/src/modules/TimeScale.js
@@ -625,7 +625,7 @@ class TimeScale {
     if (remainingMins === 60) {
       firstTickPosition = 0
       firstTickValue = firstVal.minHour
-      hour = firstTickValue + 1
+      hour = firstTickValue
     }
 
     let date = currentDate

--- a/tests/unit/timescale.spec.js
+++ b/tests/unit/timescale.spec.js
@@ -417,6 +417,58 @@ describe('Generate TimeScale', () => {
     }
   })
 
+  it('should generate an hour timescale without skipping ticks when start with full hour', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1],
+      },
+    ])
+    const timeScale = new TimeScale(chart)
+    timeScale.generateHourScale({
+      firstVal: {
+        minSecond: 0,
+        minMinute: 0,
+        minHour: 0,
+      },
+      currentDate: 22,
+      currentMonth: 11,
+      currentYear: 2022,
+      minutesWidthOnXAxis: 0.4,
+      numberOfHours: 3,
+    })
+
+    const generatedScale = timeScale.timeScaleArray
+    for (let i = 0; i < generatedScale.length - 1; i++) {
+      expect(generatedScale[i].value).toEqual(i)
+    }
+  })
+
+  it('should generate an hour timescale without skipping ticks when start with partial hour', () => {
+    const chart = createChart('line', [
+      {
+        data: [0, 1],
+      },
+    ])
+    const timeScale = new TimeScale(chart)
+    timeScale.generateHourScale({
+      firstVal: {
+        minSecond: 0,
+        minMinute: 35,
+        minHour: 0,
+      },
+      currentDate: 22,
+      currentMonth: 11,
+      currentYear: 2022,
+      minutesWidthOnXAxis: 0.4,
+      numberOfHours: 3,
+    })
+
+    const generatedScale = timeScale.timeScaleArray
+    for (let i = 0; i < generatedScale.length - 1; i++) {
+      expect(generatedScale[i].value).toEqual(i + 1)
+    }
+  })
+
   it.each([...Array(24).keys()].map((hour) => ({ hour: hour + 1 })))(
     'should generate an formatted hourly timescale with unique ticks starting on hour $hour:00',
     ({ hour }) => {


### PR DESCRIPTION
# New Pull Request

Fixes x-axis generating an incorrect hourly scale when using a full starting hour. 

This [previous merge](https://github.com/apexcharts/apexcharts.js/pull/3998) introduced this bug because the incrementation for the `hour` was changed outside the if statement but not inside.

Fixes #4111 and [this](https://github.com/apexcharts/Blazor-ApexCharts/issues/342)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
