### PR TITLE
Fix misalignment of chart to axis boundary in reverse bar charts.

### DIFF
--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -377,7 +377,7 @@ class Grid {
 
         let xAxis = new XAxis(this.ctx)
         xAxis.drawXaxisTicks(x1, 0, w.globals.dom.elGraphical)
-        x1 = x1 + w.globals.gridWidth / xCount + 0.3
+        x1 = x1 + w.globals.gridWidth / xCount
         x2 = x1
       }
     }


### PR DESCRIPTION

Fixes #4314

The issue can also be seen in the demo chart:
https://apexcharts.com/javascript-chart-demos/bar-charts/reversed-bar-chart/

Or more clearly in the sample: reversed-bar.html

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
