### PR TITLE
Fix issue 4645

### DIFF
--- a/src/charts/common/treemap/Helpers.js
+++ b/src/charts/common/treemap/Helpers.js
@@ -61,14 +61,22 @@ export default class TreemapHelpers {
     let utils = new Utils()
 
     if (w.config.plotOptions[chartType].enableShades) {
+      // The shadeColor function may return either an RGB or a hex color value
+      // However, hexToRgba requires the input to be in hex format
+      // The ternary operator checks if the color is in RGB format, and if so, converts it to hex
       if (this.w.config.theme.mode === 'dark') {
+        const shadeColor = utils.shadeColor(
+          colorShadePercent * -1,
+          colorProps.color
+        )
         color = Utils.hexToRgba(
-          utils.shadeColor(colorShadePercent * -1, colorProps.color),
+          Utils.isColorHex(shadeColor) ? shadeColor : Utils.rgb2hex(shadeColor),
           w.config.fill.opacity
         )
       } else {
+        const shadeColor = utils.shadeColor(colorShadePercent, colorProps.color)
         color = Utils.hexToRgba(
-          utils.shadeColor(colorShadePercent, colorProps.color),
+          Utils.isColorHex(shadeColor) ? shadeColor : Utils.rgb2hex(shadeColor),
           w.config.fill.opacity
         )
       }
@@ -132,7 +140,7 @@ export default class TreemapHelpers {
     return {
       color,
       foreColor,
-      percent
+      percent,
     }
   }
 
@@ -148,7 +156,7 @@ export default class TreemapHelpers {
 
     if (dataLabelsConfig.enabled) {
       elDataLabelsWrap = graphics.group({
-        class: 'apexcharts-data-labels'
+        class: 'apexcharts-data-labels',
       })
 
       const offX = dataLabelsConfig.offsetX
@@ -167,7 +175,7 @@ export default class TreemapHelpers {
         color: colorProps.foreColor,
         parent: elDataLabelsWrap,
         fontSize,
-        dataLabelsConfig
+        dataLabelsConfig,
       })
     }
 


### PR DESCRIPTION

# New Pull Request
Fix getShadeColor() handling of RGB values. Ensure hexToRgba receives a hex value by checking if the shadeColor() output is in RGB format; convert to hex if necessary before passing to hexToRgba.

Fixes # (issue)
#4645 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
