### PR TITLE
Allow property `size` in `ApexLegend.markers`

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -824,6 +824,7 @@ type ApexLegend = {
     useSeriesColors?: boolean
   }
   markers?: {
+    size?: number
     strokeColor?: string
     strokeWidth?: number
     fillColors?: string[]
@@ -871,7 +872,7 @@ type ApexMarkers = {
   strokeDashArray?: number | number[]
   fillOpacity?: number | number[]
   discrete?: ApexDiscretePoint[]
-  shape?: ApexMarkerShape 
+  shape?: ApexMarkerShape
   offsetX?: number
   offsetY?: number
   showNullDataPoints?: boolean


### PR DESCRIPTION
# New Pull Request

In the documentation, [`legends.markers`](https://apexcharts.com/docs/options/legend/#markers) has a property `size` (in replacement for `radius` from my understanding). However [the type](https://github.com/apexcharts/apexcharts.js/blob/1dd87abb0dbc0c089f1c82cba34f647fabbcd876/types/apexcharts.d.ts#L826) for it is missing, hence causing an error in the project using this property.

Additionally, these `legends` properties are missing from the documentation but still present in the file:
- `textAnchor`
- `containerMargin`
- `markers.strokeColor`

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

> [!NOTE]
> Not necessarily requires a documentation update but *might*.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
