### PR TITLE
Fix for issue 4561

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -559,16 +559,14 @@ export default class ZoomPanSelection extends Toolbar {
 
     w.config.yaxis.forEach((yaxe, index) => {
       // We can use the index of any series referenced by the Yaxis
-      // because they will all return the same value.
-      if (w.globals.seriesYAxisMap[index].length > 0) {
-        let seriesIndex = w.globals.seriesYAxisMap[index][0]
-        yHighestValue.push(
-          w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.startY
-        )
-        yLowestValue.push(
-          w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.endY
-        )
-      }
+      // because they will all return the same value, so we choose the first.
+      let seriesIndex = w.globals.seriesYAxisMap[index][0]
+      yHighestValue.push(
+        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.startY
+      )
+      yLowestValue.push(
+        w.globals.yAxisScale[index].niceMax - xyRatios.yRatio[seriesIndex] * me.endY
+      )
     })
 
     if (


### PR DESCRIPTION
For backward compatibility after the yaxis.seriesName as-an-array feature was implemented, needed to compute a yLowestValue and yHighestValue for each configured yaxis, not just the effective (visible?) yaxes.

Fixes #4561

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
