### PR TITLE
Updated actions/stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
# Updated actions/stale action

The current version of actions/stale being used (v3) has been superseded by v9. The notable changes between v3 and v9 are:
- Upgraded Node.js from 12 -> 20
- If an issue is closed, it is now closed as `not_planned`instead of `completed`
- The action is now stateful, meaning that if the action ends because of `operations-per-run` then the next run will start from the first unprocessed issue and skip the issues processed during the previous run(s). The state will be reset when all the issues are processed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
