### PR TITLE
Fix regression issue introduced in 3.49.0

### DIFF
--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -255,10 +255,11 @@ class BarStacked extends Bar {
         barWidth *= parseInt(userColumnWidth, 10) / 100
       }
 
-      zeroH =
-        w.globals.gridHeight -
-        this.baseLineY[translationsIndex] -
-        (this.isReversed ? w.globals.gridHeight : 0)
+      if (this.isReversed) {
+        zeroH = this.baseLineY[translationsIndex]
+      } else {
+        zeroH = w.globals.gridHeight - this.baseLineY[translationsIndex]
+      }
 
       // initial x position is the left-most edge of the first bar relative to
       // the left-most side of the grid area.


### PR DESCRIPTION
A regression introduced by commit 686266c (first appeared in release 3.49.0) caused stacked, reversed column chart with all negative series to render outside of masked plot area and not be visible.

Reduce/simplify the calculation of zeroH.

Fixes #4630

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
