### PR TITLE
Added functionality for click, mouseEnter and mouseLeave on annotation labels

### DIFF
--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -34,7 +34,7 @@ export default class PointAnnotations {
         pRadius: anno.marker.radius,
         class: `apexcharts-point-annotation-marker ${anno.marker.cssClass} ${
           anno.id ? anno.id : ''
-          }`,
+        }`,
       }
 
       let point = this.annoCtx.graphics.drawMarker(
@@ -62,7 +62,7 @@ export default class PointAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-point-annotation-label ${
           anno.label.style.cssClass
-          } ${anno.id ? anno.id : ''}`,
+        } ${anno.id ? anno.id : ''}`,
       })
 
       elText.attr({
@@ -81,7 +81,7 @@ export default class PointAnnotations {
         g.attr({
           transform: `translate(${x + anno.customSVG.offsetX}, ${
             y + anno.customSVG.offsetY
-            })`,
+          })`,
         })
 
         g.node.innerHTML = anno.customSVG.SVG

--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -34,7 +34,7 @@ export default class PointAnnotations {
         pRadius: anno.marker.radius,
         class: `apexcharts-point-annotation-marker ${anno.marker.cssClass} ${
           anno.id ? anno.id : ''
-        }`,
+          }`,
       }
 
       let point = this.annoCtx.graphics.drawMarker(
@@ -62,7 +62,7 @@ export default class PointAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-point-annotation-label ${
           anno.label.style.cssClass
-        } ${anno.id ? anno.id : ''}`,
+          } ${anno.id ? anno.id : ''}`,
       })
 
       elText.attr({
@@ -81,7 +81,7 @@ export default class PointAnnotations {
         g.attr({
           transform: `translate(${x + anno.customSVG.offsetX}, ${
             y + anno.customSVG.offsetY
-          })`,
+            })`,
         })
 
         g.node.innerHTML = anno.customSVG.SVG
@@ -115,7 +115,10 @@ export default class PointAnnotations {
         )
       }
       if (anno.click) {
-        point.node.addEventListener('click', anno.click.bind(this, anno))
+        point.node.addEventListener(
+          'click',
+          anno.click.bind(this, anno)
+        )
       }
     }
   }

