### PR TITLE
Fix issue 4216: grid padding calc to support array of stroke widths

### DIFF
--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -41,54 +41,53 @@ export default class Dimensions {
 
     this.lgRect = this.dimHelpers.getLegendsRect()
 
+    const maxStrokeWidth = Array.isArray(w.config.stroke.width) ? Math.max(...w.config.stroke.width) : w.config.stroke.width;
+
     if (this.isSparkline) {
       if (w.config.markers.discrete.length > 0 || w.config.markers.size > 0) {
         Object.entries(this.gridPad).forEach(([k, v]) => {
           this.gridPad[k] = Math.max(
             v,
-            this.w.globals.markers.largestSize / 1.5
+            gl.markers.largestSize / 1.5
           )
         })
       }
 
-      this.gridPad.top = Math.max(w.config.stroke.width / 2, this.gridPad.top)
-      this.gridPad.bottom = Math.max(
-        w.config.stroke.width / 2,
-        this.gridPad.bottom
-      )
+      this.gridPad.top = Math.max(maxStrokeWidth / 2, this.gridPad.top);
+      this.gridPad.bottom = Math.max(maxStrokeWidth / 2, this.gridPad.bottom);
     }
 
     if (gl.axisCharts) {
-      // for line / area / scatter / column
-      this.setDimensionsForAxisCharts()
+      // For line / area / scatter / column
+      this.setDimensionsForAxisCharts();
     } else {
-      // for pie / donuts / circle
-      this.setDimensionsForNonAxisCharts()
+      // For pie / donuts / circle
+      this.setDimensionsForNonAxisCharts();
     }
 
-    this.dimGrid.gridPadFortitleSubtitle()
+    this.dimGrid.gridPadFortitleSubtitle();
 
-    // after calculating everything, apply padding set by user
-    gl.gridHeight = gl.gridHeight - this.gridPad.top - this.gridPad.bottom
-
+    // After calculating everything, apply padding set by user
+    gl.gridHeight = gl.gridHeight - this.gridPad.top - this.gridPad.bottom;
     gl.gridWidth =
       gl.gridWidth -
       this.gridPad.left -
       this.gridPad.right -
       this.xPadRight -
-      this.xPadLeft
+      this.xPadLeft;
 
-    let barWidth = this.dimGrid.gridPadForColumnsInNumericAxis(gl.gridWidth)
+    let barWidth = this.dimGrid.gridPadForColumnsInNumericAxis(gl.gridWidth);
 
-    gl.gridWidth = gl.gridWidth - barWidth * 2
+    gl.gridWidth = gl.gridWidth - barWidth * 2;
 
     gl.translateX =
       gl.translateX +
       this.gridPad.left +
       this.xPadLeft +
-      (barWidth > 0 ? barWidth + 4 : 0)
-    gl.translateY = gl.translateY + this.gridPad.top
+      (barWidth > 0 ? barWidth + 4 : 0);
+    gl.translateY = gl.translateY + this.gridPad.top;
   }
