### PR TITLE
Fix for #4357

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -282,6 +282,11 @@ export default class Scales {
         } else {
           let yMaxPrev = yMax
           yMax = stepSize * Math.ceil(yMax / stepSize)
+          if (Math.abs(yMax - yMin) / Utils.getGCD(range, stepSize) > maxTicks) {
+            // Use default ticks to compute yMin then shrinkwrap
+            yMax = yMin + stepSize * ticks
+            yMax += stepSize * Math.ceil((yMaxPrev - yMax) / stepSize)
+          }
         }
       }
       range = Math.abs(yMax - yMin)
@@ -312,16 +317,6 @@ export default class Scales {
     ) {
       tiks = range
       stepSize = Math.round(range / tiks)
-    }
-
-    // Record final tiks for use by other series that call niceScale().
-    // Note: some don't, like logarithmicScale(), etc.
-    if (
-        gl.isMultipleYAxis
-        && gl.multiAxisTickAmount == 0
-        && gl.ignoreYAxisIndexes.indexOf(index) < 0
-    ) {
-      gl.multiAxisTickAmount = tiks
     }
 
     if (
@@ -386,6 +381,17 @@ export default class Scales {
       } else {
         stepSize = range / tt
       }
+      tiks = Math.round(range / stepSize)
+    }
+
+    // Record final tiks for use by other series that call niceScale().
+    // Note: some don't, like logarithmicScale(), etc.
+    if (
+        gl.isMultipleYAxis
+        && gl.multiAxisTickAmount == 0
+        && gl.ignoreYAxisIndexes.indexOf(index) < 0
+    ) {
+      gl.multiAxisTickAmount = tiks
     }
 
     // build Y label array.


### PR DESCRIPTION
Add a missing conditional block designed to ensure the range remains a multiple of stepSize when min is defined. Was present in the max case but not the min case.

Record the absolute final tick number used in the grid alignment of following axes, that is, after pruning to maxTicks.

Fixes #4357

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
