### PR TITLE
Fixes issue 4340

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -131,6 +131,7 @@ class Line {
         series,
         i,
         realIndex,
+        translationsIndex,
         prevX,
         prevY,
         prevY2,
@@ -285,7 +286,7 @@ class Line {
     this.appendPathFrom = true
   }
 
-  _calculatePathsFrom({ type, series, i, realIndex, prevX, prevY, prevY2 }) {
+  _calculatePathsFrom({ type, series, i, realIndex, translationsIndex, prevX, prevY, prevY2 }) {
     const w = this.w
     const graphics = new Graphics(this.ctx)
     let linePath, areaPath, pathFromLine, pathFromArea
@@ -295,7 +296,7 @@ class Line {
       for (let s = 0; s < series[i].length; s++) {
         if (series[i][s] !== null) {
           prevX = this.xDivision * s
-          prevY = this.zeroY - series[i][s] / this.yRatio[realIndex]
+          prevY = this.zeroY - series[i][s] / this.yRatio[translationsIndex]
           linePath = graphics.move(prevX, prevY)
           areaPath = graphics.move(prevX, this.areaBottomY)
           break

--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -574,13 +574,15 @@ export default class ZoomPanSelection extends Toolbar {
     w.config.yaxis.forEach((yaxe, index) => {
       // We can use the index of any series referenced by the Yaxis
       // because they will all return the same value.
-      let seriesIndex = w.globals.seriesYAxisMap[index][0]
-      yHighestValue.push(
-        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.startY
-      )
-      yLowestValue.push(
-        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.endY
-      )
+      if (w.globals.seriesYAxisMap[index].length > 0) {
+        let seriesIndex = w.globals.seriesYAxisMap[index][0]
+        yHighestValue.push(
+          w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.startY
+        )
+        yLowestValue.push(
+          w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.endY
+        )
+      }
     })
 
     if (

--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -434,11 +434,12 @@ class Grid {
     }
 
     // Draw the grid using ticks from the first unhidden Yaxis,
-    // or yaxis[0] is all hidden.
+    // or yaxis[0] if all are hidden.
     let gridAxisIndex = 0
     while (
-      gridAxisIndex < w.globals.seriesYAxisMap.length &&
-      w.globals.ignoreYAxisIndexes.indexOf(gridAxisIndex) !== -1
+      w.globals.seriesYAxisMap[gridAxisIndex].length === 0
+      && gridAxisIndex < w.globals.seriesYAxisMap.length
+      && w.globals.ignoreYAxisIndexes.indexOf(gridAxisIndex) !== -1
     ) {
       gridAxisIndex++
     }

--- a/src/modules/tooltip/AxesTooltip.js
+++ b/src/modules/tooltip/AxesTooltip.js
@@ -164,7 +164,9 @@ class AxesTooltip {
 
     let lbFormatter = w.globals.yLabelFormatters[index]
 
-    if (ttCtx.yaxisTooltips[index]) {
+    if (ttCtx.yaxisTooltips[index]
+          && w.globals.seriesYAxisMap[index].length > 0
+    ) {
       const elGrid = ttCtx.getElGrid()
       const seriesBound = elGrid.getBoundingClientRect()
 

--- a/tests/unit/multiple-scales.spec.js
+++ b/tests/unit/multiple-scales.spec.js
@@ -160,24 +160,15 @@ describe('Multiple Y-axis Scales', () => {
 
     const minYArr = chart.w.globals.minYArr
     const maxYArr = chart.w.globals.maxYArr
-    const yAxisScale = chart.w.globals.yAxisScale
+    const yAxisMap = chart.w.globals.seriesYAxisMap
+    const yAxisRevMap = chart.w.globals.seriesYAxisReverseMap
 
     expect(minYArr).toEqual([1000000, 1000000, 1000000, 1000000])
 
     expect(maxYArr).toEqual([500000000, 500000000, 500000000, 500000000])
 
-    expect(yAxisScale).toEqual([
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000,100800000,200600000,300400000,400200000,500000000,]
-      },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      }
-    ])
+    expect(yAxisMap).toEqual([[0,1],[2,3]])
+    expect(yAxisRevMap).toEqual([0,0,1,1])
   })
 
   it('should associate series to yaxes according to seriesName then assign remainder to last free axis', () => {
@@ -220,24 +211,67 @@ describe('Multiple Y-axis Scales', () => {
 
     const minYArr = chart.w.globals.minYArr
     const maxYArr = chart.w.globals.maxYArr
-    const yAxisScale = chart.w.globals.yAxisScale
+    const yAxisMap = chart.w.globals.seriesYAxisMap
+    const yAxisRevMap = chart.w.globals.seriesYAxisReverseMap
 
     expect(minYArr).toEqual([1000000, 1000000, 1000000, 1000000])
 
     expect(maxYArr).toEqual([500000000, 500000000, 500000000, 500000000])
 
-    expect(yAxisScale).toEqual([
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000,100800000,200600000,300400000,400200000,500000000,]
+    expect(yAxisMap).toEqual([[0,1],[2,3]])
+    expect(yAxisRevMap).toEqual([0,0,1,1])
+  })
+
+  it('should associate series to yaxes according to seriesName then assign remainder to last axis', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line'
       },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      }
-    ])
+      series: [
+        {
+          name: 'Series A',
+          data: logData
+        },
+        {
+          name: 'Series B',
+          data: logData
+        },
+        {
+          name: 'Series C',
+          data: logData
+        },
+        {
+          name: 'Series D',
+          data: logData
+        }
+      ],
+      yaxis: [
+        {
+          seriesName: ['Series A','Series B'],
+          min: 1000000,
+          max: 500000000,
+          tickAmount: 5,
+        },
+        {
+          seriesName: 'Series C',
+          min: 1000000,
+          max: 500000000,
+          opposite: true
+        }
+      ]
+    })
+
+    const minYArr = chart.w.globals.minYArr
+    const maxYArr = chart.w.globals.maxYArr
+    const yAxisMap = chart.w.globals.seriesYAxisMap
+    const yAxisRevMap = chart.w.globals.seriesYAxisReverseMap
+
+    expect(minYArr).toEqual([1000000, 1000000, 1000000, 1000000])
+
+    expect(maxYArr).toEqual([500000000, 500000000, 500000000, 500000000])
+
+    expect(yAxisMap).toEqual([[0,1],[2,3]])
+    expect(yAxisRevMap).toEqual([0,0,1,1])
   })
 
   it('should associate series to yaxes according to seriesName then assign remainder one-for-one', () => {
@@ -285,29 +319,15 @@ describe('Multiple Y-axis Scales', () => {
 
     const minYArr = chart.w.globals.minYArr
     const maxYArr = chart.w.globals.maxYArr
-    const yAxisScale = chart.w.globals.yAxisScale
+    const yAxisMap = chart.w.globals.seriesYAxisMap
+    const yAxisRevMap = chart.w.globals.seriesYAxisReverseMap
 
     expect(minYArr).toEqual([1000000, 1000000, 1000000, 1000000])
 
     expect(maxYArr).toEqual([500000000, 500000000, 500000000, 500000000])
 
-    expect(yAxisScale).toEqual([
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000,100800000,200600000,300400000,400200000,500000000,]
-      },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      }
-    ])
+    expect(yAxisMap).toEqual([[0,1],[2],[3]])
+    expect(yAxisRevMap).toEqual([0,0,1,2])
   })
 
   it('should associate series to yaxes according to seriesName before assigning remainder one-for-one', () => {
@@ -354,28 +374,14 @@ describe('Multiple Y-axis Scales', () => {
 
     const minYArr = chart.w.globals.minYArr
     const maxYArr = chart.w.globals.maxYArr
-    const yAxisScale = chart.w.globals.yAxisScale
+    const yAxisMap = chart.w.globals.seriesYAxisMap
+    const yAxisRevMap = chart.w.globals.seriesYAxisReverseMap
 
     expect(minYArr).toEqual([1000000, 1000000, 1000000, 1000000])
 
     expect(maxYArr).toEqual([500000000, 500000000, 500000000, 500000000])
 
-    expect(yAxisScale).toEqual([
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000,100800000,200600000,300400000,400200000,500000000,]
-      },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      },
-      {
-        niceMax: 500000000,
-        niceMin: 1000000,
-        result: [1000000, 100800000, 200600000, 300400000, 400200000, 500000000]
-      }
-    ])
+    expect(yAxisMap).toEqual([[2],[0,1],[3]])
+    expect(yAxisRevMap).toEqual([1,1,0,2])
   })
 })


### PR DESCRIPTION
# New Pull Request

Additional fixes for indexing errors using yaxis-series mappings after seriesName-as-an-array feature implementation.

Add additional checks to manage old and new modes.

Unit tests targeting seriesName-as-an-array feature have been modified and expanded to "prove" yaxis-series forward and reverse mapping correctness.

Context:
Backward compatibility requires that various data structures be indexable by either the yaxis index or the series index at different times, which rely on the old one-to-one correspondence [in multi axis charts]. The new seriesName-as-an-array feature removes this correspondence and implements forward and reverse maps to bridge compatibility, nevertheless, every reference into those arrays in the codebase needs to be discovered and adjusted. All instances that have so far been discovered after exhaustive searching have been modified and tested.

Fixes #4340
Fixes #4342
Fixes #4344

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
