### PR TITLE
Fixed test coverage report failing to generate on Windows

### DIFF
--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -328,7 +328,7 @@ async function processSamples(command, paths) {
     const { status } = spawnSync(
       `${rootDir}/node_modules/.bin/nyc`,
       ['report', '--reporter=html'],
-      { cwd: rootDir }
+      { cwd: rootDir, shell: process.platform === 'win32' }
     )
 
     if (status === 0) {


### PR DESCRIPTION
This PR fixes the test coverage report failing to generate on Windows by running nyc in a shell if the command is ran from a Windows machine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
