### PR TITLE
[Fix] Use ShadowRoot getElementById() when in ShadowDOM.

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -73,29 +73,28 @@ export default class ApexCharts {
         window.addEventListener('resize', this.windowResizeHandler)
         addResizeListener(this.el.parentNode, this.parentResizeHandler)
 
-        // Add CSS if not already added
-        if (!this.css) {
-          let rootNode = this.el.getRootNode && this.el.getRootNode()
-          let inShadowRoot = Utils.is('ShadowRoot', rootNode)
-          let doc = this.el.ownerDocument
-          let globalCSS = doc.getElementById('apexcharts-css')
+        let rootNode = this.el.getRootNode && this.el.getRootNode()
+        let inShadowRoot = Utils.is('ShadowRoot', rootNode)
+        let doc = this.el.ownerDocument
+        let css = inShadowRoot
+          ? rootNode.getElementById('apexcharts-css')
+          : doc.getElementById('apexcharts-css')
 
-          if (inShadowRoot || !globalCSS) {
-            this.css = document.createElement('style')
-            this.css.id = 'apexcharts-css'
-            this.css.textContent = apexCSS
-            const nonce = this.opts.chart?.nonce || this.w.config.chart.nonce;
-            if (nonce) {
-              this.css.setAttribute('nonce', nonce);
-            }
+        if (!css) {
+          css = document.createElement('style')
+          css.id = 'apexcharts-css'
+          css.textContent = apexCSS
+          const nonce = this.opts.chart?.nonce || this.w.config.chart.nonce;
+          if (nonce) {
+            this.css.setAttribute('nonce', nonce);
+          }
 
-            if (inShadowRoot) {
-              // We are in Shadow DOM, add to shadow root
-              rootNode.prepend(this.css)
-            } else {
-              // Add to <head> of element's document
-              doc.head.appendChild(this.css)
-            }
+          if (inShadowRoot) {
+            // We are in Shadow DOM, add to shadow root
+            rootNode.prepend(css)
+          } else {
+            // Add to <head> of element's document
+            doc.head.appendChild(css)
           }
         }
 


### PR DESCRIPTION
# New Pull Request

The original code checked for the style element by using it's this.css, and when using ng-apexcharts (for example) having multiple components in a ShadowDOM resulted in multiple additions. So it wouldn't actually find the element and always add it again when in ShadowDOM. To solve this, it doesn't cache the style elem (using this.css) and uses a getElementById() from the ShadowRoot instead if in ShadowDOM, otherwise the usual document getElementById(). I've tested it and works nicely in and out of ShadowDOM in my tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
