### PR TITLE
Zoomed scale fixes:

### DIFF
--- a/src/modules/Formatters.js
+++ b/src/modules/Formatters.js
@@ -53,10 +53,13 @@ class Formatters {
             ? yaxe.decimalsInFloat
             : w.globals.yValueDecimal
         )
-      } else if (w.globals.maxYArr[i] - w.globals.minYArr[i] < 5) {
-        v = v.toFixed(1)
       } else {
-        v = v.toFixed(0)
+        // We have an integer value but the label is not an integer. We can
+        // deduce this is due to the number of ticks exceeding the even lower
+        // integer range. Add an additional decimal place only in this case.
+        const f = v.toFixed(0)
+        // Do not change the == to ===
+        v = v == f ? f : v.toFixed(1)
       }
     }
     return v

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -54,14 +54,14 @@ class Range {
         if (cnf.xaxis.min) {
           for (
             firstXIndex = 0;
-            firstXIndex < lastXIndex && seriesX[firstXIndex] <= cnf.xaxis.min;
+            firstXIndex < lastXIndex && seriesX[firstXIndex] < cnf.xaxis.min;
             firstXIndex++
           ) {}
         }
         if (cnf.xaxis.max) {
           for (
             ;
-            lastXIndex > firstXIndex && seriesX[lastXIndex] >= cnf.xaxis.max;
+            lastXIndex > firstXIndex && seriesX[lastXIndex] > cnf.xaxis.max;
             lastXIndex--
           ) {}
         }

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -285,6 +285,19 @@ export default class Scales {
         tiks++
       }
     }
+    
+    // Prune tiks down to range if series is all integers. Since tiks > range,
+    // range is very low (< 10 or so). Skip this step if tickAmount is true
+    // because, either the user set it, or the chart is multiscale and this
+    // axis is not determining the number of grid lines.
+    if (!gotTickAmount &&
+          axisCnf.forceNiceScale &&
+            gl.yValueDecimal === 0 &&
+              tiks > range
+    ) {
+      tiks = range
+      stepSize = Math.round(range / tiks)
+    }
 
     // Record final tiks for use by other series that call niceScale().
     // Note: some don't, like logarithmicScale(), etc.


### PR DESCRIPTION
In zoomed charts, ensure the Y axis scale fits the full min..max range of Y values. Observed when looking at an unrelated bug report involving a zoomed brush chart with category based X axis.

Visual improvement to Yaxis scale:
For an all-integer series, prune fractional ticks when the number of ticks is greater than the range. For example, a range of 4 with 7 ticks (1,1.5,2,2.5,3,3.5,4) is reduced to (1,2,3,4).

A related change was made to the defaultYFormatter() routine for integer-only series/charts, to convert labels toFixed(1) only if the label does not match the Y value. This replaces the previous condition that converted all integer-only series labels to toFixed(1) if the range of the series was < 5. In the previous para example would unexpectedly emit the labels (1.0,2.0,3.0,4.0).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
