### PR TITLE
Fix: direction rtl the vertical text displaced

### DIFF
--- a/src/assets/apexcharts.css
+++ b/src/assets/apexcharts.css
@@ -18,6 +18,7 @@
 
 .apexcharts-canvas {
   position: relative;
+  direction: ltr !important;
   user-select: none
 }
 


### PR DESCRIPTION
# New Pull Request

summary of changes: in **src/assets/apexchart.css** added `direction: ltr !important;`  to ` .apexcharts-canvas`  class.
And the result: when the user uses apexchart.js the the ` .apexcharts-canvas` div inside `#chart` will always be **ltr** even if the user changes the app direction like: `direction: ltr !important;` won't affect the chart.

![fix_apex](https://github.com/user-attachments/assets/a0f8aaf0-3a49-4bbe-a292-9c452bab2491)


Fixes #4660

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
