### PR TITLE
Update types to add missing arguments and return types

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -924,7 +924,7 @@ type ApexDataLabels = {
     dropShadow?: ApexDropShadow
   }
   dropShadow?: ApexDropShadow
-  formatter?(val: string | number | number[], opts?: any): string | number
+  formatter?(val: string | number | number[], opts?: any): string | number | string[]
 }
 
 type ApexResponsive = {
@@ -934,7 +934,7 @@ type ApexResponsive = {
 
 type ApexTooltipY = {
   title?: {
-    formatter?(seriesName: string): string
+    formatter?(seriesName: string, opts?: any): string
   }
   formatter?(val: number, opts?: any): string
 }


### PR DESCRIPTION
# Fixing types

## :one:
The `dataLabels` formatter can return an array. It will display both string on a separate line.
You can see this usage in this demo: [Treemap color range](https://apexcharts.com/vue-chart-demos/treemap-charts/color-range/)

```js
dataLabels: {
  ...
  formatter: function(text, op) {
    return [text, op.value]
  },
  ...
},
```

We can see further down in the code that the function is handling the case where `text` is an array: https://github.com/apexcharts/apexcharts.js/blob/483c471aeec4c9fa3401ed23cfe1219ba264da82/src/modules/Graphics.js#L693

----

## :two: 

The tooltip y formatter, accepts a second arguments (like many other formatter). It's `opts?: any` and is missing.
This one fixes #4762 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
