### PR TITLE
Fix createBorderRadiusArr

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -251,7 +251,7 @@ export default class Helpers {
       w.config.plotOptions.bar.borderRadius <= 0
 
     const numSeries = series.length
-    const numColumns = series[0].length
+    const numColumns = series[0]?.length | 0
     const output = Array.from({ length: numSeries }, () =>
       Array(numColumns).fill(alwaysApplyRadius ? 'top' : 'none')
     )


### PR DESCRIPTION
Function ```createBorderRadiusArr()``` failed if no series are defined, eg when data series are expected to be loaded later via the update call. Two samples (axios and jquery) were failing during ```npm run e2e```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
