### PR TITLE
Updates to improve stacking of line-area type series.

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -52,6 +52,7 @@ class Bar {
       'column',
     ])
 
+    this.columnGroupIndices = []
     const barSeriesIndices = ser.getBarSeriesIndices()
     const coreUtils = new CoreUtils(this.ctx)
     this.stackedSeriesTotals = coreUtils.getStackedSeriesTotals(
@@ -108,6 +109,9 @@ class Bar {
       let xArrj = [] // hold x values of current iterating series
 
       let realIndex = w.globals.comboCharts ? seriesIndex[i] : i
+
+      let {columnGroupIndex} =
+              this.barHelpers.getGroupIndex(realIndex)
 
       // el to which series will be drawn
       let elSeries = graphics.group({
@@ -262,6 +266,7 @@ class Bar {
           pathFill,
           j,
           i,
+          columnGroupIndex,
           pathFrom: paths.pathFrom,
           pathTo: paths.pathTo,
           strokeWidth,
@@ -295,7 +300,7 @@ class Bar {
     lineFill,
     j,
     i,
-    groupIndex, // required in grouped-stacked bars
+    columnGroupIndex,
     pathFrom,
     pathTo,
     strokeWidth,
@@ -408,7 +413,7 @@ class Bar {
       j,
       series,
       realIndex,
-      groupIndex,
+      columnGroupIndex,
       barHeight,
       barWidth,
       barXPosition,

--- a/src/charts/BoxCandleStick.js
+++ b/src/charts/BoxCandleStick.js
@@ -48,6 +48,9 @@ class BoxCandleStick extends Bar {
       let xArrj = [] // hold x values of current iterating series
 
       let realIndex = w.globals.comboCharts ? seriesIndex[i] : i
+      // As BoxCandleStick derives from Bar, we need this to render.
+      let {columnGroupIndex} =
+              this.barHelpers.getGroupIndex(realIndex)
 
       // el to which series will be drawn
       let elSeries = graphics.group({
@@ -161,6 +164,7 @@ class BoxCandleStick extends Bar {
             x,
             y,
             series,
+            columnGroupIndex,
             barHeight,
             barWidth,
             elDataLabelsWrap,

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -54,8 +54,11 @@ class Line {
 
     series = coreUtils.getLogSeries(series)
     this.yRatio = coreUtils.getLogYRatios(this.yRatio)
+    // We call draw() for each series group
+    this.prevSeriesY = []
 
-    // push all series in an array, so we can draw in reverse order (for stacked charts)
+    // push all series in an array, so we can draw in reverse order
+    // (for stacked charts)
     let allSeries = []
 
     for (let i = 0; i < series.length; i++) {
@@ -224,8 +227,8 @@ class Line {
     }
 
     if (w.config.chart.stacked) {
-      for (let s = allSeries.length; s > 0; s--) {
-        ret.add(allSeries[s - 1])
+      for (let s = allSeries.length - 1; s >= 0; s--) {
+        ret.add(allSeries[s])
       }
     } else {
       for (let s = 0; s < allSeries.length; s++) {
@@ -595,15 +598,16 @@ class Line {
           // for the next series, hence find the prevIndex of prev series
           // which is not collapsed - fixes apexcharts.js#1372
           const prevIndex = (pi) => {
-            let pii = pi
-            for (let cpi = 0; cpi < w.globals.series.length; cpi++) {
-              if (w.globals.collapsedSeriesIndices.indexOf(pi) > -1) {
+            for (let pii = pi; pii > 0; pii--) {
+              if (w.globals.collapsedSeriesIndices.indexOf(
+                    seriesIndex?.[pii] || pii
+              ) > -1) {
                 pii--
-                break
+              } else {
+                return pii
               }
             }
-
-            return pii >= 0 ? pii : 0
+            return 0
           }
           lineYPosition = this.prevSeriesY[prevIndex(i - 1)][j + 1]
         } else {

--- a/src/charts/RangeBar.js
+++ b/src/charts/RangeBar.js
@@ -34,6 +34,8 @@ class RangeBar extends Bar {
         zeroW // zeroW is the baseline where 0 meets x axis
 
       let realIndex = w.globals.comboCharts ? seriesIndex[i] : i
+      let {columnGroupIndex} =
+              this.barHelpers.getGroupIndex(realIndex)
 
       // el to which series will be drawn
       let elSeries = graphics.group({
@@ -212,6 +214,7 @@ class RangeBar extends Bar {
           barXPosition,
           barYPosition,
           barWidth,
+          columnGroupIndex,
           elDataLabelsWrap,
           elGoalsMarkers,
           visibleSeries: this.visibleI,

--- a/src/modules/CoreUtils.js
+++ b/src/modules/CoreUtils.js
@@ -116,6 +116,175 @@ class CoreUtils {
     return total
   }
 
+  setSeriesYAxisMappings() {
+    const gl = this.w.globals
+    const cnf = this.w.config
+
+    // The old config method to map multiple series to a y axis is to
+    // include one yaxis config per series but set each yaxis seriesName to the
+    // same series name. This relies on indexing equivalence to map series to
+    // an axis: series[n] => yaxis[n]. This needs to be retained for compatibility.
+    // But we introduce an alternative that explicitly configures yaxis elements
+    // with the series that will be referenced to them (seriesName: []). This
+    // only requires including the yaxis elements that will be seen on the chart.
+    // Old way:
+    // ya: s
+    // 0: 0
+    // 1: 1
+    // 2: 1
+    // 3: 1
+    // 4: 1
+    // Axes 0..4 are all scaled and all will be rendered unless the axes are
+    // show: false. If the chart is stacked, it's assumed that series 1..4 are
+    // the contributing series. This is not particularly intuitive.
+    // New way:
+    // ya: s
+    // 0: [0]
+    // 1: [1,2,3,4]
+    // If the chart is stacked, it can be assumed that any axis with multiple
+    // series is stacked.
+    // 
+    // If this is an old chart and we are being backward compatible, it will be
+    // expected that each series is associated with it's corresponding yaxis
+    // through their indices, one-to-one.
+    // If yaxis.seriesName matches series.name, we have indices yi and si.
+    // A name match where yi != si is interpretted as yaxis[yi] and yaxis[si]
+    // will both be scaled to fit the combined series[si] and series[yi].
+    // Consider series named: S0,S1,S2 and yaxes A0,A1,A2.
+    // 
+    // Example 1: A0 and A1 scaled the same.
+    // A0.seriesName: S0
+    // A1.seriesName: S0
+    // A2.seriesName: S2
+    // Then A1 <-> A0
+    // 
+    // Example 2: A0, A1 and A2 all scaled the same.
+    // A0.seriesName: S2
+    // A1.seriesName: S0
+    // A2.seriesName: S1
+    // A0 <-> A2, A1 <-> A0, A2 <-> A1 --->>> A0 <-> A1 <-> A2
+
+    let axisSeriesMap = []
+    let seriesYAxisReverseMap = []
+    let unassignedSeriesIndices = []
+    let seriesNameArrayStyle = 
+            gl.series.length > cnf.yaxis.length
+            || cnf.yaxis.some((a) => Array.isArray(a.seriesName))
+
+    cnf.series.forEach((s, i) => {
+      unassignedSeriesIndices.push(i)
+      seriesYAxisReverseMap.push(null)
+    })
+    cnf.yaxis.forEach((yaxe, yi) => {
+      axisSeriesMap[yi] = []
+    })
+
+    let unassignedYAxisIndices = []
+
+    // here, we loop through the yaxis array and find the item which has "seriesName" property
+    cnf.yaxis.forEach((yaxe, yi) => {
+      let assigned = false
+      // Allow seriesName to be either a string (for backward compatibility),
+      // in which case, handle multiple yaxes referencing the same series.
+      // or an array of strings so that a yaxis can reference multiple series.
+      // Feature request #4237
+      if (yaxe.seriesName) {
+        let seriesNames = []
+        if (Array.isArray(yaxe.seriesName)) {
+          seriesNames = yaxe.seriesName
+        } else {
+          seriesNames.push(yaxe.seriesName)
+        }
+        seriesNames.forEach((name) => {
+          cnf.series.forEach((s, si) => {
+            if (s.name === name) {
+              let remove = si
+              if (yi === si || seriesNameArrayStyle) {
+                // New style, don't allow series to be double referenced
+                if (!seriesNameArrayStyle
+                      || unassignedSeriesIndices.indexOf(si) > -1
+                ) {
+                  axisSeriesMap[yi].push([yi,si])
+                } else {
+                  console.warn(
+                    "Series '"
+                    + s.name
+                    + "' referenced more than once in what looks like the new style."
+                    + " That is, when using either seriesName: [],"
+                    + " or when there are more series than yaxes.")
+                }
+              } else {
+                // The series index refers to the target yaxis and the current
+                // yaxis index refers to the actual referenced series.
+                axisSeriesMap[si].push([si,yi])
+                remove = yi
+              }
+              assigned = true
+              remove = unassignedSeriesIndices.indexOf(remove)
+              if (remove !== -1) {
+                unassignedSeriesIndices.splice(remove, 1)
+              }
+            }
+          })
+        })
+      }
+      if (!assigned) {
+        unassignedYAxisIndices.push(yi)
+      }
+    })
+    axisSeriesMap = axisSeriesMap.map((yaxe, yi) => {
+      let ra = []
+      yaxe.forEach((sa) => {
+        seriesYAxisReverseMap[sa[1]] = sa[0]
+        ra.push(sa[1])
+      })
+      return ra
+    })
+
+    // All series referenced directly by yaxes have been assigned to those axes.
+    // Any series so far unassigned will be assigned to any yaxes that have yet
+    // to reference series directly, one-for-one in order of appearance, with
+    // all left-over series assigned to either the last unassigned yaxis, or the
+    // last yaxis if all have assigned series. This captures the
+    // default single and multiaxis config options which simply includes zero,
+    // one or as many yaxes as there are series but do not reference them by name.
+    let lastUnassignedYAxis = cnf.yaxis.length - 1
+    for (let i = 0; i < unassignedYAxisIndices.length; i++) {
+      lastUnassignedYAxis = unassignedYAxisIndices[i]
+      axisSeriesMap[lastUnassignedYAxis] = []
+      if (unassignedSeriesIndices) {
+        let si = unassignedSeriesIndices[0]
+        unassignedSeriesIndices.shift()
+        axisSeriesMap[lastUnassignedYAxis].push(si)
+        seriesYAxisReverseMap[si] = lastUnassignedYAxis
+      } else {
+        break
+      }
+    }
+
+    unassignedSeriesIndices.forEach((i) => {
+      axisSeriesMap[lastUnassignedYAxis].push(i)
+      seriesYAxisReverseMap[i] = lastUnassignedYAxis
+    })
+
+    // For the old-style seriesName-as-string-only, leave the zero-length yaxis
+    // array elements in for compatibility so that series.length == yaxes.length
+    // for multi axis charts.
+    gl.seriesYAxisMap = axisSeriesMap.map((x) => x)
+    gl.seriesYAxisReverseMap = seriesYAxisReverseMap.map((x) => x)
+    // Set default series group names
+    gl.seriesYAxisMap.forEach((axisSeries, ai) => {
+      axisSeries.forEach((si) => {
+        // series may be bare until loaded in realtime
+        if (cnf.series[si] && cnf.series[si].group === undefined) {
+          // A series with no group defined will be named after the axis that
+          // referenced it and thus form a group automatically.
+          cnf.series[si].group = 'apexcharts-axis-'.concat(ai.toString())
+        }
+      })
+    })
+  }
+
   isSeriesNull(index = null) {
     let r = []
     if (index === null) {
@@ -433,6 +602,28 @@ class CoreUtils {
     }
 
     return options
+  }
+
+  // Series of the same group and type can be stacked together distinct from
+  // other series of the same type on the same axis.
+  drawSeriesByGroup(typeSeries, typeGroups, type, chartClass) {
+    let w = this.w
+    let graph = []
+    if (typeSeries.series.length > 0) {
+      // draw each group separately
+      typeGroups.forEach((gn) => {
+        let gs = []
+        let gi = []
+        typeSeries.i.forEach((i, ii) => {
+          if (w.config.series[i].group === gn) {
+            gs.push(typeSeries.series[ii])
+            gi.push(i)
+          }
+        })
+        gs.length > 0 && graph.push(chartClass.draw(gs, type, gi))
+      })
+    }
+    return graph
   }
 }
 

--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -412,18 +412,20 @@ export default class Data {
       }
     })
 
-    gl.hasSeriesGroups = ser[0]?.group
-    if (gl.hasSeriesGroups) {
-      let buckets = []
-      let groups = [...new Set(ser.map((s) => s.group))]
-      ser.forEach((s, i) => {
-        let index = groups.indexOf(s.group)
-        if (!buckets[index]) buckets[index] = []
+    this.coreUtils.setSeriesYAxisMappings()
+    // At this point, every series that didn't have a user defined group name
+    // has been given a name according to the yaxis the series is referenced by.
+    // This fits the existing behaviour where all series associated with an axis
+    // are defacto presented as a single group. It is now formalised.
+    let buckets = []
+    let groups = [...new Set(cnf.series.map((s) => s.group))]
+    cnf.series.forEach((s, i) => {
+      let index = groups.indexOf(s.group)
+      if (!buckets[index]) buckets[index] = []
 
-        buckets[index].push(gl.seriesNames[i])
-      })
-      gl.seriesGroups = buckets
-    }
+      buckets[index].push(gl.seriesNames[i])
+    })
+    gl.seriesGroups = buckets
 
     const handleDates = () => {
       for (let j = 0; j < xlabels.length; j++) {

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -327,29 +327,39 @@ class Range {
       })
     }
 
-    // for multi y-axis we need different scales for each
     if (gl.isMultipleYAxis) {
       this.scales.scaleMultipleYAxes()
       gl.minY = lowestYInAllSeries
     } else {
-      gl.barGroups = []
-      cnf.series.forEach((s) => {
-        if ((!s.type && cnf.chart.type === 'bar')
-              || s.type === 'bar'
-              || s.type === 'column'
-        ) {
-          gl.barGroups.push(s.group ? s.group : 'axis-0')
-        }
-      })
-      gl.barGroups = gl.barGroups.filter((v,i,a) => a.indexOf(v) === i)
       this.scales.setYScaleForIndex(0, gl.minY, gl.maxY)
       gl.minY = gl.yAxisScale[0].niceMin
       gl.maxY = gl.yAxisScale[0].niceMax
-      gl.minYArr[0] = gl.yAxisScale[0].niceMin
-      gl.maxYArr[0] = gl.yAxisScale[0].niceMax
-      gl.seriesYAxisMap = [gl.series.map((x, i) => i)]
-      gl.seriesYAxisReverseMap = gl.series.map((x, i) => 0)
+      gl.minYArr[0] = gl.minY
+      gl.maxYArr[0] = gl.maxY
     }
+
+    gl.barGroups = []
+    gl.lineGroups = []
+    gl.areaGroups = []
+    cnf.series.forEach((s) => {
+      let type = s.type || cnf.chart.type
+      switch (type) {
+        case 'bar':
+        case 'column':
+          gl.barGroups.push(s.group)
+          break
+        case 'line':
+          gl.lineGroups.push(s.group)
+          break
+        case 'area':
+          gl.areaGroups.push(s.group)
+          break
+      }
+    })
+    // Uniquify the group names in each stackable chart type.
+    gl.barGroups = gl.barGroups.filter((v,i,a) => a.indexOf(v) === i)
+    gl.lineGroups = gl.lineGroups.filter((v,i,a) => a.indexOf(v) === i)
+    gl.areaGroups = gl.areaGroups.filter((v,i,a) => a.indexOf(v) === i)
 
     return {
       minY: gl.minY,

--- a/src/modules/Responsive.js
+++ b/src/modules/Responsive.js
@@ -37,9 +37,14 @@ export default class Responsive {
       const width = window.innerWidth > 0 ? window.innerWidth : screen.width
 
       if (width > largestBreakpoint) {
+        let initialConfig = Utils.clone(w.globals.initialConfig)
+        // Retain state of series in case any have been collapsed
+        // (indicated by series.data === [], these series' will be zeroed later
+        // enabling stacking to work correctly)
+        initialConfig.series = Utils.clone(w.config.series)
         let options = CoreUtils.extendArrayProps(
           config,
-          w.globals.initialConfig,
+          initialConfig,
           w
         )
         newOptions = Utils.extend(options, newOptions)
@@ -48,7 +53,8 @@ export default class Responsive {
       } else {
         for (let i = 0; i < res.length; i++) {
           if (width < res[i].breakpoint) {
-            newOptions = CoreUtils.extendArrayProps(config, res[i].options, w)
+            let options = CoreUtils.extendArrayProps(config, res[i].options, w)
+            newOptions = Utils.extend(options, newOptions)
             newOptions = Utils.extend(w.config, newOptions)
             this.overrideResponsiveOptions(newOptions)
           }

--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -830,12 +830,12 @@ export default class Scales {
               maxY = Math.max(maxY, Math.max.apply(null, posSeries[gni]))
             })
           } else {
-            // We don't expect multiple groups per yaxis for line-like
-            // series, but we allow it anyway.
             groupNames.forEach((gn, gni) => {
-              minY = Math.min(lowestY, Math.min.apply(null, sumSeries[gni]))
-              maxY = Math.max(highestY, Math.max.apply(null, sumSeries[gni]))
+              lowestY = Math.min(lowestY, Math.min.apply(null, sumSeries[gni]))
+              highestY = Math.max(highestY, Math.max.apply(null, sumSeries[gni]))
             })
+            minY = lowestY
+            maxY = highestY
           }
           if (minY === Number.MIN_VALUE && maxY === Number.MIN_VALUE) {
             // No series data

--- a/src/modules/axes/XAxis.js
+++ b/src/modules/axes/XAxis.js
@@ -31,7 +31,7 @@ export default class XAxis {
     if (w.config.xaxis.position === 'top') {
       this.offY = 0
     } else {
-      this.offY = w.globals.gridHeight + 1
+      this.offY = w.globals.gridHeight
     }
     this.offY = this.offY + w.config.xaxis.axisBorder.offsetY
     this.isCategoryBarHorizontal =

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -87,7 +87,7 @@ export default class Dimensions {
       gl.translateX +
       this.gridPad.left +
       this.xPadLeft +
-      (barWidth > 0 ? barWidth + 4 : 0)
+      (barWidth > 0 ? barWidth : 0)
     gl.translateY = gl.translateY + this.gridPad.top
   }
 

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -29,6 +29,8 @@ export default class Globals {
     gl.hasXaxisGroups = false
     gl.groups = []
     gl.barGroups = []
+    gl.lineGroups = []
+    gl.areaGroups = []
     gl.hasSeriesGroups = false
     gl.seriesGroups = []
     gl.categoryLabels = []


### PR DESCRIPTION
# New Pull Request

## Fixes
Fixes corner cases and some basic omissions from earlier merged post-3.48.0 pull request to with series groups and stacking of series.

## Expanding potential use cases
Updates to improve stacking of line-area type series to expand use cases, further leveraging the recent yaxis.seriesName as-an-array feature. Not really adding any new features but bridging some gaps that previously did not make sense to do using the existing config options.

Generalization of series group naming to apply to line/area series in similar way to how it applies to bar/column series.

It remains the case that only series of the same type can be stacked together.

Example:
The familiar grouped and stacked columns on one yaxis are charted together with three area series (on another yaxis, although that is not a requirement), two of those series, one stepline and the other linestep are stacked, with the third series drawn as monotoneCubic but not stacked. Finally, a line series on it's own yaxis. Normally, all three area series on the same yaxis would be stacked because group names were ignored, and that remains the default if series do not have group names (their group name will be that of the yaxis, eg, 'axis-0').

![aqfpyor5j](https://github.com/apexcharts/apexcharts.js/assets/159597299/96eee1b7-1538-4544-b32c-e90494b603ec)

The stepline and linestep stacked series isolated below have the same series.group name, while the monotoneCubic has no series.group name (defaulting to 'axis-1' in this case) and is therefore not stacked (actually stacked on it's own).

![aqfpyor5j (1)](https://github.com/apexcharts/apexcharts.js/assets/159597299/f6e10b6c-9b46-4461-8e76-f7e4963bede5)

## Axis/grid offset fixes
* Remove an arbitrary x offset: X axisBorder was shifted too far right by 4px.
* Remove an arbitrary y offset: X axisBorder line (whole X axis?) was shifted down in relation to the Y axis ticks by 1px.

### Before:
![zix6p93i](https://github.com/apexcharts/apexcharts.js/assets/159597299/3ce14795-76fa-453b-ab6c-f68f622f895b)

### After:
![lbj0iqfp](https://github.com/apexcharts/apexcharts.js/assets/159597299/d9d501ed-e271-4c59-a9ab-e5c1060bf930)

## Bar/column stroke
Center the stroke on the svg bar/column outline coordinates. Without this, bar/column outline strokes introduce an offset that moves the apparent position of the bar/column to the left by a full stroke width. This can be seen in the pre-fix example images above where the stroke is transparent to create the gap. Compare to the fixed version shown below.

![3pticq7n](https://github.com/apexcharts/apexcharts.js/assets/159597299/75849fca-16a7-43b5-8ef2-7ebd5b305b7d)

## Refactoring

Formally group all data series by default, removing a discontinuity when consulting some global data structures and local variables that required additional logic to resolve. Ie, w.globals.seriesGroups now includes all series, so that the local groupIndex variable ('bar' and similar type charts) will always be > -1 and w.globals.hasSeriesGroups will always be true. Several conditionals were able to be flattened as a result.

The rule for *default* grouping reflects current expectations and usage, that is:
* All series that reference the same (Y) axis are considered grouped together unless they have a user defined group.
* Stacking distinguishes based on series types and grouping.

This work is intended to more easily facilitate requested feature additions, for example:
* adding a plotOptions.bar.separation option that will enable users to add a gap between groups of bars, without using the existing work-around of a transparent stroke.
* adding sub-group totals.
* etc
All of these could be done without these changes but not without overly complicating/bloating the logic.

## Various minor fixes in positionings
Bar and/or columns and/or labels could have been positioned incorrectly under certain uncommon conditions.

## Fix `dataLabels.totals` alignment
Under certain conditions totals would become shifted incorrectly. In the example below, the two series in one stack have been collapsed, which caused the totals labels to shift to the left because they were positioned relative to the last dataLabels drawn (the column labels). In the fixed version they don't shift because they are now positioned independently of the column labels.

### Before:
![fc3noor2](https://github.com/apexcharts/apexcharts.js/assets/159597299/3dcc3b75-1873-4c57-bbf7-8754c8461e65)

### After:
![fc3noor2 (1)](https://github.com/apexcharts/apexcharts.js/assets/159597299/454f122f-0e0e-4e04-bd02-6cd91c3aac77)

## Fix stacking bug when `responsive` option used

Resetting out of `responsive` mode did not restore `w.config.series` to indicate collapsed series (`w.config.series.data` === []). This caused collapsed series (`w.globals.series`) to not be zeroed, causing gaps in stacked charts. The chart below did not exhibit this bug until zoomed in. Other examples (eg, `columns/stacked-column-with-line.html`) trigger it under normal conditions when series are collapsed.

### Before:
![stacking_bug](https://github.com/apexcharts/apexcharts.js/assets/159597299/7416b9c3-cd54-4c98-9a24-755e2d118aae)

### After:
![stacking_bug_fixed](https://github.com/apexcharts/apexcharts.js/assets/159597299/7e6275e8-ea73-4d07-a2d2-821ab8c57f54)

Additionally, any new options passed in as arguments were not applied when entering `responsive` mode (**please check this was actually an omission as this is based solely on code review, ie, arg `newOptions` is overwritten in the 'else' branch, thanks**).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
