### PR TITLE
fix: fixed theme change from dark mode to light mode not working

### DIFF
--- a/src/modules/Theme.js
+++ b/src/modules/Theme.js
@@ -178,20 +178,26 @@ export default class Theme {
   updateThemeOptions(options) {
     options.chart = options.chart || {}
     options.tooltip = options.tooltip || {}
-    const mode = options.theme.mode || 'light'
-    const palette = options.theme.palette
-      ? options.theme.palette
-      : mode === 'dark'
+    const mode = options.theme.mode
+    const background = mode === 'dark'
+      ? '#424242'
+      : mode === 'light'
+        ? '#fff'
+        : options.chart.background || '#fff'
+    const palette = mode === 'dark'
       ? 'palette4'
-      : 'palette1'
-    const foreColor = options.chart.foreColor
-      ? options.chart.foreColor
-      : mode === 'dark'
+      : mode === 'light'
+        ? 'palette1'
+        : options.theme.palette || 'palette1'
+    const foreColor = mode === 'dark'
       ? '#f6f7f8'
-      : '#373d3f'
+      : mode === 'light'
+        ? '#373d3f'
+        : options.chart.foreColor || '#373d3f'
 
     options.tooltip.theme = mode
     options.chart.foreColor = foreColor
+    options.chart.background = background
     options.theme.palette = palette
 
     return options

--- a/src/modules/Theme.js
+++ b/src/modules/Theme.js
@@ -195,7 +195,7 @@ export default class Theme {
         ? '#373d3f'
         : options.chart.foreColor || '#373d3f'
 
-    options.tooltip.theme = mode
+    options.tooltip.theme = mode || 'light'
     options.chart.foreColor = foreColor
     options.chart.background = background
     options.theme.palette = palette


### PR DESCRIPTION
# Fixed chart theme change from dark mode to light mode not working

Changing a chart from dark mode to light mode with the options object wasn't working (example at https://github.com/Sebastian-Webster/apex-reproducible-example)
This pull request fixes that issue so dark mode charts can be changed to light mode successfully

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes