### PR TITLE
Improved e2e test reliability

### DIFF
--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -92,17 +92,26 @@ async function processSample(page, sample, command) {
 
   await page.goto(`file://${htmlPath}`)
 
-  //Wait for all network requests to finish
-  await page.waitForNetworkIdle()
+  let wait = true;
+  while (wait) {
+    //Wait for all intervals in the page to have been cleared
+    await page.waitForFunction(() => window.activeIntervalCount === 0)
 
-  //Wait for all intervals in the page to have been cleared
-  await page.waitForFunction(() => window.activeIntervalCount === 0)
+    //Wait for all timers in the page to have all executed
+    await page.waitForFunction(() => window.activeTimerCount === 0)
 
-  //Wait for all timers in the page to have all executed
-  await page.waitForFunction(() => window.activeTimerCount === 0)
+    //Wait for the chart animation to end
+    await page.waitForFunction(() => chart.w.globals.animationEnded)
 
-  //Wait for the chart animation to end
-  await page.waitForFunction(() => chart.w.globals.animationEnded)
+    //Wait for all network requests to finish
+    await page.waitForNetworkIdle()
+
+    //After the network requests, timers, and intervals finish, if another request, timer, or interval is created then we need
+    //to wait for that to finish before continuing on.
+    wait = await page.evaluate(() => {
+      return !(window.activeIntervalCount === 0 && window.activeTimerCount === 0 && chart.w.globals.animationEnded)
+    })
+  }
 
   // Check that there are no console errors
   if (consoleErrors.length > 0) {

--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -92,8 +92,8 @@ async function processSample(page, sample, command) {
 
   await page.goto(`file://${htmlPath}`)
 
-  let wait = true;
-  while (wait) {
+  let wait;
+  do {
     //Wait for all intervals in the page to have been cleared
     await page.waitForFunction(() => window.activeIntervalCount === 0)
 
@@ -111,7 +111,7 @@ async function processSample(page, sample, command) {
     wait = await page.evaluate(() => {
       return !(window.activeIntervalCount === 0 && window.activeTimerCount === 0 && chart.w.globals.animationEnded)
     })
-  }
+  } while (wait)
 
   // Check that there are no console errors
   if (consoleErrors.length > 0) {


### PR DESCRIPTION
With https://github.com/apexcharts/apexcharts.js/pull/4515 the tests passed locally, but ever since then some tests (mostly funnel/funnel, funnel/pyramid, and line/line-with-annotations) would sometimes fail spontaneously and running the tests again with no code changes would fix the error.  Adding a while loop to wait for all timers/intervals/network requests and the chart animation to end fixes the reliability issues.
This change would also improve reliability for future possible tests, like for example if a test needed a timeout after the chart animation ended, the test would not wait for that timeout because it had already waited for all timeouts to finish. With this PR, if a timeout is created after a chart animation ends, the test would wait for the timeout to end before continuing.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
