### PR TITLE
Add annotation position option

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -267,6 +267,10 @@ export default class ApexCharts {
       me.annotations.drawImageAnnos()
       me.annotations.drawTextAnnos()
 
+      if (w.config.annotations.position === 'front') {
+        me.annotations.drawAxesAnnotations()
+      }
+
       if (w.config.grid.position === 'back') {
         if (elgrid) {
           w.globals.dom.elGraphical.add(elgrid.el)
@@ -318,7 +322,9 @@ export default class ApexCharts {
         })
       }
 
-      me.annotations.drawAxesAnnotations()
+      if (w.config.annotations.position === 'back') {
+        me.annotations.drawAxesAnnotations()
+      }
 
       if (!w.globals.noData) {
         // draw tooltips at the end

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -351,6 +351,7 @@ type ApexStroke = {
 }
 
 type ApexAnnotations = {
+  position?: string
   yaxis?: YAxisAnnotations[]
   xaxis?: XAxisAnnotations[]
   points?: PointAnnotations[]


### PR DESCRIPTION
# New Pull Request

For some reason the option to position the chart annotations has been removed [with this commit](https://github.com/apexcharts/apexcharts.js/commit/773f2a40f5d45e193deecd0e361f3b46e706ed89)
Since i would like to see the feature again ave added it ([related issue](https://github.com/apexcharts/apexcharts.js/issues/4303))

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
