### PR TITLE
Use createElementNS instead of createElement for svg objects

### DIFF
--- a/src/svgjs/svg.js
+++ b/src/svgjs/svg.js
@@ -400,7 +400,7 @@
   }
 
   SVG.extend(SVG.Array, {
- 
+
     // Convert array to string
     toString: function () {
       return this.value.join(' ')
@@ -418,7 +418,7 @@
 
       return this.split(array)
     },
-   
+
   })
   // Poly points array
   SVG.PointArray = function (array, fallback) {
@@ -520,7 +520,7 @@
       y -= box.y
 
       return this
-    },        
+    },
     // Get morphed path array at given position
     at: function (pos) {
     // make sure a destination is defined
@@ -797,7 +797,7 @@
       // Remove element
       remove: function () {
         if (this.parent()) { this.parent().removeElement(this) }
-        
+
         return this
       },
       // Replace element
@@ -818,7 +818,7 @@
       id: function (id) {
         return this.attr('id', id)
       },
-      
+
       // Show element
       show: function () {
         return this.style('display', '')
@@ -920,7 +920,7 @@
       // Import raw svg
       svg: function (svg) {
       // create temporary holder
-        var well = document.createElement('svg')
+      var well = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
         // act as a setter if svg is given
         if (svg && this instanceof SVG.Parent) {
@@ -933,7 +933,7 @@
           // otherwise act as a getter
         } else {
         // create a wrapping svg element in case of partial content
-          well.appendChild(svg = document.createElement('svg'))
+        well.appendChild(svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'));
 
           // write svgjs data to the dom
           this.writeDataToDom()
@@ -947,7 +947,7 @@
 
         return this
       },
-      
+
       // write svgjs data to the dom
       writeDataToDom: function () {
       // dump variables recursively
@@ -1084,7 +1084,7 @@
      * @param delay Duration of delay in milliseconds
      * @return this.target()
      */
-     
+
 
       /**
      * sets or returns the target of this animation
@@ -1251,9 +1251,9 @@
 
         return this.clearCurrent()
       },
-    
-    
-     
+
+
+
       after: function (fn) {
         var c = this.last(),
           wrapper = function wrapper (e) {
@@ -1508,7 +1508,7 @@
 
         return this
       },
-    
+
     }
 
   })
@@ -1659,7 +1659,7 @@
 
   SVG.BBox.prototype.constructor = SVG.BBox
 
- 
+
   SVG.Matrix = SVG.invent({
   // Initialize
     create: function (source) {
@@ -1722,7 +1722,7 @@
 
         return this
       },
-     
+
       // Multiplies by given matrix
       multiply: function (matrix) {
         return new SVG.Matrix(this.native().multiply(parseMatrix(matrix).native()))
@@ -1735,8 +1735,8 @@
       translate: function (x, y) {
         return new SVG.Matrix(this.native().translate(x || 0, y || 0))
       },
-     
-      
+
+
       // Convert to native SVGMatrix
       native: function () {
       // create new matrix
@@ -1816,8 +1816,8 @@
 
         return this
       },
-      
-      
+
+
 
     }
 
@@ -1898,7 +1898,7 @@
       return this
     }
   })
-  
+
   SVG.extend(SVG.Element, {
   // Add transformations
     transform: function (o, relative) {
@@ -1927,13 +1927,13 @@
           ? matrix.multiply(new SVG.Matrix(o))
         // absolute
           : new SVG.Matrix(o)
-      } 
+      }
 
       return this.attr('transform', matrix)
     }
   })
 
- 
+
 
   SVG.extend(SVG.Element, {
   // Reset all transformations
@@ -2016,10 +2016,10 @@
 
   })
 
-  
 
 
- 
+
+
   SVG.extend(SVG.Element, {
   // Dynamic style generator
     style: function (s, v) {
@@ -2335,7 +2335,7 @@
     // Move over x-axis
       x: function (x) {
         return x == null ? this.transform('x') : this.transform({ x: x - this.x() }, true)
-      },     
+      },
     },
 
     // Add parent method
@@ -2402,7 +2402,7 @@
         if (!this.node.parentNode || this.node.parentNode.nodeName == '#document') return null
         return this.node.parentNode
       },
-      
+
 
       // Removes the doc from the DOM
       remove: function () {
@@ -2452,12 +2452,12 @@
   //
   SVG.extend(SVG.Element, {
   // Get all siblings, including myself
-    
+
 
   })
- 
 
- 
+
+
   SVG.Gradient = SVG.invent({
   // Initialize node
     create: function (type) {
@@ -2961,65 +2961,65 @@
 
     // Add class methods
     extend: {
-      // (re)load image	
-      load: function (url) {	
-        if (!url) return this	
+      // (re)load image
+      load: function (url) {
+        if (!url) return this
 
-        var self = this,	
-          img = new window.Image()	
+        var self = this,
+          img = new window.Image()
 
-        // preload image	
-        SVG.on(img, 'load', function () {	
-          SVG.off(img)	
+        // preload image
+        SVG.on(img, 'load', function () {
+          SVG.off(img)
 
-          var p = self.parent(SVG.Pattern)	
+          var p = self.parent(SVG.Pattern)
 
-          if (p === null) return	
+          if (p === null) return
 
-          // ensure image size	
-          if (self.width() == 0 && self.height() == 0) { self.size(img.width, img.height) }	
+          // ensure image size
+          if (self.width() == 0 && self.height() == 0) { self.size(img.width, img.height) }
 
-          // ensure pattern size if not set	
-          if (p && p.width() == 0 && p.height() == 0) { p.size(self.width(), self.height()) }	
+          // ensure pattern size if not set
+          if (p && p.width() == 0 && p.height() == 0) { p.size(self.width(), self.height()) }
 
-          // callback	
-          if (typeof self._loaded === 'function') {	
-            self._loaded.call(self, {	
-              width: img.width,	
-              height: img.height,	
-              ratio: img.width / img.height,	
-              url: url	
-            })	
-          }	
-        })	
+          // callback
+          if (typeof self._loaded === 'function') {
+            self._loaded.call(self, {
+              width: img.width,
+              height: img.height,
+              ratio: img.width / img.height,
+              url: url
+            })
+          }
+        })
 
-        SVG.on(img, 'error', function (e) {	
-          SVG.off(img)	
+        SVG.on(img, 'error', function (e) {
+          SVG.off(img)
 
-          if (typeof self._error === 'function') {	
-            self._error.call(self, e)	
-          }	
-        })	
+          if (typeof self._error === 'function') {
+            self._error.call(self, e)
+          }
+        })
 
-        return this.attr('href', (img.src = this.src = url), SVG.xlink)	
-      },	
-      // Add loaded callback	
-      loaded: function (loaded) {	
-        this._loaded = loaded	
-        return this	
-      },	
+        return this.attr('href', (img.src = this.src = url), SVG.xlink)
+      },
+      // Add loaded callback
+      loaded: function (loaded) {
+        this._loaded = loaded
+        return this
+      },
 
-      error: function (error) {	
-        this._error = error	
-        return this	
+      error: function (error) {
+        this._error = error
+        return this
       }
     },
 
     // Add parent method
     construct: {
-      // create image element, load image and set its size	
-      image: function (source, width, height) {	
-        return this.put(new SVG.Image()).load(source).size(width || 0, height || width || 0)	
+      // create image element, load image and set its size
+      image: function (source, width, height) {
+        return this.put(new SVG.Image()).load(source).size(width || 0, height || width || 0)
       }
     }
 
@@ -3307,9 +3307,9 @@
       }
     }
   })
-  
-  
- 
+
+
+
   // Define list of available attributes for stroke and fill
   var sugar = {
     stroke: ['color', 'width', 'opacity', 'linecap', 'linejoin', 'miterlimit', 'dasharray', 'dashoffset'],
@@ -3340,7 +3340,7 @@
   })
 
   SVG.extend(SVG.Element, SVG.FX, {
-  
+
     // Map translate to transform
     translate: function (x, y) {
       return this.transform({ x: x, y: y })
@@ -3361,7 +3361,7 @@
     dy: function (y) {
       return this.y(new SVG.Number(y).plus(this instanceof SVG.FX ? 0 : this.y()), true)
     },
-   
+
   })
 
 
@@ -3376,7 +3376,7 @@
     }
   })
 
-  
+
   SVG.Set = SVG.invent({
   // Initialize
     create: function (members) {
@@ -3444,7 +3444,7 @@
       valueOf: function () {
         return this.members
       },
-      
+
     },
 
     // Add parent method
@@ -3504,7 +3504,7 @@
   }
 
   SVG.extend(SVG.Element, {
- 
+
   })
   SVG.extend(SVG.Element, {
   // Remember arbitrary data
@@ -3735,22 +3735,22 @@
   // Create matrix array for looping
   var abcdef = 'abcdef'.split('')
 
- 
-  // Add CustomEvent to IE9 and IE10	
+
+  // Add CustomEvent to IE9 and IE10
   if (typeof window.CustomEvent !== 'function') {
-  // Code from: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent	
-    var CustomEventPoly = function (event, options) {	
-      options = options || { bubbles: false, cancelable: false, detail: undefined }	
-      var e = document.createEvent('CustomEvent')	
-      e.initCustomEvent(event, options.bubbles, options.cancelable, options.detail)	
-      return e	
-    }	
+  // Code from: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
+    var CustomEventPoly = function (event, options) {
+      options = options || { bubbles: false, cancelable: false, detail: undefined }
+      var e = document.createEvent('CustomEvent')
+      e.initCustomEvent(event, options.bubbles, options.cancelable, options.detail)
+      return e
+    }
 
-    CustomEventPoly.prototype = window.Event.prototype	
+    CustomEventPoly.prototype = window.Event.prototype
 
-    SVG.CustomEvent = CustomEventPoly	
-  } else {	
-    SVG.CustomEvent = window.CustomEvent	
+    SVG.CustomEvent = CustomEventPoly
+  } else {
+    SVG.CustomEvent = window.CustomEvent
   }
 
   return SVG


### PR DESCRIPTION
# New Pull Request

While checking out the repo, I noticed that there was an error in the build file. we should be using createElementNS instead of createElement for SVG elements. this fix addresses the issue I noticed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
