### PR TITLE
fix: line/realtime test

### DIFF
--- a/samples/source/line/realtime.xml
+++ b/samples/source/line/realtime.xml
@@ -104,7 +104,9 @@ legend: {
 </chart>
 
 <vanilla-js-script>
-window.setInterval(function () {
+var intervalRuns = 0;
+var interval = window.setInterval(function () {
+  intervalRuns++
   getNewSeries(lastDate, {
     min: 10,
     max: 90
@@ -113,6 +115,10 @@ window.setInterval(function () {
   chart.updateSeries([{
     data: data
   }])
+
+  if (intervalRuns === 2 && window.isATest === true) {
+    clearInterval(interval)
+  }
 }, 1000)
 </vanilla-js-script>
 

--- a/samples/vanilla-js/line/realtime.html
+++ b/samples/vanilla-js/line/realtime.html
@@ -152,7 +152,9 @@
         chart.render();
       
       
-        window.setInterval(function () {
+        var intervalRuns = 0;
+      var interval = window.setInterval(function () {
+        intervalRuns++
         getNewSeries(lastDate, {
           min: 10,
           max: 90
@@ -161,6 +163,10 @@
         chart.updateSeries([{
           data: data
         }])
+      
+        if (intervalRuns === 2 && window.isATest === true) {
+          clearInterval(interval)
+        }
       }, 1000)
       
     </script>

--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -44,6 +44,8 @@ async function processSample(page, sample, command) {
   page.on('pageerror', (error) => consoleErrors.push(error.message))
 
   await page.evaluateOnNewDocument(() => {
+    window.isATest = true
+
     //Keep track of running timers and intervals in the page
     window.activeTimerCount = 0
     window.activeIntervalCount = 0


### PR DESCRIPTION
# Fixed line/realtime test

In #4515 a change was made to the line/realtime sample so that its setInterval would stop after 2 seconds so Puppeteer wouldn't timeout from waiting for the setInterval to be cleared. That change was not added to the XML file so whenever samples were rebuilt the test would start to cause an issue again.

This pull request adds that change to the XML file so the test won't cause issues when samples are rebuilt. This pull request also makes the setInterval stop after 2 seconds only if it is used in e2e testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
