### PR TITLE
Fix responsive options failure in 3.49.1

### DIFF
--- a/src/modules/Responsive.js
+++ b/src/modules/Responsive.js
@@ -53,8 +53,7 @@ export default class Responsive {
       } else {
         for (let i = 0; i < res.length; i++) {
           if (width < res[i].breakpoint) {
-            let options = CoreUtils.extendArrayProps(config, res[i].options, w)
-            newOptions = Utils.extend(options, newOptions)
+            newOptions = CoreUtils.extendArrayProps(config, res[i].options, w)
             newOptions = Utils.extend(w.config, newOptions)
             this.overrideResponsiveOptions(newOptions)
           }


### PR DESCRIPTION
Revert an erroneous and ineffectual change introduced in 3.49.1 via commit  b6a6874. The remainder of that commit is still required.

Fixes #4519

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
