### PR TITLE
Implements feature request: #4313

### DIFF
--- a/samples/playground/options.js
+++ b/samples/playground/options.js
@@ -3320,7 +3320,7 @@ export const optionsPattern = {
             'In line/area charts, whether to draw smooth lines or straight lines',
           url: 'https://apexcharts.com/docs/options/stroke/#curve',
           type: String,
-          choices: ['smooth', 'straight', 'stepline'],
+          choices: ['smooth', 'straight', 'stepline', 'linestep'],
           default: 'smooth'
         },
         lineCap: {

--- a/samples/react/line/linestep.html
+++ b/samples/react/line/linestep.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Linestep Chart</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      
+        #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+      
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    
+    <script src="https://cdn.jsdelivr.net/npm/react@16.12/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@16.12/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prop-types@15.7.2/prop-types.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-apexcharts@1.3.6/dist/react-apexcharts.iife.min.js"></script>
+    
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42;
+      Math.random = function() {
+        _seed = _seed * 16807 % 2147483647;
+        return (_seed - 1) / 2147483646;
+      };
+    </script>
+
+    <script src="../../assets/irregular-data-series.js"></script>
+  <script>
+    var ts2 = 1484418600000;
+    var data = [];
+    var spikes = [5, -5, 3, -3, 8, -8]
+    for (var i = 0; i < 30; i++) {
+      ts2 = ts2 + 86400000;
+      var innerArr = [ts2, dataSeries[1][i].value];
+      data.push(innerArr)
+    }
+  </script>
+  </head>
+
+  <body>
+    
+    <div id="app"></div>
+
+    <div id="html">
+      &lt;div id=&quot;chart&quot;&gt;
+  &lt;ReactApexChart options={this.state.options} series={this.state.series} type=&quot;line&quot; height={350} /&gt;
+&lt;/div&gt;
+    </div>
+
+    <script type="text/babel">
+      class ApexChart extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.state = {
+          
+            series: [{
+              data: [34, 44, 54, 21, 12, 43, 33, 23, 66, 66, 58]
+            }],
+            options: {
+              chart: {
+                type: 'line',
+                height: 350
+              },
+              stroke: {
+                curve: 'linestep',
+              },
+              dataLabels: {
+                enabled: false
+              },
+              title: {
+                text: 'Linestep Chart',
+                align: 'left'
+              },
+              markers: {
+                hover: {
+                  sizeOffset: 4
+                }
+              }
+            },
+          
+          
+          };
+        }
+
+      
+
+        render() {
+          return (
+            <div>
+              <div id="chart">
+                <ReactApexChart options={this.state.options} series={this.state.series} type="line" height={350} />
+              </div>
+              <div id="html-dist"></div>
+            </div>
+          );
+        }
+      }
+
+      const domContainer = document.querySelector('#app');
+      ReactDOM.render(React.createElement(ApexChart), domContainer);
+    </script>
+
+    
+  </body>
+</html>

--- a/samples/source/line/linestep.xml
+++ b/samples/source/line/linestep.xml
@@ -1,0 +1,45 @@
+<title>Linestep Chart</title>
+
+<scripts>
+<script src="../../assets/irregular-data-series.js"></script>
+<script>
+  var ts2 = 1484418600000;
+  var data = [];
+  var spikes = [5, -5, 3, -3, 8, -8]
+  for (var i = 0; i < 30; i++) {
+    ts2 = ts2 + 86400000;
+    var innerArr = [ts2, dataSeries[1][i].value];
+    data.push(innerArr)
+  }
+</script>
+</scripts>
+
+<chart>
+<options>
+chart: {
+  type: 'line',
+  height: 350
+},
+stroke: {
+  curve: 'linestep',
+},
+dataLabels: {
+  enabled: false
+},
+title: {
+  text: 'Linestep Chart',
+  align: 'left'
+},
+markers: {
+  hover: {
+    sizeOffset: 4
+  }
+}
+</options>
+
+<series>
+[{
+  data: [34, 44, 54, 21, 12, 43, 33, 23, 66, 66, 58]
+}]
+</series>
+</chart>

--- a/samples/vanilla-js/line/linestep.html
+++ b/samples/vanilla-js/line/linestep.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Linestep Chart</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      
+        #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+      
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    
+    <script src="../../../dist/apexcharts.js"></script>
+    
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42;
+      Math.random = function() {
+        _seed = _seed * 16807 % 2147483647;
+        return (_seed - 1) / 2147483646;
+      };
+    </script>
+
+    <script src="../../assets/irregular-data-series.js"></script>
+  <script>
+    var ts2 = 1484418600000;
+    var data = [];
+    var spikes = [5, -5, 3, -3, 8, -8]
+    for (var i = 0; i < 30; i++) {
+      ts2 = ts2 + 86400000;
+      var innerArr = [ts2, dataSeries[1][i].value];
+      data.push(innerArr)
+    }
+  </script>
+  </head>
+
+  <body>
+     <div id="chart"></div>
+
+    <script>
+      
+        var options = {
+          series: [{
+          data: [34, 44, 54, 21, 12, 43, 33, 23, 66, 66, 58]
+        }],
+          chart: {
+          type: 'line',
+          height: 350
+        },
+        stroke: {
+          curve: 'linestep',
+        },
+        dataLabels: {
+          enabled: false
+        },
+        title: {
+          text: 'Linestep Chart',
+          align: 'left'
+        },
+        markers: {
+          hover: {
+            sizeOffset: 4
+          }
+        }
+        };
+
+        var chart = new ApexCharts(document.querySelector("#chart"), options);
+        chart.render();
+      
+      
+    </script>
+
+    
+  </body>
+</html>

