### PR TITLE
Multiple-yaxis-scales, 3 series with 2 scales demo was broken by 3.47.0

### DIFF
--- a/samples/react/column/stacked-column-with-line-new.html
+++ b/samples/react/column/stacked-column-with-line-new.html
@@ -290,7 +290,8 @@
                 labels: {
                   showDuplicates: false,
                   formatter: function(value) {
-                    return value?.toFixed(0) // Value is undefined if all series are collapsed
+                    // Value is undefined if all series are collapsed
+                    return value !== undefined ? value.toFixed(0) : ''
                   }
                 }
               },

--- a/samples/react/column/stacked-column-with-line.html
+++ b/samples/react/column/stacked-column-with-line.html
@@ -290,7 +290,8 @@
                 labels: {
                   showDuplicates: false,
                   formatter: function(value) {
-                    return value?.toFixed(0) // Value is undefined if all series are collapsed
+                    // Value is undefined if all series are collapsed
+                    return value !== undefined ? value.toFixed(0) : ''
                   }
                 }
               },

--- a/samples/react/mixed/multiple-yaxes.html
+++ b/samples/react/mixed/multiple-yaxes.html
@@ -114,7 +114,6 @@
               },
               yaxis: [
                 {
-                  min: 0,
                   seriesName: 'Income',
                   axisTicks: {
                     show: true,
@@ -139,7 +138,6 @@
                   }
                 },
                 {
-                  min: 0,
                   seriesName: 'Cashflow',
                   opposite: true,
                   axisTicks: {

--- a/samples/source/column/stacked-column-with-line-new.xml
+++ b/samples/source/column/stacked-column-with-line-new.xml
@@ -71,7 +71,8 @@ xaxis: {
   labels: {
     showDuplicates: false,
     formatter: function(value) {
-      return value?.toFixed(0) // Value is undefined if all series are collapsed
+      // Value is undefined if all series are collapsed
+      return value !== undefined ? value.toFixed(0) : ''
     }
   }
 },

--- a/samples/source/column/stacked-column-with-line.xml
+++ b/samples/source/column/stacked-column-with-line.xml
@@ -71,7 +71,8 @@ xaxis: {
   labels: {
     showDuplicates: false,
     formatter: function(value) {
-      return value?.toFixed(0) // Value is undefined if all series are collapsed
+      // Value is undefined if all series are collapsed
+      return value !== undefined ? value.toFixed(0) : ''
     }
   }
 },

--- a/samples/source/mixed/multiple-yaxes.xml
+++ b/samples/source/mixed/multiple-yaxes.xml
@@ -38,7 +38,6 @@ xaxis: {
 },
 yaxis: [
   {
-    min: 0,
     seriesName: 'Income',
     axisTicks: {
       show: true,
@@ -63,7 +62,6 @@ yaxis: [
     }
   },
   {
-    min: 0,
     seriesName: 'Cashflow',
     opposite: true,
     axisTicks: {

--- a/samples/vanilla-js/column/stacked-column-with-line-new.html
+++ b/samples/vanilla-js/column/stacked-column-with-line-new.html
@@ -273,7 +273,8 @@
           labels: {
             showDuplicates: false,
             formatter: function(value) {
-              return value?.toFixed(0) // Value is undefined if all series are collapsed
+              // Value is undefined if all series are collapsed
+              return value !== undefined ? value.toFixed(0) : ''
             }
           }
         },

--- a/samples/vanilla-js/column/stacked-column-with-line.html
+++ b/samples/vanilla-js/column/stacked-column-with-line.html
@@ -273,7 +273,8 @@
           labels: {
             showDuplicates: false,
             formatter: function(value) {
-              return value?.toFixed(0) // Value is undefined if all series are collapsed
+              // Value is undefined if all series are collapsed
+              return value !== undefined ? value.toFixed(0) : ''
             }
           }
         },

--- a/samples/vanilla-js/mixed/multiple-yaxes.html
+++ b/samples/vanilla-js/mixed/multiple-yaxes.html
@@ -97,7 +97,6 @@
         },
         yaxis: [
           {
-            min: 0,
             seriesName: 'Income',
             axisTicks: {
               show: true,
@@ -122,7 +121,6 @@
             }
           },
           {
-            min: 0,
             seriesName: 'Cashflow',
             opposite: true,
             axisTicks: {

--- a/samples/vue/column/stacked-column-with-line-new.html
+++ b/samples/vue/column/stacked-column-with-line-new.html
@@ -293,7 +293,8 @@
               labels: {
                 showDuplicates: false,
                 formatter: function(value) {
-                  return value?.toFixed(0) // Value is undefined if all series are collapsed
+                  // Value is undefined if all series are collapsed
+                  return value !== undefined ? value.toFixed(0) : ''
                 }
               }
             },

--- a/samples/vue/column/stacked-column-with-line.html
+++ b/samples/vue/column/stacked-column-with-line.html
@@ -293,7 +293,8 @@
               labels: {
                 showDuplicates: false,
                 formatter: function(value) {
-                  return value?.toFixed(0) // Value is undefined if all series are collapsed
+                  // Value is undefined if all series are collapsed
+                  return value !== undefined ? value.toFixed(0) : ''
                 }
               }
             },

--- a/samples/vue/mixed/multiple-yaxes.html
+++ b/samples/vue/mixed/multiple-yaxes.html
@@ -117,7 +117,6 @@
             },
             yaxis: [
               {
-                min: 0,
                 seriesName: 'Income',
                 axisTicks: {
                   show: true,
@@ -142,7 +141,6 @@
                 }
               },
               {
-                min: 0,
                 seriesName: 'Cashflow',
                 opposite: true,
                 axisTicks: {

--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -42,6 +42,7 @@ class Bar {
       this.baseLineInvertedY = xyRatios.baseLineInvertedY
     }
     this.yaxisIndex = 0
+    this.translationsIndex = 0
     this.seriesLen = 0
     this.pathArr = []
 
@@ -126,8 +127,10 @@ class Bar {
       let barWidth = 0
 
       if (this.yRatio.length > 1) {
-        this.yaxisIndex = realIndex
+        this.yaxisIndex = w.globals.seriesYAxisReverseMap[realIndex]
+        this.translationsIndex = realIndex
       }
+      let translationsIndex = this.translationsIndex
 
       this.isReversed =
         w.config.yaxis[this.yaxisIndex] &&
@@ -182,6 +185,7 @@ class Bar {
             i,
             j,
             realIndex,
+            translationsIndex,
             bc,
           },
           x,
@@ -204,7 +208,7 @@ class Bar {
             barWidth,
             zeroH,
           })
-          barHeight = this.series[i][j] / this.yRatio[this.yaxisIndex]
+          barHeight = this.series[i][j] / this.yRatio[translationsIndex]
         }
 
         let pathFill = this.barHelpers.getPathFillColor(series, i, j, realIndex)
@@ -511,6 +515,7 @@ class Bar {
     let w = this.w
 
     let realIndex = indexes.realIndex
+    let translationsIndex = indexes.translationsIndex
     let i = indexes.i
     let j = indexes.j
     let bc = indexes.bc
@@ -540,7 +545,7 @@ class Bar {
       }
     }
 
-    y = this.barHelpers.getYForValue(this.series[i][j], zeroH)
+    y = this.barHelpers.getYForValue(this.series[i][j], zeroH, translationsIndex)
 
     const paths = this.barHelpers.getColumnPaths({
       barXPosition,
@@ -549,7 +554,7 @@ class Bar {
       y2: y,
       strokeWidth,
       series: this.series,
-      realIndex: indexes.realIndex,
+      realIndex: realIndex,
       i,
       j,
       w,
@@ -573,7 +578,7 @@ class Bar {
       pathFrom: paths.pathFrom,
       x,
       y,
-      goalY: this.barHelpers.getGoalValues('y', null, zeroH, i, j),
+      goalY: this.barHelpers.getGoalValues('y', null, zeroH, i, j, translationsIndex),
       barXPosition,
       barWidth,
     }

--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -61,8 +61,10 @@ class BarStacked extends Bar {
 
       let realIndex = w.globals.comboCharts ? seriesIndex[i] : i
 
+      let translationsIndex = 0
       if (this.yRatio.length > 1) {
-        this.yaxisIndex = realIndex
+        this.yaxisIndex = w.globals.seriesYAxisReverseMap[realIndex][0]
+        translationsIndex = realIndex
       }
 
       this.isReversed =
@@ -97,7 +99,8 @@ class BarStacked extends Bar {
         xDivision,
         yDivision,
         zeroH,
-        zeroW
+        zeroW,
+        translationsIndex
       )
       y = initPositions.y
       barHeight = initPositions.barHeight
@@ -126,7 +129,7 @@ class BarStacked extends Bar {
       for (let j = 0; j < w.globals.dataPoints; j++) {
         const strokeWidth = this.barHelpers.getStrokeWidth(i, j, realIndex)
         const commonPathOpts = {
-          indexes: { i, j, realIndex, bc },
+          indexes: { i, j, realIndex, translationsIndex, bc },
           strokeWidth,
           x,
           y,
@@ -150,7 +153,7 @@ class BarStacked extends Bar {
             barWidth,
             zeroH,
           })
-          barHeight = this.series[i][j] / this.yRatio[this.yaxisIndex]
+          barHeight = this.series[i][j] / this.yRatio[translationsIndex]
         }
 
         const barGoalLine = this.barHelpers.drawGoalLine({
@@ -214,7 +217,7 @@ class BarStacked extends Bar {
     return ret
   }
 
-  initialPositions(x, y, xDivision, yDivision, zeroH, zeroW) {
+  initialPositions(x, y, xDivision, yDivision, zeroH, zeroW, translationsIndex) {
     let w = this.w
 
     let barHeight, barWidth
@@ -257,9 +260,9 @@ class BarStacked extends Bar {
       }
       zeroH =
         w.globals.gridHeight -
-        this.baseLineY[this.yaxisIndex] -
+        this.baseLineY[translationsIndex] -
         (this.isReversed ? w.globals.gridHeight : 0) +
-        (this.isReversed ? this.baseLineY[this.yaxisIndex] * 2 : 0)
+        (this.isReversed ? this.baseLineY[translationsIndex] * 2 : 0)
 
       // initial x position is one third of barWidth
       x = w.globals.padHorizontal + (xDivision - barWidth) / 2
@@ -297,6 +300,7 @@ class BarStacked extends Bar {
     let barXPosition
     let i = indexes.i
     let j = indexes.j
+    let translationsIndex = indexes.translationsIndex
 
     let prevBarW = 0
     for (let k = 0; k < this.groupCtx.prevXF.length; k++) {
@@ -369,7 +373,7 @@ class BarStacked extends Bar {
     return {
       pathTo: paths.pathTo,
       pathFrom: paths.pathFrom,
-      goalX: this.barHelpers.getGoalValues('x', zeroW, null, i, j),
+      goalX: this.barHelpers.getGoalValues('x', zeroW, null, i, j, translationsIndex),
       barYPosition,
       x,
       y,
@@ -391,6 +395,7 @@ class BarStacked extends Bar {
     let i = indexes.i
     let j = indexes.j
     let bc = indexes.bc
+    let translationsIndex = indexes.translationsIndex
 
     if (w.globals.isXNumeric) {
       let seriesVal = w.globals.seriesX[i][j]
@@ -485,9 +490,9 @@ class BarStacked extends Bar {
     if (this.series[i][j]) {
       y =
         barYPosition -
-        this.series[i][j] / this.yRatio[this.yaxisIndex] +
+        this.series[i][j] / this.yRatio[translationsIndex] +
         (this.isReversed
-          ? this.series[i][j] / this.yRatio[this.yaxisIndex]
+          ? this.series[i][j] / this.yRatio[translationsIndex]
           : 0) *
           2
     } else {
@@ -500,7 +505,7 @@ class BarStacked extends Bar {
       barWidth,
       y1: barYPosition,
       y2: y,
-      yRatio: this.yRatio[this.yaxisIndex],
+      yRatio: this.yRatio[translationsIndex],
       strokeWidth: this.strokeWidth,
       series: this.series,
       seriesGroup,

--- a/src/charts/BoxCandleStick.js
+++ b/src/charts/BoxCandleStick.js
@@ -66,8 +66,10 @@ class BoxCandleStick extends Bar {
       let barHeight = 0
       let barWidth = 0
 
+      let translationsIndex = 0
       if (this.yRatio.length > 1) {
-        this.yaxisIndex = realIndex
+        this.yaxisIndex = w.globals.seriesYAxisReverseMap[realIndex][0]
+        translationsIndex = realIndex
       }
 
       let initPositions = this.barHelpers.initialPositions()
@@ -98,7 +100,8 @@ class BoxCandleStick extends Bar {
           indexes: {
             i,
             j,
-            realIndex
+            realIndex,
+            translationsIndex
           },
           x,
           y,
@@ -201,7 +204,7 @@ class BoxCandleStick extends Bar {
       color = [this.boxOptions.colors.lower, this.boxOptions.colors.upper]
     }
 
-    const yRatio = this.yRatio[this.yaxisIndex]
+    const yRatio = this.yRatio[indexes.translationsIndex]
     let realIndex = indexes.realIndex
 
     const ohlc = this.getOHLCValue(realIndex, j)

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -62,6 +62,8 @@ class Line {
       series = this.lineHelpers.sameValueSeriesFix(i, series)
 
       let realIndex = w.globals.comboCharts ? seriesIndex[i] : i
+      let translationsIndex = this.yRatio.length > 1 ? realIndex: 0
+
 
       this._initSerieVariables(series, i, realIndex)
 
@@ -97,6 +99,7 @@ class Line {
         series,
         prevY,
         lineYPosition,
+        translationsIndex
       })
       prevY = firstPrevY.prevY
       if (w.config.stroke.curve === 'monotonCubic' && series[i][0] === null) {
@@ -116,6 +119,7 @@ class Line {
           series: seriesRangeEnd,
           prevY: prevY2,
           lineYPosition,
+          translationsIndex
         })
         prevY2 = firstPrevY2.prevY
         pY2 = prevY2
@@ -136,6 +140,7 @@ class Line {
         type,
         series,
         realIndex,
+        translationsIndex,
         i,
         x,
         y,
@@ -221,8 +226,10 @@ class Line {
       ? w.config.stroke.width[realIndex]
       : w.config.stroke.width
 
+    let translationsIndex = 0
     if (this.yRatio.length > 1) {
-      this.yaxisIndex = realIndex
+      this.yaxisIndex = w.globals.seriesYAxisReverseMap[realIndex]
+      translationsIndex = realIndex
     }
 
     this.isReversed =
@@ -232,9 +239,9 @@ class Line {
     // zeroY is the 0 value in y series which can be used in negative charts
     this.zeroY =
       w.globals.gridHeight -
-      this.baseLineY[this.yaxisIndex] -
+      this.baseLineY[translationsIndex] -
       (this.isReversed ? w.globals.gridHeight : 0) +
-      (this.isReversed ? this.baseLineY[this.yaxisIndex] * 2 : 0)
+      (this.isReversed ? this.baseLineY[translationsIndex] * 2 : 0)
 
     this.areaBottomY = this.zeroY
     if (
@@ -288,7 +295,7 @@ class Line {
       for (let s = 0; s < series[i].length; s++) {
         if (series[i][s] !== null) {
           prevX = this.xDivision * s
-          prevY = this.zeroY - series[i][s] / this.yRatio[this.yaxisIndex]
+          prevY = this.zeroY - series[i][s] / this.yRatio[realIndex]
           linePath = graphics.move(prevX, prevY)
           areaPath = graphics.move(prevX, this.areaBottomY)
           break
@@ -478,6 +485,7 @@ class Line {
     series,
     iterations,
     realIndex,
+    translationsIndex,
     i,
     x,
     y,
@@ -513,8 +521,8 @@ class Line {
     const getY = (_y, lineYPos) => {
       return (
         lineYPos -
-        _y / yRatio[this.yaxisIndex] +
-        (this.isReversed ? _y / yRatio[this.yaxisIndex] : 0) * 2
+        _y / yRatio[translationsIndex] +
+        (this.isReversed ? _y / yRatio[translationsIndex] : 0) * 2
       )
     }
 

--- a/src/charts/Radar.js
+++ b/src/charts/Radar.js
@@ -40,13 +40,14 @@ class Radar {
         : w.globals.gridWidth
 
     this.isLog = w.config.yaxis[0].logarithmic
+    this.logBase = w.config.yaxis[0].logBase
 
     this.coreUtils = new CoreUtils(this.ctx)
     this.maxValue = this.isLog
-      ? this.coreUtils.getLogVal(w.globals.maxY, 0)
+      ? this.coreUtils.getLogVal(this.logBase, w.globals.maxY, 0)
       : w.globals.maxY
     this.minValue = this.isLog
-      ? this.coreUtils.getLogVal(this.w.globals.minY, 0)
+      ? this.coreUtils.getLogVal(this.logBase, this.w.globals.minY, 0)
       : w.globals.minY
 
     this.polygons = w.config.plotOptions.radar.polygons
@@ -122,7 +123,7 @@ class Radar {
         dv = dv + Math.abs(this.minValue)
 
         if (this.isLog) {
-          dv = this.coreUtils.getLogVal(dv, 0)
+          dv = this.coreUtils.getLogVal(this.logBase, dv, 0)
         }
 
         this.dataRadiusOfPercent[i][j] = dv / range

--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -52,8 +52,10 @@ class RangeBar extends Bar {
       let barHeight = 0
       let barWidth = 0
 
+      let translationsIndex = 0
       if (this.yRatio.length > 1) {
-        this.yaxisIndex = realIndex
+        this.yaxisIndex = w.globals.seriesYAxisReverseMap[realIndex][0]
+        translationsIndex = realIndex
       }
 
       let initPositions = this.barHelpers.initialPositions()
@@ -159,7 +161,7 @@ class RangeBar extends Bar {
           }
 
           paths = this.drawRangeColumnPaths({
-            indexes: { i, j, realIndex },
+            indexes: { i, j, realIndex, translationsIndex },
             barWidth,
             barXPosition,
             zeroH,
@@ -319,7 +321,7 @@ class RangeBar extends Bar {
     let i = indexes.i
     let j = indexes.j
 
-    const yRatio = this.yRatio[this.yaxisIndex]
+    const yRatio = this.yRatio[indexes.translationsIndex]
     let realIndex = indexes.realIndex
 
     const range = this.getRangeValue(realIndex, j)
@@ -370,7 +372,13 @@ class RangeBar extends Bar {
       barHeight,
       x,
       y: y2,
-      goalY: this.barHelpers.getGoalValues('y', null, zeroH, i, j),
+      goalY: this.barHelpers.getGoalValues(
+              'y',
+              null,
+              zeroH,
+              i,
+              j,
+              indexes.translationsIndex),
       barXPosition,
     }
   }

--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -128,14 +128,13 @@ export default class Helpers {
 
       zeroH =
         w.globals.gridHeight -
-        this.barCtx.baseLineY[this.barCtx.yaxisIndex] -
+        this.barCtx.baseLineY[this.barCtx.translationsIndex] -
         (this.barCtx.isReversed ? w.globals.gridHeight : 0) +
         (this.barCtx.isReversed
-          ? this.barCtx.baseLineY[this.barCtx.yaxisIndex] * 2
+          ? this.barCtx.baseLineY[this.barCtx.translationsIndex] * 2
           : 0)
 
-      x =
-        w.globals.padHorizontal +
+      x = w.globals.padHorizontal +
         (xDivision - barWidth * this.barCtx.seriesLen) / 2
     }
 
@@ -515,21 +514,21 @@ export default class Helpers {
     return xForVal
   }
 
-  getYForValue(value, zeroH, zeroPositionForNull = true) {
+  getYForValue(value, zeroH, translationsIndex, zeroPositionForNull = true) {
     let yForVal = zeroPositionForNull ? zeroH : null
     if (typeof value !== 'undefined' && value !== null) {
       yForVal =
         zeroH -
-        value / this.barCtx.yRatio[this.barCtx.yaxisIndex] +
+        value / this.barCtx.yRatio[translationsIndex] +
         (this.barCtx.isReversed
-          ? value / this.barCtx.yRatio[this.barCtx.yaxisIndex]
+          ? value / this.barCtx.yRatio[translationsIndex]
           : 0) *
           2
     }
     return yForVal
   }
 
-  getGoalValues(type, zeroW, zeroH, i, j) {
+  getGoalValues(type, zeroW, zeroH, i, j, translationsIndex) {
     const w = this.w
 
     let goals = []
@@ -539,7 +538,7 @@ export default class Helpers {
         [type]:
           type === 'x'
             ? this.getXForValue(value, zeroW, false)
-            : this.getYForValue(value, zeroH, false),
+            : this.getYForValue(value, zeroH, translationsIndex, false),
         attrs,
       })
     }
@@ -600,45 +599,51 @@ export default class Helpers {
     if (this.barCtx.isHorizontal) {
       if (Array.isArray(goalX)) {
         goalX.forEach((goal) => {
-          let sHeight =
-            typeof goal.attrs.strokeHeight !== 'undefined'
-              ? goal.attrs.strokeHeight
-              : barHeight / 2
-          let y = barYPosition + sHeight + barHeight / 2
+          // Need a tiny margin of 1 each side so goals don't disappear at extremeties
+          if (goal.x >= -1 && goal.x <= graphics.w.globals.gridWidth + 1) {
+            let sHeight =
+              typeof goal.attrs.strokeHeight !== 'undefined'
+                ? goal.attrs.strokeHeight
+                : barHeight / 2
+            let y = barYPosition + sHeight + barHeight / 2
 
-          line = graphics.drawLine(
-            goal.x,
-            y - sHeight * 2,
-            goal.x,
-            y,
-            goal.attrs.strokeColor ? goal.attrs.strokeColor : undefined,
-            goal.attrs.strokeDashArray,
-            goal.attrs.strokeWidth ? goal.attrs.strokeWidth : 2,
-            goal.attrs.strokeLineCap
-          )
-          lineGroup.add(line)
+            line = graphics.drawLine(
+              goal.x,
+              y - sHeight * 2,
+              goal.x,
+              y,
+              goal.attrs.strokeColor ? goal.attrs.strokeColor : undefined,
+              goal.attrs.strokeDashArray,
+              goal.attrs.strokeWidth ? goal.attrs.strokeWidth : 2,
+              goal.attrs.strokeLineCap
+            )
+            lineGroup.add(line)
+          }
         })
       }
     } else {
       if (Array.isArray(goalY)) {
         goalY.forEach((goal) => {
-          let sWidth =
-            typeof goal.attrs.strokeWidth !== 'undefined'
-              ? goal.attrs.strokeWidth
-              : barWidth / 2
-          let x = barXPosition + sWidth + barWidth / 2
+          // Need a tiny margin of 1 each side so goals don't disappear at extremeties
+          if (goal.y >= -1 && goal.y <= graphics.w.globals.gridHeight + 1) {
+            let sWidth =
+              typeof goal.attrs.strokeWidth !== 'undefined'
+                ? goal.attrs.strokeWidth
+                : barWidth / 2
+            let x = barXPosition + sWidth + barWidth / 2
 
-          line = graphics.drawLine(
-            x - sWidth * 2,
-            goal.y,
-            x,
-            goal.y,
-            goal.attrs.strokeColor ? goal.attrs.strokeColor : undefined,
-            goal.attrs.strokeDashArray,
-            goal.attrs.strokeHeight ? goal.attrs.strokeHeight : 2,
-            goal.attrs.strokeLineCap
-          )
-          lineGroup.add(line)
+            line = graphics.drawLine(
+              x - sWidth * 2,
+              goal.y,
+              x,
+              goal.y,
+              goal.attrs.strokeColor ? goal.attrs.strokeColor : undefined,
+              goal.attrs.strokeDashArray,
+              goal.attrs.strokeHeight ? goal.attrs.strokeHeight : 2,
+              goal.attrs.strokeLineCap
+            )
+            lineGroup.add(line)
+          }
         })
       }
     }

--- a/src/charts/common/line/Helpers.js
+++ b/src/charts/common/line/Helpers.js
@@ -102,7 +102,7 @@ export default class Helpers {
     }
   }
 
-  determineFirstPrevY({ i, series, prevY, lineYPosition }) {
+  determineFirstPrevY({ i, series, prevY, lineYPosition, translationsIndex }) {
     let w = this.w
     let stackSeries =
       (w.config.chart.stacked && !w.globals.comboCharts) ||
@@ -125,11 +125,9 @@ export default class Helpers {
       }
       prevY =
         lineYPosition -
-        series[i][0] / this.lineCtx.yRatio[this.lineCtx.yaxisIndex] +
-        (this.lineCtx.isReversed
-          ? series[i][0] / this.lineCtx.yRatio[this.lineCtx.yaxisIndex]
-          : 0) *
-          2
+        series[i][0] / this.lineCtx.yRatio[translationsIndex] +
+        (this.lineCtx.isReversed 
+          ? series[i][0] / this.lineCtx.yRatio[translationsIndex] : 0) * 2
     } else {
       // the first value in the current series is null
       if (stackSeries && i > 0 && typeof series[i][0] === 'undefined') {

--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -572,11 +572,14 @@ export default class ZoomPanSelection extends Toolbar {
     let yLowestValue = []
 
     w.config.yaxis.forEach((yaxe, index) => {
+      // We can use the index of any series referenced by the Yaxis
+      // because they will all return the same value.
+      let seriesIndex = w.globals.seriesYAxisMap[index][0]
       yHighestValue.push(
-        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[index] * me.startY
+        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.startY
       )
       yLowestValue.push(
-        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[index] * me.endY
+        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.endY
       )
     })
 

--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -11,102 +11,108 @@ export default class PointAnnotations {
   addPointAnnotation(anno, parent, index) {
     const w = this.w
 
-    let x = this.helpers.getX1X2('x1', anno)
-    let y = this.helpers.getY1Y2('y1', anno)
+    let result = this.helpers.getX1X2('x1', anno)
+    let x = result.x
+    let clipX = result.clipped
+    result = this.helpers.getY1Y2('y1', anno)
+    let y = result.yP
+    let clipY = result.clipped
 
     if (!Utils.isNumber(x)) return
 
-    let optsPoints = {
-      pSize: anno.marker.size,
-      pointStrokeWidth: anno.marker.strokeWidth,
-      pointFillColor: anno.marker.fillColor,
-      pointStrokeColor: anno.marker.strokeColor,
-      shape: anno.marker.shape,
-      pRadius: anno.marker.radius,
-      class: `apexcharts-point-annotation-marker ${anno.marker.cssClass} ${
-        anno.id ? anno.id : ''
-      }`,
-    }
+    if (!(clipY || clipX)) {
+      let optsPoints = {
+        pSize: anno.marker.size,
+        pointStrokeWidth: anno.marker.strokeWidth,
+        pointFillColor: anno.marker.fillColor,
+        pointStrokeColor: anno.marker.strokeColor,
+        shape: anno.marker.shape,
+        pRadius: anno.marker.radius,
+        class: `apexcharts-point-annotation-marker ${anno.marker.cssClass} ${
+          anno.id ? anno.id : ''
+        }`,
+      }
 
-    let point = this.annoCtx.graphics.drawMarker(
-      x + anno.marker.offsetX,
-      y + anno.marker.offsetY,
-      optsPoints
-    )
-
-    parent.appendChild(point.node)
-
-    const text = anno.label.text ? anno.label.text : ''
-
-    let elText = this.annoCtx.graphics.drawText({
-      x: x + anno.label.offsetX,
-      y:
-        y +
-        anno.label.offsetY -
-        anno.marker.size -
-        parseFloat(anno.label.style.fontSize) / 1.6,
-      text,
-      textAnchor: anno.label.textAnchor,
-      fontSize: anno.label.style.fontSize,
-      fontFamily: anno.label.style.fontFamily,
-      fontWeight: anno.label.style.fontWeight,
-      foreColor: anno.label.style.color,
-      cssClass: `apexcharts-point-annotation-label ${
-        anno.label.style.cssClass
-      } ${anno.id ? anno.id : ''}`,
-    })
-
-    elText.attr({
-      rel: index,
-    })
-
-    parent.appendChild(elText.node)
-
-    // TODO: deprecate this as we will use custom
-    if (anno.customSVG.SVG) {
-      let g = this.annoCtx.graphics.group({
-        class:
-          'apexcharts-point-annotations-custom-svg ' + anno.customSVG.cssClass,
-      })
-
-      g.attr({
-        transform: `translate(${x + anno.customSVG.offsetX}, ${
-          y + anno.customSVG.offsetY
-        })`,
-      })
-
-      g.node.innerHTML = anno.customSVG.SVG
-      parent.appendChild(g.node)
-    }
-
-    if (anno.image.path) {
-      let imgWidth = anno.image.width ? anno.image.width : 20
-      let imgHeight = anno.image.height ? anno.image.height : 20
-
-      point = this.annoCtx.addImage({
-        x: x + anno.image.offsetX - imgWidth / 2,
-        y: y + anno.image.offsetY - imgHeight / 2,
-        width: imgWidth,
-        height: imgHeight,
-        path: anno.image.path,
-        appendTo: '.apexcharts-point-annotations',
-      })
-    }
-
-    if (anno.mouseEnter) {
-      point.node.addEventListener(
-        'mouseenter',
-        anno.mouseEnter.bind(this, anno)
+      let point = this.annoCtx.graphics.drawMarker(
+        x + anno.marker.offsetX,
+        y + anno.marker.offsetY,
+        optsPoints
       )
-    }
-    if (anno.mouseLeave) {
-      point.node.addEventListener(
-        'mouseleave',
-        anno.mouseLeave.bind(this, anno)
-      )
-    }
-    if (anno.click) {
-      point.node.addEventListener('click', anno.click.bind(this, anno))
+
+      parent.appendChild(point.node)
+
+      const text = anno.label.text ? anno.label.text : ''
+
+      let elText = this.annoCtx.graphics.drawText({
+        x: x + anno.label.offsetX,
+        y:
+          y +
+          anno.label.offsetY -
+          anno.marker.size -
+          parseFloat(anno.label.style.fontSize) / 1.6,
+        text,
+        textAnchor: anno.label.textAnchor,
+        fontSize: anno.label.style.fontSize,
+        fontFamily: anno.label.style.fontFamily,
+        fontWeight: anno.label.style.fontWeight,
+        foreColor: anno.label.style.color,
+        cssClass: `apexcharts-point-annotation-label ${
+          anno.label.style.cssClass
+        } ${anno.id ? anno.id : ''}`,
+      })
+
+      elText.attr({
+        rel: index,
+      })
+
+      parent.appendChild(elText.node)
+
+      // TODO: deprecate this as we will use custom
+      if (anno.customSVG.SVG) {
+        let g = this.annoCtx.graphics.group({
+          class:
+            'apexcharts-point-annotations-custom-svg ' + anno.customSVG.cssClass,
+        })
+
+        g.attr({
+          transform: `translate(${x + anno.customSVG.offsetX}, ${
+            y + anno.customSVG.offsetY
+          })`,
+        })
+
+        g.node.innerHTML = anno.customSVG.SVG
+        parent.appendChild(g.node)
+      }
+
+      if (anno.image.path) {
+        let imgWidth = anno.image.width ? anno.image.width : 20
+        let imgHeight = anno.image.height ? anno.image.height : 20
+
+        point = this.annoCtx.addImage({
+          x: x + anno.image.offsetX - imgWidth / 2,
+          y: y + anno.image.offsetY - imgHeight / 2,
+          width: imgWidth,
+          height: imgHeight,
+          path: anno.image.path,
+          appendTo: '.apexcharts-point-annotations',
+        })
+      }
+
+      if (anno.mouseEnter) {
+        point.node.addEventListener(
+          'mouseenter',
+          anno.mouseEnter.bind(this, anno)
+        )
+      }
+      if (anno.mouseLeave) {
+        point.node.addEventListener(
+          'mouseleave',
+          anno.mouseLeave.bind(this, anno)
+        )
+      }
+      if (anno.click) {
+        point.node.addEventListener('click', anno.click.bind(this, anno))
+      }
     }
   }
 

--- a/src/modules/annotations/XAxisAnnotations.js
+++ b/src/modules/annotations/XAxisAnnotations.js
@@ -14,7 +14,10 @@ export default class XAnnotations {
   addXaxisAnnotation(anno, parent, index) {
     let w = this.w
 
-    let x1 = this.helpers.getX1X2('x1', anno)
+    let result = this.helpers.getX1X2('x1', anno)
+    let x1 = result.x
+    let clipX1 = result.clipped
+    let clipX2 = true
     let x2
 
     const text = anno.label.text
@@ -24,89 +27,97 @@ export default class XAnnotations {
     if (!Utils.isNumber(x1)) return
 
     if (anno.x2 === null || typeof anno.x2 === 'undefined') {
-      let line = this.annoCtx.graphics.drawLine(
-        x1 + anno.offsetX, // x1
-        0 + anno.offsetY, // y1
-        x1 + anno.offsetX, // x2
-        w.globals.gridHeight + anno.offsetY, // y2
-        anno.borderColor, // lineColor
-        strokeDashArray, //dashArray
-        anno.borderWidth
-      )
-      parent.appendChild(line.node)
-      if (anno.id) {
-        line.node.classList.add(anno.id)
+      if (!clipX1) {
+        let line = this.annoCtx.graphics.drawLine(
+          x1 + anno.offsetX, // x1
+          0 + anno.offsetY, // y1
+          x1 + anno.offsetX, // x2
+          w.globals.gridHeight + anno.offsetY, // y2
+          anno.borderColor, // lineColor
+          strokeDashArray, //dashArray
+          anno.borderWidth
+        )
+        parent.appendChild(line.node)
+        if (anno.id) {
+          line.node.classList.add(anno.id)
+        }
       }
     } else {
-      x2 = this.helpers.getX1X2('x2', anno)
+      let result = this.helpers.getX1X2('x2', anno)
+      x2 = result.x
+      clipX2 = result.clipped
+      
+      if (!(clipX1 && clipX2)) {
+        if (x2 < x1) {
+          let temp = x1
+          x1 = x2
+          x2 = temp
+        }
 
-      if (x2 < x1) {
-        let temp = x1
-        x1 = x2
-        x2 = temp
-      }
-
-      let rect = this.annoCtx.graphics.drawRect(
-        x1 + anno.offsetX, // x1
-        0 + anno.offsetY, // y1
-        x2 - x1, // x2
-        w.globals.gridHeight + anno.offsetY, // y2
-        0, // radius
-        anno.fillColor, // color
-        anno.opacity, // opacity,
-        1, // strokeWidth
-        anno.borderColor, // strokeColor
-        strokeDashArray // stokeDashArray
-      )
-      rect.node.classList.add('apexcharts-annotation-rect')
-      rect.attr('clip-path', `url(#gridRectMask${w.globals.cuid})`)
-      parent.appendChild(rect.node)
-      if (anno.id) {
-        rect.node.classList.add(anno.id)
+        let rect = this.annoCtx.graphics.drawRect(
+          x1 + anno.offsetX, // x1
+          0 + anno.offsetY, // y1
+          x2 - x1, // x2
+          w.globals.gridHeight + anno.offsetY, // y2
+          0, // radius
+          anno.fillColor, // color
+          anno.opacity, // opacity,
+          1, // strokeWidth
+          anno.borderColor, // strokeColor
+          strokeDashArray // stokeDashArray
+        )
+        rect.node.classList.add('apexcharts-annotation-rect')
+        rect.attr('clip-path', `url(#gridRectMask${w.globals.cuid})`)
+        parent.appendChild(rect.node)
+        if (anno.id) {
+          rect.node.classList.add(anno.id)
+        }
       }
     }
 
-    let textRects = this.annoCtx.graphics.getTextRects(
-      text,
-      parseFloat(anno.label.style.fontSize)
-    )
-    let textY =
-      anno.label.position === 'top'
-        ? 4
-        : anno.label.position === 'center'
-        ? w.globals.gridHeight / 2 +
-          (anno.label.orientation === 'vertical' ? textRects.width / 2 : 0)
-        : w.globals.gridHeight
+    if (!(clipX1 && clipX2)) {
+      let textRects = this.annoCtx.graphics.getTextRects(
+        text,
+        parseFloat(anno.label.style.fontSize)
+      )
+      let textY =
+        anno.label.position === 'top'
+          ? 4
+          : anno.label.position === 'center'
+          ? w.globals.gridHeight / 2 +
+            (anno.label.orientation === 'vertical' ? textRects.width / 2 : 0)
+          : w.globals.gridHeight
 
-    let elText = this.annoCtx.graphics.drawText({
-      x: x1 + anno.label.offsetX,
-      y:
-        textY +
-        anno.label.offsetY -
-        (anno.label.orientation === 'vertical'
-          ? anno.label.position === 'top'
-            ? textRects.width / 2 - 12
-            : -textRects.width / 2
-          : 0),
-      text,
-      textAnchor: anno.label.textAnchor,
-      fontSize: anno.label.style.fontSize,
-      fontFamily: anno.label.style.fontFamily,
-      fontWeight: anno.label.style.fontWeight,
-      foreColor: anno.label.style.color,
-      cssClass: `apexcharts-xaxis-annotation-label ${
-        anno.label.style.cssClass
-      } ${anno.id ? anno.id : ''}`
-    })
+      let elText = this.annoCtx.graphics.drawText({
+        x: x1 + anno.label.offsetX,
+        y:
+          textY +
+          anno.label.offsetY -
+          (anno.label.orientation === 'vertical'
+            ? anno.label.position === 'top'
+              ? textRects.width / 2 - 12
+              : -textRects.width / 2
+            : 0),
+        text,
+        textAnchor: anno.label.textAnchor,
+        fontSize: anno.label.style.fontSize,
+        fontFamily: anno.label.style.fontFamily,
+        fontWeight: anno.label.style.fontWeight,
+        foreColor: anno.label.style.color,
+        cssClass: `apexcharts-xaxis-annotation-label ${
+          anno.label.style.cssClass
+        } ${anno.id ? anno.id : ''}`
+      })
 
-    elText.attr({
-      rel: index
-    })
+      elText.attr({
+        rel: index
+      })
 
-    parent.appendChild(elText.node)
+      parent.appendChild(elText.node)
 
-    // after placing the annotations on svg, set any vertically placed annotations
-    this.annoCtx.helpers.setOrientations(anno, index)
+      // after placing the annotations on svg, set any vertically placed annotations
+      this.annoCtx.helpers.setOrientations(anno, index)
+    }
   }
   drawXAxisAnnotations() {
     let w = this.w

--- a/src/modules/axes/AxesUtils.js
+++ b/src/modules/axes/AxesUtils.js
@@ -185,10 +185,10 @@ export default class AxesUtils {
     })
 
     return (
+      allCollapsed ||
       !w.config.yaxis[index].show ||
       (!w.config.yaxis[index].showForNullSeries &&
-        coreUtils.isSeriesNull(index) &&
-        allCollapsed)
+        coreUtils.isSeriesNull(index))
     )
   }
 

--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -377,7 +377,7 @@ class Grid {
 
         let xAxis = new XAxis(this.ctx)
         xAxis.drawXaxisTicks(x1, 0, w.globals.dom.elGraphical)
-        x1 = x1 + w.globals.gridWidth / xCount + 0.3
+        x1 = x1 + w.globals.gridWidth / xCount
         x2 = x1
       }
     }

--- a/src/modules/tooltip/AxesTooltip.js
+++ b/src/modules/tooltip/AxesTooltip.js
@@ -168,10 +168,12 @@ class AxesTooltip {
       const elGrid = ttCtx.getElGrid()
       const seriesBound = elGrid.getBoundingClientRect()
 
-      const hoverY = (clientY - seriesBound.top) * xyRatios.yRatio[index]
-      const height = w.globals.maxYArr[index] - w.globals.minYArr[index]
-
-      const val = w.globals.minYArr[index] + (height - hoverY)
+      // We can use the index of any series referenced by the Yaxis
+      // because they will all return the same value.
+      let seriesIndex = w.globals.seriesYAxisMap[anno.yAxisIndex][0]
+      const hoverY = (clientY - seriesBound.top) * xyRatios.yRatio[seriesIndex]
+      const height = w.globals.maxYArr[seriesIndex] - w.globals.minYArr[seriesIndex]
+      const val = w.globals.minYArr[seriesIndex] + (height - hoverY)
 
       ttCtx.tooltipPosition.moveYCrosshairs(clientY - seriesBound.top)
       ttCtx.yaxisTooltipText[index].innerHTML = lbFormatter(val)


### PR DESCRIPTION
# New Pull Request

Fixes relating to yaxis.seriesName array feature added at revision 3.47.0:
1) The forward and reverse yaxis to series maps had errors.
2) Anything that indexed into various global or context arrays (yaxis array, series working arrays, baseline or ratio arrays, etc), needed to be mapped through the new forward or reverse yaxis to series maps.

Fix historical issue with goals and annotations being drawn when the axis is hidden or outside the grid area when zoomed or panned, or where rectangular area annotation should be clipped.

Fix historical issue: baseLineY calculation not adjusted for logarithmic y axes.

Miscellaneous:
1) Remove yaxis.min: 0 from the bar axes in sample as not required.
2) Fix several calls to CoreUtils.getLogVal(b,d,seriesIndex) that were missing the 'b' (base) argument.
3) Fix what may have been an historical issue with log charts and return 0 for negative or zero values passed to getLogVal(), not just values that equal 0. Negative values appear to cause the chart to misalign with the axis.
4) wrong point annotation x position in sparkline chart.

Fixes #2757
Fixes #3073
Fixes #3421
Fixes #3553
Fixes #4081
Fixes #4241 (maybe)
Fixes #4323

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