--- a/src/modules/annotations/XAxisAnnotations.js
+++ b/src/modules/annotations/XAxisAnnotations.js
@@ -84,9 +84,9 @@ export default class XAnnotations {
         anno.label.position === 'top'
           ? 4
           : anno.label.position === 'center'
-            ? w.globals.gridHeight / 2 +
+          ? w.globals.gridHeight / 2 +
             (anno.label.orientation === 'vertical' ? textRects.width / 2 : 0)
-            : w.globals.gridHeight
+          : w.globals.gridHeight
 
       let elText = this.annoCtx.graphics.drawText({
         x: x1 + anno.label.offsetX,
@@ -106,7 +106,7 @@ export default class XAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-xaxis-annotation-label ${
           anno.label.style.cssClass
-          } ${anno.id ? anno.id : ''}`
+        } ${anno.id ? anno.id : ''}`
       })
 
       if (anno.label.mouseEnter) {

--- a/src/modules/annotations/XAxisAnnotations.js
+++ b/src/modules/annotations/XAxisAnnotations.js
@@ -46,7 +46,7 @@ export default class XAnnotations {
       let result = this.helpers.getX1X2('x2', anno)
       x2 = result.x
       clipX2 = result.clipped
-      
+
       if (!(clipX1 && clipX2)) {
         if (x2 < x1) {
           let temp = x1
@@ -84,9 +84,9 @@ export default class XAnnotations {
         anno.label.position === 'top'
           ? 4
           : anno.label.position === 'center'
-          ? w.globals.gridHeight / 2 +
+            ? w.globals.gridHeight / 2 +
             (anno.label.orientation === 'vertical' ? textRects.width / 2 : 0)
-          : w.globals.gridHeight
+            : w.globals.gridHeight
 
       let elText = this.annoCtx.graphics.drawText({
         x: x1 + anno.label.offsetX,
@@ -106,8 +106,27 @@ export default class XAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-xaxis-annotation-label ${
           anno.label.style.cssClass
-        } ${anno.id ? anno.id : ''}`
+          } ${anno.id ? anno.id : ''}`
       })
+
+      if (anno.label.mouseEnter) {
+        elText.node.addEventListener(
+          'mouseenter',
+          anno.label.mouseEnter.bind(this, anno)
+        )
+      }
+      if (anno.label.mouseLeave) {
+        elText.node.addEventListener(
+          'mouseleave',
+          anno.label.mouseLeave.bind(this, anno)
+        )
+      }
+      if (anno.label.click) {
+        elText.node.addEventListener(
+          'click',
+          anno.label.click.bind(this, anno)
+        );
+      }
 
       elText.attr({
         rel: index

--- a/src/modules/annotations/YAxisAnnotations.js
+++ b/src/modules/annotations/YAxisAnnotations.js
@@ -81,8 +81,8 @@ export default class YAnnotations {
         anno.label.position === 'right'
           ? w.globals.gridWidth
           : anno.label.position === 'center'
-          ? w.globals.gridWidth / 2
-          : 0
+            ? w.globals.gridWidth / 2
+            : 0
 
       let elText = this.annoCtx.graphics.drawText({
         x: textX + anno.label.offsetX,
@@ -95,8 +95,27 @@ export default class YAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-yaxis-annotation-label ${
           anno.label.style.cssClass
-        } ${anno.id ? anno.id : ''}`
+          } ${anno.id ? anno.id : ''}`
       })
+
+      if (anno.label.mouseEnter) {
+        elText.node.addEventListener(
+          'mouseenter',
+          anno.label.mouseEnter.bind(this, anno)
+        )
+      }
+      if (anno.label.mouseLeave) {
+        elText.node.addEventListener(
+          'mouseleave',
+          anno.label.mouseLeave.bind(this, anno)
+        )
+      }
+      if (anno.label.click) {
+        elText.node.addEventListener(
+          'click',
+          anno.label.click.bind(this, anno)
+        );
+      }
 
       elText.attr({
         rel: index
@@ -128,8 +147,8 @@ export default class YAnnotations {
     w.config.annotations.yaxis.forEach((anno, index) => {
       anno.yAxisIndex = this.axesUtils.translateYAxisIndex(anno.yAxisIndex)
       if (
-            !(this.axesUtils.isYAxisHidden(anno.yAxisIndex)
-            && this.axesUtils.yAxisAllSeriesCollapsed(anno.yAxisIndex))
+        !(this.axesUtils.isYAxisHidden(anno.yAxisIndex)
+          && this.axesUtils.yAxisAllSeriesCollapsed(anno.yAxisIndex))
       ) {
         this.addYaxisAnnotation(anno, elg.node, index)
       }

--- a/src/modules/annotations/YAxisAnnotations.js
+++ b/src/modules/annotations/YAxisAnnotations.js
@@ -81,8 +81,8 @@ export default class YAnnotations {
         anno.label.position === 'right'
           ? w.globals.gridWidth
           : anno.label.position === 'center'
-            ? w.globals.gridWidth / 2
-            : 0
+          ? w.globals.gridWidth / 2
+          : 0
 
       let elText = this.annoCtx.graphics.drawText({
         x: textX + anno.label.offsetX,
@@ -95,7 +95,7 @@ export default class YAnnotations {
         foreColor: anno.label.style.color,
         cssClass: `apexcharts-yaxis-annotation-label ${
           anno.label.style.cssClass
-          } ${anno.id ? anno.id : ''}`
+        } ${anno.id ? anno.id : ''}`
       })
 
       if (anno.label.mouseEnter) {
@@ -147,8 +147,8 @@ export default class YAnnotations {
     w.config.annotations.yaxis.forEach((anno, index) => {
       anno.yAxisIndex = this.axesUtils.translateYAxisIndex(anno.yAxisIndex)
       if (
-        !(this.axesUtils.isYAxisHidden(anno.yAxisIndex)
-          && this.axesUtils.yAxisAllSeriesCollapsed(anno.yAxisIndex))
+            !(this.axesUtils.isYAxisHidden(anno.yAxisIndex)
+            && this.axesUtils.yAxisAllSeriesCollapsed(anno.yAxisIndex))
       ) {
         this.addYaxisAnnotation(anno, elg.node, index)
       }


### PR DESCRIPTION
# New Pull Request

I saw that the `AnnotationLabel` type includes `click`, `mouseEnter`, and `mouseLeave` events, which are also mentioned in the documentation. However, no corresponding functionality was found in the codebase.

I replicated the logic from `PointAnnotations.addPointAnnotation` to implement these events.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