+
 
   setDimensionsForAxisCharts() {
     let w = this.w
@@ -126,8 +125,8 @@ export default class Dimensions {
     gl.translateXAxisY = w.globals.rotateXLabels ? this.xAxisHeight / 8 : -4
     gl.translateXAxisX =
       w.globals.rotateXLabels &&
-      w.globals.isXNumeric &&
-      w.config.xaxis.labels.rotate <= -45
+        w.globals.isXNumeric &&
+        w.config.xaxis.labels.rotate <= -45
         ? -this.xAxisWidth / 4
         : 0
 
@@ -231,8 +230,8 @@ export default class Dimensions {
 
     const type =
       cnf.chart.type === 'pie' ||
-      cnf.chart.type === 'polarArea' ||
-      cnf.chart.type === 'donut'
+        cnf.chart.type === 'polarArea' ||
+        cnf.chart.type === 'donut'
         ? 'pie'
         : 'radialBar'
 

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -41,7 +41,7 @@ export default class Dimensions {
 
     this.lgRect = this.dimHelpers.getLegendsRect()
 
-    const maxStrokeWidth = Array.isArray(w.config.stroke.width) ? Math.max(...w.config.stroke.width) : w.config.stroke.width;
+    const maxStrokeWidth = Array.isArray(w.config.stroke.width) ? Math.max(...w.config.stroke.width) : w.config.stroke.width
 
     if (this.isSparkline) {
       if (w.config.markers.discrete.length > 0 || w.config.markers.size > 0) {
@@ -53,41 +53,40 @@ export default class Dimensions {
         })
       }
 
-      this.gridPad.top = Math.max(maxStrokeWidth / 2, this.gridPad.top);
-      this.gridPad.bottom = Math.max(maxStrokeWidth / 2, this.gridPad.bottom);
+      this.gridPad.top = Math.max(maxStrokeWidth / 2, this.gridPad.top)
+      this.gridPad.bottom = Math.max(maxStrokeWidth / 2, this.gridPad.bottom)
     }
 
     if (gl.axisCharts) {
-      // For line / area / scatter / column
-      this.setDimensionsForAxisCharts();
+      // for line / area / scatter / column
+      this.setDimensionsForAxisCharts()
     } else {
-      // For pie / donuts / circle
-      this.setDimensionsForNonAxisCharts();
+      // for pie / donuts / circle
+      this.setDimensionsForNonAxisCharts()
     }
 
-    this.dimGrid.gridPadFortitleSubtitle();
+    this.dimGrid.gridPadFortitleSubtitle()
 
     // After calculating everything, apply padding set by user
-    gl.gridHeight = gl.gridHeight - this.gridPad.top - this.gridPad.bottom;
+    gl.gridHeight = gl.gridHeight - this.gridPad.top - this.gridPad.bottom
     gl.gridWidth =
       gl.gridWidth -
       this.gridPad.left -
       this.gridPad.right -
       this.xPadRight -
-      this.xPadLeft;
+      this.xPadLeft
 
-    let barWidth = this.dimGrid.gridPadForColumnsInNumericAxis(gl.gridWidth);
+    let barWidth = this.dimGrid.gridPadForColumnsInNumericAxis(gl.gridWidth)
 
-    gl.gridWidth = gl.gridWidth - barWidth * 2;
+    gl.gridWidth = gl.gridWidth - barWidth * 2
 
     gl.translateX =
       gl.translateX +
       this.gridPad.left +
       this.xPadLeft +
-      (barWidth > 0 ? barWidth + 4 : 0);
-    gl.translateY = gl.translateY + this.gridPad.top;
+      (barWidth > 0 ? barWidth + 4 : 0)
+    gl.translateY = gl.translateY + this.gridPad.top
   }
-
 
   setDimensionsForAxisCharts() {
     let w = this.w
@@ -125,8 +124,8 @@ export default class Dimensions {
     gl.translateXAxisY = w.globals.rotateXLabels ? this.xAxisHeight / 8 : -4
     gl.translateXAxisX =
       w.globals.rotateXLabels &&
-        w.globals.isXNumeric &&
-        w.config.xaxis.labels.rotate <= -45
+      w.globals.isXNumeric &&
+      w.config.xaxis.labels.rotate <= -45
         ? -this.xAxisWidth / 4
         : 0
 
@@ -230,8 +229,8 @@ export default class Dimensions {
 
     const type =
       cnf.chart.type === 'pie' ||
-        cnf.chart.type === 'polarArea' ||
-        cnf.chart.type === 'donut'
+      cnf.chart.type === 'polarArea' ||
+      cnf.chart.type === 'donut'
         ? 'pie'
         : 'radialBar'
 

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -48,7 +48,7 @@ export default class Dimensions {
         Object.entries(this.gridPad).forEach(([k, v]) => {
           this.gridPad[k] = Math.max(
             v,
-            gl.markers.largestSize / 1.5
+            this.w.globals.markers.largestSize / 1.5
           )
         })
       }
@@ -67,8 +67,9 @@ export default class Dimensions {
 
     this.dimGrid.gridPadFortitleSubtitle()
 
-    // After calculating everything, apply padding set by user
+    // after calculating everything, apply padding set by user
     gl.gridHeight = gl.gridHeight - this.gridPad.top - this.gridPad.bottom
+    
     gl.gridWidth =
       gl.gridWidth -
       this.gridPad.left -


### PR DESCRIPTION
# New Pull Request
This commit adjusts the `plotCoords` method to correctly handle cases where the stroke width (`stroke.width`) is provided as an array of values, which corresponds to different series in the visualization. Previously, the code assumed a single numeric value, leading to incorrect grid padding calculations when multiple series with different stroke widths were present. 

Now, the method checks if `stroke.width` is an array and uses the maximum value from this array for setting grid padding, ensuring that the largest stroke width is properly accommodated.

Changes include:
- Adding a condition to determine whether `stroke.width` is an array.
- Using `Math.max(...)` to find the maximum stroke width when necessary.
- Applying this maximum value to adjust `gridPad.top` and `gridPad.bottom`.

Fixes #4216 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
