### PR TITLE
Fix a potential crash condition when collapsing series'

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -69,19 +69,8 @@ export default class Scales {
       (yMin === Number.MIN_VALUE && yMax === -Number.MAX_VALUE)
     ) {
       // when all values are 0
-      if (gotMin && gotMax) {
-        yMin = gl.minY
-        yMax = gl.maxY
-      } else if (gotMin) {
-        yMin = gl.minY
-        yMax = yMin + ticks
-      } else if (gotMax) {
-        yMax = gl.maxY
-        yMin = yMax - ticks
-      } else {
-        yMin = 0
-        yMax = ticks
-      }
+      yMin = Utils.isNumber(axisCnf.min) ? axisCnf.min : 0
+      yMax = Utils.isNumber(axisCnf.max) ? axisCnf.max : yMin + ticks
       gl.allSeriesCollapsed = false
     }
 


### PR DESCRIPTION
Fixes a bug introduced in a previous PR.

In Scales.niceScale() when the passed-in yMin and yMax indicate no data, cannot simply substitute w.globals.min and w.globals.max as the user may have configured one or both as a function, making it likely that the global min/max values are not suitable and which can cause undefined behaviour. Substitute sane default values in that case.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