--- a/samples/vue/line/linestep.html
+++ b/samples/vue/line/linestep.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Linestep Chart</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      
+        #chart {
+      max-width: 650px;
+      margin: 35px auto;
+    }
+      
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue-apexcharts"></script>
+    
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42;
+      Math.random = function() {
+        _seed = _seed * 16807 % 2147483647;
+        return (_seed - 1) / 2147483646;
+      };
+    </script>
+
+    <script src="../../assets/irregular-data-series.js"></script>
+  <script>
+    var ts2 = 1484418600000;
+    var data = [];
+    var spikes = [5, -5, 3, -3, 8, -8]
+    for (var i = 0; i < 30; i++) {
+      ts2 = ts2 + 86400000;
+      var innerArr = [ts2, dataSeries[1][i].value];
+      data.push(innerArr)
+    }
+  </script>
+  </head>
+
+  <body>
+    
+    <div id="app">
+      <div id="chart">
+      <apexchart type="line" height="350" :options="chartOptions" :series="series"></apexchart>
+    </div>
+    </div>
+
+    <!-- Below element is just for displaying source code. it is not required. DO NOT USE -->
+    <div id="html">
+      &lt;div id=&quot;chart&quot;&gt;
+        &lt;apexchart type=&quot;line&quot; height=&quot;350&quot; :options=&quot;chartOptions&quot; :series=&quot;series&quot;&gt;&lt;/apexchart&gt;
+      &lt;/div&gt;
+    </div>
+
+    <script>
+      new Vue({
+        el: '#app',
+        components: {
+          apexchart: VueApexCharts,
+        },
+        data: {
+          
+          series: [{
+            data: [34, 44, 54, 21, 12, 43, 33, 23, 66, 66, 58]
+          }],
+          chartOptions: {
+            chart: {
+              type: 'line',
+              height: 350
+            },
+            stroke: {
+              curve: 'linestep',
+            },
+            dataLabels: {
+              enabled: false
+            },
+            title: {
+              text: 'Linestep Chart',
+              align: 'left'
+            },
+            markers: {
+              hover: {
+                sizeOffset: 4
+              }
+            }
+          },
+          
+          
+        },
+        
+      })
+    </script>
+    
+  </body>
+</html>

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -875,6 +875,11 @@ class Line {
           linePath + graphics.line(x, null, 'H') + graphics.line(null, y, 'V')
         areaPath =
           areaPath + graphics.line(x, null, 'H') + graphics.line(null, y, 'V')
+      } else if (curve === 'linestep') {
+        linePath =
+          linePath + graphics.line(null, y, 'V') + graphics.line(x, null, 'H')
+        areaPath =
+          areaPath + graphics.line(null, y, 'V') + graphics.line(x, null, 'H')
       } else if (curve === 'straight') {
         linePath = linePath + graphics.line(x, y)
         areaPath = areaPath + graphics.line(x, y)

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -915,7 +915,7 @@ export default class Options {
       },
       stroke: {
         show: true,
-        curve: 'smooth', // "smooth" / "straight" / "monotoneCubic" / "stepline"
+        curve: 'smooth', // "smooth" / "straight" / "monotoneCubic" / "stepline" / "linestep"
         lineCap: 'butt', // round, butt , square
         width: 2,
         colors: undefined, // array of colors

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -342,7 +342,7 @@ type ApexNonAxisChartSeries = number[]
  */
 type ApexStroke = {
   show?: boolean
-  curve?: 'smooth' | 'straight' | 'stepline' | 'monotoneCubic' | ('smooth' | 'straight' | 'stepline' | 'monotoneCubic')[]
+  curve?: 'smooth' | 'straight' | 'stepline' | 'linestep' | 'monotoneCubic' | ('smooth' | 'straight' | 'stepline' | 'linestep' | 'monotoneCubic')[]
   lineCap?: 'butt' | 'square' | 'round'
   colors?: string[]
   width?: number | number[]


### PR DESCRIPTION
Provide a "step before" version of the current "step after" line chart.

API:
Retain the existing "stepline" curve type for backward compatibility and denote the new type as "linestep".

Perhaps read these as "step follows line" and "line follows step" respectively.

Example:

stroke: {
	curve: 'linestep'
}

Add e2e sample: source/line/linestep.xml and derived (built) samples.

Fixes #4313

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

![fc3noor2 (1)](https://github.com/apexcharts/apexcharts.js/assets/159597299/da0ca49d-4774-4ef4-8660-aeec5aacd2fe)

![fc3noor2](https://github.com/apexcharts/apexcharts.js/assets/159597299/ea83eb94-aa2d-4d3d-9b3c-90dfdf563e8d)
