### PR TITLE
Add null checks on gridRect to avoid safari error

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -198,9 +198,9 @@ export default class ZoomPanSelection extends Toolbar {
       e.type === 'mouseleave'
     ) {
       // we will be calling getBoundingClientRect on each mousedown/mousemove/mouseup
-      let gridRectDim = me.gridRect.getBoundingClientRect()
+      let gridRectDim = me.gridRect?.getBoundingClientRect()
 
-      if (me.w.globals.mousedown) {
+      if (gridRectDim && me.w.globals.mousedown) {
         // user released the drag, now do all the calculations
         me.endX = me.clientX - gridRectDim.left
         me.endY = me.clientY - gridRectDim.top


### PR DESCRIPTION
# New Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Bug:
In Safari 17.5, moving the mouse over a line or bar chart with a datetime x axis, while it is loading, results in "TypeError null is not an object (evaluating 'r.gridRect.getBoundingClientRect')". This is referenced in this issue thread: https://github.com/apexcharts/apexcharts.js/issues/1790

Fix:
A basic null check.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project // not sure where to find these...
- [ ] I have performed a self-review of my own code // too hard for me to test on Mac virtual machine, but this should fix the line of code that is erroring in safari
- [ ] I have commented my code, particularly in hard-to-understand areas // I do not think additional comments are required
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works // not super relevant
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
