### PR TITLE
Handle collapsed series when yAxis seriesName arrays are used.

### DIFF
--- a/samples/react/area/multi-axis-with-seriesname-arrays.html
+++ b/samples/react/area/multi-axis-with-seriesname-arrays.html
@@ -156,8 +156,11 @@
                       colors: '#008800',
                     },
                     formatter: (val) => {
-                      let ref = val.toFixed(0);
-                      return val == ref ? val : ''
+                      if (typeof val !== "undefined") {
+                        let ref = val.toFixed(0);
+                        return val == ref ? val : ''
+                      }
+                      return val
                     }
                   },
                   title: {
@@ -183,8 +186,11 @@
                       colors: '#FF0000',
                     },
                     formatter: (val) => {
-                      let ref = val.toFixed(0);
-                      return val == ref ? val : ''
+                      if (typeof val !== "undefined") {
+                        let ref = val.toFixed(0);
+                        return val == ref ? val : ''
+                      }
+                      return val
                     }
                   },
                   title: {

--- a/samples/source/area/multi-axis-with-seriesname-arrays.xml
+++ b/samples/source/area/multi-axis-with-seriesname-arrays.xml
@@ -74,8 +74,11 @@ yaxis: [
         colors: '#008800',
       },
       formatter: (val) => {
-        let ref = val.toFixed(0);
-        return val == ref ? val : ''
+        if (typeof val !== "undefined") {
+          let ref = val.toFixed(0);
+          return val == ref ? val : ''
+        }
+        return val
       }
     },
     title: {
@@ -101,8 +104,11 @@ yaxis: [
         colors: '#FF0000',
       },
       formatter: (val) => {
-        let ref = val.toFixed(0);
-        return val == ref ? val : ''
+        if (typeof val !== "undefined") {
+          let ref = val.toFixed(0);
+          return val == ref ? val : ''
+        }
+        return val
       }
     },
     title: {

--- a/samples/vanilla-js/area/multi-axis-with-seriesname-arrays.html
+++ b/samples/vanilla-js/area/multi-axis-with-seriesname-arrays.html
@@ -139,8 +139,11 @@
                 colors: '#008800',
               },
               formatter: (val) => {
-                let ref = val.toFixed(0);
-                return val == ref ? val : ''
+                if (typeof val !== "undefined") {
+                  let ref = val.toFixed(0);
+                  return val == ref ? val : ''
+                }
+                return val
               }
             },
             title: {
@@ -166,8 +169,11 @@
                 colors: '#FF0000',
               },
               formatter: (val) => {
-                let ref = val.toFixed(0);
-                return val == ref ? val : ''
+                if (typeof val !== "undefined") {
+                  let ref = val.toFixed(0);
+                  return val == ref ? val : ''
+                }
+                return val
               }
             },
             title: {

--- a/samples/vue/area/multi-axis-with-seriesname-arrays.html
+++ b/samples/vue/area/multi-axis-with-seriesname-arrays.html
@@ -159,8 +159,11 @@
                     colors: '#008800',
                   },
                   formatter: (val) => {
-                    let ref = val.toFixed(0);
-                    return val == ref ? val : ''
+                    if (typeof val !== "undefined") {
+                      let ref = val.toFixed(0);
+                      return val == ref ? val : ''
+                    }
+                    return val
                   }
                 },
                 title: {
@@ -186,8 +189,11 @@
                     colors: '#FF0000',
                   },
                   formatter: (val) => {
-                    let ref = val.toFixed(0);
-                    return val == ref ? val : ''
+                    if (typeof val !== "undefined") {
+                      let ref = val.toFixed(0);
+                      return val == ref ? val : ''
+                    }
+                    return val
                   }
                 },
                 title: {

--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -714,14 +714,24 @@ export default class Data {
 
   excludeCollapsedSeriesInYAxis() {
     const w = this.w
-    w.globals.ignoreYAxisIndexes = w.globals.collapsedSeries.map(
-      (collapsed, i) => {
-        // fix issue #1215
-        // if stacked, not returning collapsed.index to preserve yaxis
-        if (this.w.globals.isMultipleYAxis && !w.config.chart.stacked) {
-          return collapsed.index
+    // fix issue #1215
+    // if stacked, not returning collapsed.index to preserve yaxis
+    if (this.w.globals.isMultipleYAxis && !w.config.chart.stacked) {
+      // Post revision 3.46.0 there is no longer a strict one-to-one
+      // correspondence between series and Y axes.
+      // An axis can be ignored only while all series referenced by it
+      // are collapsed.
+      let yAxisIndexes = []
+      w.globals.seriesYAxisMap.forEach((yAxisArr, yi) => {
+        let allCollapsed = true
+        yAxisArr.forEach((seriesIndex) => {
+          allCollapsed = allCollapsed && w.globals.collapsedSeriesIndices.indexOf(seriesIndex) !== -1
+        })
+        if (allCollapsed) {
+          yAxisIndexes.push(yi)
         }
-      }
-    )
+      })
+      w.globals.ignoreYAxisIndexes = yAxisIndexes ? yAxisIndexes.map((x) => x) : []
+    }
   }
 }

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -315,6 +315,7 @@ class Range {
       gl.maxY = gl.yAxisScale[0].niceMax
       gl.minYArr[0] = gl.yAxisScale[0].niceMin
       gl.maxYArr[0] = gl.yAxisScale[0].niceMax
+      gl.seriesYAxisMap = [gl.series.map((x, i) => i)]
     }
 
     return {

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -604,6 +604,7 @@ export default class Scales {
       })
     }
 
+    gl.seriesYAxisMap = axisSeriesMap.map((x) => x)
     this.sameScaleInMultipleAxes(minYArr, maxYArr, axisSeriesMap)
   }
 

