### PR TITLE
Y axis hiding bug fix

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -608,7 +608,7 @@ export default class Scales {
       if (unassignedSeriesIndices) {
         let si = unassignedSeriesIndices[0]
         unassignedSeriesIndices.shift()
-        axisSeriesMap[lastUnassignedYAxis].push([si])
+        axisSeriesMap[lastUnassignedYAxis].push(si)
         seriesYAxisReverseMap[si] = lastUnassignedYAxis
       } else {
         break


### PR DESCRIPTION
Fixes a bug in my earlier merged pull request related to collapsed series. Yaxes with a single referenced series that was collapsed remained visible.
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
