### PR TITLE
Issue #4121: plotting a mixed line and column chart with different xaxis datasets

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -173,7 +173,7 @@ class Bar {
       })
       elBarShadows.node.classList.add('apexcharts-element-hidden')
 
-      for (let j = 0; j < w.globals.dataPoints; j++) {
+      for (let j = 0; j < series[i].length; j++) {
         const strokeWidth = this.barHelpers.getStrokeWidth(i, j, realIndex)
 
         let paths = null


### PR DESCRIPTION
Fixes # 4121

Avoid large delays in combo charts that include bars, specifically when mixing X series with highly disparate numbers of data points. The sample from the issue renders a >3000 point line with a single point bar.

With animations turned off, chart rendering time fell from 16.5 to 0.37 seconds (from 32.5 to 1.3 seconds, with animations).
The reduction comes from not constructing the >3000 phantom bars with their corresponding DOM elements as a workaround to enable tooltips to be displayed for every datapoint.

There was no observed change to any of the e2e test sample charts or their tooltips following this change.

Downside: after this change, the default options will only show tooltips for each bar (the series drawn first).

Upside: broaden application of apexcharts to a category of uses similar to the issue example. Tooltips can be accessed for the other more dense series by collapsing the less dense bar series, but that also requires the legend to be explicitly 
enabled.

A potential compromise solution: construct the phantom dataPoint bars as a single rendered path rather than a separate path for each dataPoint. Constructing a single element as for the line path is significantly faster than >3000 individual elements.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
