### PR TITLE
Fixed bug with exporting to CSV when categories are null

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -256,6 +256,11 @@ class Exports {
         }
       }
 
+      // let the caller know the current category is null. this can happen for example
+      // when dealing with line charts having inconsistent time series data
+      if (cat === null)
+        return 'nullvalue'
+
       if (Array.isArray(cat)) {
         cat = cat.join(' ')
       }
@@ -282,6 +287,11 @@ class Exports {
           columns = []
 
           let cat = getCat(i)
+
+          // current category is null, let's move on to the next one
+          if (cat === 'nullvalue')
+            continue
+
           if (!cat) {
             if (dataFormat.isFormatXY()) {
               cat = series[sI].data[i].x
@@ -296,8 +306,8 @@ class Exports {
               isTimeStamp(cat)
                 ? w.config.chart.toolbar.export.csv.dateFormatter(cat)
                 : Utils.isNumber(cat)
-                ? cat
-                : cat.split(columnDelimiter).join('')
+                  ? cat
+                  : cat.split(columnDelimiter).join('')
             )
 
             for (let ci = 0; ci < w.globals.series.length; ci++) {
@@ -380,8 +390,8 @@ class Exports {
             isTimeStamp(cat) && w.config.xaxis.type === 'datetime'
               ? w.config.chart.toolbar.export.csv.dateFormatter(cat)
               : Utils.isNumber(cat)
-              ? cat
-              : cat.split(columnDelimiter).join(''),
+                ? cat
+                : cat.split(columnDelimiter).join(''),
             data[cat].join(columnDelimiter),
           ])
         })
@@ -446,7 +456,7 @@ class Exports {
 
     this.triggerDownload(
       'data:text/csv; charset=utf-8,' +
-        encodeURIComponent(universalBOM + result),
+      encodeURIComponent(universalBOM + result),
       fileName ? fileName : w.config.chart.toolbar.export.csv.filename,
       '.csv'
     )


### PR DESCRIPTION
# New Pull Request

I encountered a bug while attempting to export chart data to CSV from a line chart that had null datetime categories and values (to show inconsistencies of data over time), and I was getting the same error as described on #2101, #2185 and #3247. My fix simply checks if the current category is null and moves on to the next if such is the case.

Fixes #2101, #2185 and #3247.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
