### PR TITLE
Issue 4271:

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -104,7 +104,7 @@ class Range {
         firstXIndex = 0
         lastXIndex = gl.series[i].length
       }
-      for (let j = firstXIndex; j <= lastXIndex; j++) {
+      for (let j = firstXIndex; j <= lastXIndex && j < gl.series[i].length; j++) {
         let val = series[i][j]
         if (val !== null && Utils.isNumber(val)) {
           if (typeof seriesMax[i][j] !== 'undefined') {


### PR DESCRIPTION
Bug introduced in 3.46.0 caused collapsed series' to be scanned for min and max values only to find null values, setting w.globals.hasNullValues, which causes the effects described in the issue report.

Fixes #4271

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
