### PR TITLE
Changes to accommodate issue 4632

### DIFF
--- a/samples/react/column/stacked-column-with-line-new.html
+++ b/samples/react/column/stacked-column-with-line-new.html
@@ -295,13 +295,19 @@
                   }
                 }
               },
+              // In order to align the ticks of multiple yaxes with the charts horizontal grid
+              // lines, the scaling of the first [unhidden] yaxis determines the number
+              // of grid lines and hence the number of ticks for all subsequent yaxes, unless
+              // they specify a tickAmount.
+              // We want the stacked bars to have the best possible resolution
+              // visually so they have been listed first.
               yaxis: [
+                {
+                  seriesName: ['Bar1','Bar2','Bar3','bar4']
+                },
                 {
                   seriesName: 'Line',
                   opposite: true
-                },
-                {
-                  seriesName: ['Bar1','Bar2','Bar3','bar4']
                 }
               ],
               legend: {

--- a/samples/source/column/stacked-column-with-line-new.xml
+++ b/samples/source/column/stacked-column-with-line-new.xml
@@ -76,13 +76,19 @@ xaxis: {
     }
   }
 },
+// In order to align the ticks of multiple yaxes with the charts horizontal grid
+// lines, the scaling of the first [unhidden] yaxis determines the number
+// of grid lines and hence the number of ticks for all subsequent yaxes, unless
+// they specify a tickAmount.
+// We want the stacked bars to have the best possible resolution
+// visually so they have been listed first.
 yaxis: [
+  {
+    seriesName: ['Bar1','Bar2','Bar3','bar4']
+  },
   {
     seriesName: 'Line',
     opposite: true
-  },
-  {
-    seriesName: ['Bar1','Bar2','Bar3','bar4']
   }
 ],
 legend: {

--- a/samples/vanilla-js/column/stacked-column-with-line-new.html
+++ b/samples/vanilla-js/column/stacked-column-with-line-new.html
@@ -278,13 +278,19 @@
             }
           }
         },
+        // In order to align the ticks of multiple yaxes with the charts horizontal grid
+        // lines, the scaling of the first [unhidden] yaxis determines the number
+        // of grid lines and hence the number of ticks for all subsequent yaxes, unless
+        // they specify a tickAmount.
+        // We want the stacked bars to have the best possible resolution
+        // visually so they have been listed first.
         yaxis: [
+          {
+            seriesName: ['Bar1','Bar2','Bar3','bar4']
+          },
           {
             seriesName: 'Line',
             opposite: true
-          },
-          {
-            seriesName: ['Bar1','Bar2','Bar3','bar4']
           }
         ],
         legend: {

--- a/samples/vue/column/stacked-column-with-line-new.html
+++ b/samples/vue/column/stacked-column-with-line-new.html
@@ -298,13 +298,19 @@
                 }
               }
             },
+            // In order to align the ticks of multiple yaxes with the charts horizontal grid
+            // lines, the scaling of the first [unhidden] yaxis determines the number
+            // of grid lines and hence the number of ticks for all subsequent yaxes, unless
+            // they specify a tickAmount.
+            // We want the stacked bars to have the best possible resolution
+            // visually so they have been listed first.
             yaxis: [
+              {
+                seriesName: ['Bar1','Bar2','Bar3','bar4']
+              },
               {
                 seriesName: 'Line',
                 opposite: true
-              },
-              {
-                seriesName: ['Bar1','Bar2','Bar3','bar4']
               }
             ],
             legend: {

--- a/tests/unit/exponential-data.spec.js
+++ b/tests/unit/exponential-data.spec.js
@@ -72,6 +72,9 @@ describe('Exponential values should parse', () => {
           ]
         }
       ],
+      yaxis: {
+        tickAmount: 10
+      },
       xaxis: {
         type: 'datetime'
       }

--- a/tests/unit/small-range.spec.js
+++ b/tests/unit/small-range.spec.js
@@ -139,6 +139,7 @@ describe('yaxis scale to ignore duplication if fractions are present in series',
         ],
       },
       yaxis: {
+        tickAmount: 8,
         labels: {
           formatter: (val) => {
             return val.toFixed(2)


### PR DESCRIPTION
1. Unconditionally select default initial axis ticks based on SVG size.
2. Unconditionally, if not user specified, snap yMin or yMax to zero if already close.
3. Re-order yaxes in one sample chart to prioritize stacked column visual resolution. Add comment to draw attention to this feature of multi axis charts.
4. In Scales.niceScale: Check that maxTicks is always valid (suspect some Unit tests don't set SVG dimensions).
5. Set tickAmount explicitly in two unit tests to compensate for variation in scaling following the above changes.

Fixes #4632

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
