### PR TITLE
Added support for the Angular compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/apexcharts/apexcharts.js.git"
   },
   "main": "dist/apexcharts.common.js",
+  "es2020": "dist/apexcharts.esm.js",
   "unpkg": "dist/apexcharts.js",
   "jsdelivr": "dist/apexcharts.js",
   "typings": "types/apexcharts.d.ts",


### PR DESCRIPTION
# New Pull Request

The Angular compiler looks for the main field using a few fields in the package.json. The order it uses is:
- es2020
- es2015
- browser
- module
- main

The first entry the Angular compiler would find before this change was the 'main' entry point. This is however compiled as `common js` and Angular is looking for an `esm` so it would complain (it would still work though). Adding `es2020` as an entry point fixes this problem.

Fixes [ng-apexcharts#92](https://github.com/apexcharts/ng-apexcharts/issues/92)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
