### PR TITLE
fix: prevent issues with tests running in non-TTY environments

### DIFF
--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -195,10 +195,12 @@ async function processSamples(command, paths) {
   })
 
   await cluster.task(async ({ page, data: sample }) => {
-    process.stdout.clearLine()
-    process.stdout.cursorTo(0)
-    const percentComplete = Math.round((100 * numCompleted) / samples.length)
-    process.stdout.write(`Processing samples: ${percentComplete}%`)
+    if (process.stdout.isTTY) {
+      process.stdout.clearLine()
+      process.stdout.cursorTo(0)
+      const percentComplete = Math.round((100 * numCompleted) / samples.length)
+      process.stdout.write(`Processing samples: ${percentComplete}%`)
+    }
 
     // BUG: some chart are animated - need special processing. Some just need to be skipped.
 
@@ -214,7 +216,9 @@ async function processSamples(command, paths) {
       })
     }
     numCompleted++
-    process.stdout.clearLine()
+    if (!process.stdout.isTTY) {
+      console.log(`Processed samples: ${numCompleted}/${samples.length}`)
+    }
   })
 
   for (const sample of samples) {
@@ -223,6 +227,12 @@ async function processSamples(command, paths) {
 
   await cluster.idle()
   await cluster.close()
+
+  if (process.stdout.isTTY) {
+    process.stdout.clearLine()
+  } else {
+    console.log('All samples have now been processed')
+  }
 
   console.log('')
 


### PR DESCRIPTION
# Prevented issues with tests running in non-TTY environments

This was done by adding a check to see if Node is running in a TTY environment. If it isn't in a TTY environment, logs are made with console.log instead of process.stdout.write() and process.stdout.clearLine().

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
