### PR TITLE
Restore Y axis highlighting during legend series mouseover.

### DIFF
--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -44,7 +44,10 @@
 rect.legend-mouseover-inactive,
 .legend-mouseover-inactive rect,
 .legend-mouseover-inactive path,
-.legend-mouseover-inactive circle {
+.legend-mouseover-inactive circle,
+.legend-mouseover-inactive line,
+.legend-mouseover-inactive text.apexcharts-yaxis-title-text,
+.legend-mouseover-inactive text.apexcharts-yaxis-label {
   transition: .15s ease all;
   opacity: .2
 }


### PR DESCRIPTION
The recent commit 9f1d327 introduced extra CSS selectivity that caused the exclusion of Y axes highlighting. This patch selectively re-adds those chart components.

The intent of commit 9f1d327 is unchanged by this PR.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
