### PR TITLE
Multiple-yaxis-scales, 3 series with 2 scales demo was broken by 3.47.0

### DIFF
--- a/samples/react/mixed/multiple-yaxes.html
+++ b/samples/react/mixed/multiple-yaxes.html
@@ -114,7 +114,6 @@
               },
               yaxis: [
                 {
-                  min: 0,
                   seriesName: 'Income',
                   axisTicks: {
                     show: true,
@@ -139,7 +138,6 @@
                   }
                 },
                 {
-                  min: 0,
                   seriesName: 'Cashflow',
                   opposite: true,
                   axisTicks: {

--- a/samples/source/mixed/multiple-yaxes.xml
+++ b/samples/source/mixed/multiple-yaxes.xml
@@ -38,7 +38,6 @@ xaxis: {
 },
 yaxis: [
   {
-    min: 0,
     seriesName: 'Income',
     axisTicks: {
       show: true,
@@ -63,7 +62,6 @@ yaxis: [
     }
   },
   {
-    min: 0,
     seriesName: 'Cashflow',
     opposite: true,
     axisTicks: {

--- a/samples/vanilla-js/mixed/multiple-yaxes.html
+++ b/samples/vanilla-js/mixed/multiple-yaxes.html
@@ -97,7 +97,6 @@
         },
         yaxis: [
           {
-            min: 0,
             seriesName: 'Income',
             axisTicks: {
               show: true,
@@ -122,7 +121,6 @@
             }
           },
           {
-            min: 0,
             seriesName: 'Cashflow',
             opposite: true,
             axisTicks: {

--- a/samples/vue/mixed/multiple-yaxes.html
+++ b/samples/vue/mixed/multiple-yaxes.html
@@ -117,7 +117,6 @@
             },
             yaxis: [
               {
-                min: 0,
                 seriesName: 'Income',
                 axisTicks: {
                   show: true,
@@ -142,7 +141,6 @@
                 }
               },
               {
-                min: 0,
                 seriesName: 'Cashflow',
                 opposite: true,
                 axisTicks: {

--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -377,7 +377,7 @@ class Grid {
 
         let xAxis = new XAxis(this.ctx)
         xAxis.drawXaxisTicks(x1, 0, w.globals.dom.elGraphical)
-        x1 = x1 + w.globals.gridWidth / xCount + 0.3
+        x1 = x1 + w.globals.gridWidth / xCount
         x2 = x1
       }
     }


### PR DESCRIPTION
# New Pull Request

Multiple-yaxis-scales, 3 series with 2 scales demo was broken by 3.47.0 after the introduction of the new yaxis:seriesName as an array feature. Refactored some of that code.

Miscellaneous:
Remove yaxis.min: 0 from the bar axes in sample as not required.

Fixes #4323

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
