### PR TITLE
Area path animation glitching issues

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -208,6 +208,8 @@ class Line {
         }
         paths.linePaths.splice(segments)
         paths.pathFromLine = rangePaths.pathFromLine + paths.pathFromLine
+      } else {
+        paths.pathFromArea += graphics.line(0, this.zeroY)
       }
 
       this._handlePaths({ type, realIndex, i, paths })
@@ -337,8 +339,8 @@ class Line {
         graphics.move(prevX, this.areaBottomY) + graphics.line(prevX, prevY)
     }
 
-    pathFromLine = graphics.move(-1, this.zeroY) + graphics.line(-1, this.zeroY)
-    pathFromArea = graphics.move(-1, this.zeroY) + graphics.line(-1, this.zeroY)
+    pathFromLine = graphics.move(0, this.zeroY) + graphics.line(0, this.zeroY)
+    pathFromArea = graphics.move(0, this.zeroY) + graphics.line(0, this.zeroY)
 
     if (w.globals.previousPaths.length > 0) {
       const pathFrom = this.lineHelpers.checkPreviousPaths({
@@ -690,8 +692,8 @@ class Line {
         this.appendPathFrom &&
         !(curve === 'monotoneCubic' && type === 'rangeArea')
       ) {
-        pathFromLine = pathFromLine + graphics.line(x, this.zeroY)
-        pathFromArea = pathFromArea + graphics.line(x, this.zeroY)
+        pathFromLine += graphics.line(x, this.zeroY)
+        pathFromArea += graphics.line(x, this.zeroY)
       }
 
       this.handleNullDataPoints(series, pointsPos, i, j, realIndex)
@@ -972,9 +974,6 @@ class Line {
                 linePath +=
                     graphics.curve(x, y, x, y, x, y2)
                   + graphics.move(x, y2)
-              } else {
-                linePath +=
-                    graphics.move(x, y)
               }
               areaPath +=
                   graphics.curve(x, y, x, y, x, areaBottomY)
@@ -1056,8 +1055,6 @@ class Line {
               if (isLowerRangeAreaPath) {
               // Need to add path portion that will join to the upper path
                 linePath += graphics.line(x, y2)
-              } else {
-                linePath += graphics.move(x, y)
               }
               areaPath +=
                   graphics.line(x, areaBottomY)


### PR DESCRIPTION
Recent refactoring of line paths creation to fix various issues did not update the pathFromArea paths, upsetting animation morphing from those paths to final areaPaths.

1) Remove redundant graphics.move() from end of lower rangeArea paths.
2) Add closing line segment to pathFromArea path.

Fixes #4437

This has fixed the major issue but is still not perfect. There does appear to be an overall improvement visually over 3.45.2, the version preceeding the start of these refactoring efforts. If we compare, for example, the area-spline sample generated by 3.45.2 with that obtained after this patch, there is no longer a split between the line path and fill at every datapoint during the morphing process. There is instead a single artifact with the last datapoint that it would be nice to resolve.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
