### PR TITLE
Hide datalabels when the series is collapsed.

### DIFF
--- a/samples/react/mixed/line-column.html
+++ b/samples/react/mixed/line-column.html
@@ -96,9 +96,6 @@
                 enabledOnSeries: [1]
               },
               labels: ['01 Jan 2001', '02 Jan 2001', '03 Jan 2001', '04 Jan 2001', '05 Jan 2001', '06 Jan 2001', '07 Jan 2001', '08 Jan 2001', '09 Jan 2001', '10 Jan 2001', '11 Jan 2001', '12 Jan 2001'],
-              xaxis: {
-                type: 'datetime'
-              },
               yaxis: [{
                 title: {
                   text: 'Website Blog',

--- a/samples/source/mixed/line-column.xml
+++ b/samples/source/mixed/line-column.xml
@@ -17,9 +17,6 @@ dataLabels: {
   enabledOnSeries: [1]
 },
 labels: ['01 Jan 2001', '02 Jan 2001', '03 Jan 2001', '04 Jan 2001', '05 Jan 2001', '06 Jan 2001', '07 Jan 2001', '08 Jan 2001', '09 Jan 2001', '10 Jan 2001', '11 Jan 2001', '12 Jan 2001'],
-xaxis: {
-  type: 'datetime'
-},
 yaxis: [{
   title: {
     text: 'Website Blog',

--- a/samples/vanilla-js/mixed/line-column.html
+++ b/samples/vanilla-js/mixed/line-column.html
@@ -79,9 +79,6 @@
           enabledOnSeries: [1]
         },
         labels: ['01 Jan 2001', '02 Jan 2001', '03 Jan 2001', '04 Jan 2001', '05 Jan 2001', '06 Jan 2001', '07 Jan 2001', '08 Jan 2001', '09 Jan 2001', '10 Jan 2001', '11 Jan 2001', '12 Jan 2001'],
-        xaxis: {
-          type: 'datetime'
-        },
         yaxis: [{
           title: {
             text: 'Website Blog',

--- a/samples/vue/mixed/line-column.html
+++ b/samples/vue/mixed/line-column.html
@@ -99,9 +99,6 @@
               enabledOnSeries: [1]
             },
             labels: ['01 Jan 2001', '02 Jan 2001', '03 Jan 2001', '04 Jan 2001', '05 Jan 2001', '06 Jan 2001', '07 Jan 2001', '08 Jan 2001', '09 Jan 2001', '10 Jan 2001', '11 Jan 2001', '12 Jan 2001'],
-            xaxis: {
-              type: 'datetime'
-            },
             yaxis: [{
               title: {
                 text: 'Website Blog',

--- a/src/modules/DataLabels.js
+++ b/src/modules/DataLabels.js
@@ -81,6 +81,7 @@ class DataLabels {
     // this method handles line, area, bubble, scatter charts as those charts contains markers/points which have pre-defined x/y positions
     // all other charts like radar / bars / heatmaps will define their own drawDataLabel routine
     let w = this.w
+    
     const graphics = new Graphics(this.ctx)
 
     let dataLabelsConfig = w.config.dataLabels
@@ -92,7 +93,10 @@ class DataLabels {
 
     let elDataLabelsWrap = null
 
-    if (!dataLabelsConfig.enabled || !Array.isArray(pos.x)) {
+    const seriesCollapsed = 
+        w.globals.collapsedSeriesIndices.indexOf(i) !== -1
+
+    if (seriesCollapsed || !dataLabelsConfig.enabled || !Array.isArray(pos.x)) {
       return elDataLabelsWrap
     }
 


### PR DESCRIPTION
Hide datalabels when the series is collapsed.

Also:
sample/source/mixed/line-column.xml: remove xaxis options overriding the labels option (X axis ticks and axis labels were not aligned with datapoints or columns).

Both these issues predate 3.46.0 changes

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
