### PR TITLE
Restore checks for single isolated data points

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -794,7 +794,6 @@ class Line {
     curve,
     isRangeStart,
   }) {
-    let w = this.w
     let graphics = new Graphics(this.ctx)
     const areaBottomY = this.areaBottomY
     let rangeArea = type === 'rangeArea'
@@ -952,6 +951,13 @@ class Line {
               }
               areaPath = graphics.move(pX, pY)
 
+              // Check for single isolated point
+              if (series[i][j + 1] === null) {
+                linePaths.push(linePath);
+                areaPaths.push(areaPath);
+                // Stay in pathState = 0;
+                break
+              }
               pathState = 1
               if (j < series[i].length - 2) {
                 let p = graphics.curve(pX + length, pY, x - length, y, x, y)
@@ -1034,6 +1040,13 @@ class Line {
               }
               areaPath = graphics.move(pX, pY)
 
+              // Check for single isolated point
+              if (series[i][j + 1] === null) {
+                linePaths.push(linePath);
+                areaPaths.push(areaPath);
+                // Stay in pathState = 0
+                break
+              }
               pathState = 1
               if (j < series[i].length - 2) {
                 let p = pathToPoint(curve, x, y)


### PR DESCRIPTION
Remove unused variable (tidy-up, unrelated to the main issue)

Broken at revision 3.49.0:
Explicitly check for single isolated points when creating paths for 'straight' and 'smooth' curves. Curve type 'monotoneCubic' already does this intrinsically due to the different algorithm employed.

Fixes #4686

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
