### PR TITLE
Make YAxis seriesName an Array

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1118,7 +1118,7 @@ type ApexYAxis = {
   show?: boolean
   showAlways?: boolean
   showForNullSeries?: boolean
-  seriesName?: string
+  seriesName?: string[]
   opposite?: boolean
   reversed?: boolean
   logarithmic?: boolean,


### PR DESCRIPTION
#4247 now allows or requires seriesName to be an array, and that wasn't reflected in the types. I wasn't able to find out which case it is, and even the documentation doesn't mention seriesName being an array, in one place it's a string, in another it's undefined.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
