### PR TITLE
CSV Export numberFormatter

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -304,7 +304,7 @@ class Exports {
               isTimeStamp(cat)
                 ? w.config.chart.toolbar.export.csv.dateFormatter(cat)
                 : Utils.isNumber(cat)
-                ? cat
+                ? w.config.chart.toolbar.export.csv.numberFormatter(cat)
                 : cat.split(columnDelimiter).join('')
             )
 
@@ -385,7 +385,7 @@ class Exports {
             isTimeStamp(cat) && w.config.xaxis.type === 'datetime'
               ? w.config.chart.toolbar.export.csv.dateFormatter(cat)
               : Utils.isNumber(cat)
-              ? cat
+              ? w.config.chart.toolbar.export.csv.numberFormatter(cat)
               : cat.split(columnDelimiter).join(''),
             data[cat].join(columnDelimiter),
           ])

--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -309,11 +309,8 @@ class Exports {
             )
 
             for (let ci = 0; ci < w.globals.series.length; ci++) {
-              if (dataFormat.isFormatXY()) {
-                columns.push(series[ci].data[i]?.y)
-              } else {
-                columns.push(gSeries[ci][i])
-              }
+              const value = dataFormat.isFormatXY() ? series[ci].data[i]?.y : gSeries[ci][i];
+              columns.push(Utils.isNumber(value) ? w.config.chart.toolbar.export.csv.numberFormatter(value) : value)
             }
           }
 

--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -369,7 +369,7 @@ class Exports {
           if (!data[cat]) {
             data[cat] = Array(series.length).fill('')
           }
-          data[cat][sI] = value
+          data[cat][sI] = Utils.isNumber(value) ? w.config.chart.toolbar.export.csv.numberFormatter(value) : value
           categories.add(cat)
         })
       })
@@ -441,7 +441,7 @@ class Exports {
           columns = []
 
           columns.push(w.globals.labels[sI].split(columnDelimiter).join(''))
-          columns.push(gSeries[sI])
+          columns.push(gSeries[sI].map(x => Utils.isNumber(x) ? w.config.chart.toolbar.export.csv.numberFormatter(value) : value))
           rows.push(columns.join(columnDelimiter))
         }
       })

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -372,6 +372,9 @@ export default class Options {
               dateFormatter(timestamp) {
                 return new Date(timestamp).toDateString()
               },
+              numberFormatter(value) {
+                return value;
+              }
             },
             png: {
               filename: undefined,

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -192,6 +192,7 @@ type ApexChart = {
         headerCategory?: string
         headerValue?: string
         dateFormatter?(timestamp?: number): any
+        numberFormatter?(value?: number): any
       },
       svg?: {
         filename?: undefined | string


### PR DESCRIPTION
# New Pull Request

We needed the numbers in a csv export to be formatted correctly with a comma as a decimal separator. So I thought it would be a good way to implement a numberFormatter like the dateFormatter for the CSV Export.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Sorry, I don't know how to write unit tests. 