--- a/src/modules/axes/AxesUtils.js
+++ b/src/modules/axes/AxesUtils.js
@@ -175,16 +175,20 @@ export default class AxesUtils {
     }
     return labels
   }
-
+  
   isYAxisHidden(index) {
     const w = this.w
     const coreUtils = new CoreUtils(this.ctx)
+    
+    let allCollapsed = !w.globals.seriesYAxisMap[index].some((si) => {
+      return w.globals.collapsedSeriesIndices.indexOf(si) === -1
+    })
 
     return (
       !w.config.yaxis[index].show ||
       (!w.config.yaxis[index].showForNullSeries &&
         coreUtils.isSeriesNull(index) &&
-        w.globals.collapsedSeriesIndices.indexOf(index) === -1)
+        allCollapsed)
     )
   }
 

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -228,7 +228,8 @@ export default class Globals {
       // example, stepSize: 3. This value will be preferred to the value determined through
       // this array. The range-normalized value is checked for consistency with other
       // user defined options and will be ignored if inconsistent.
-      niceScaleAllowedMagMsd: [[1,1,2,5,5,5,10,10,10,10,10],[1,1,2,5,5,5,10,10,10,10,10]]
+      niceScaleAllowedMagMsd: [[1,1,2,5,5,5,10,10,10,10,10],[1,1,2,5,5,5,10,10,10,10,10]],
+      seriesYAxisMap: [] // Indices of Series to Indices of yAxis map. Multiple series can be referenced to each yAxis.
     }
   }
 


### PR DESCRIPTION
# New Pull Request

Add code necessary to handle collapsed series for charts that use the new yaxis: seriesName: as an array feature (to reference multiple data series'). 

The incorrect yAxis was  being hidden as series were collapsed. Also, a yAxis can only be hidden while all of the series' referenced by it are collapsed. Fixed the tooltip formatters in the sample `multi-axis-with-seriesname-arrays.xml` to detect undefined label values (as per established practice found in other samples).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
