### PR TITLE
Fix isolated point in line chart not closing path

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -953,7 +953,7 @@ class Line {
               areaPath = graphics.move(pX, pY)
 
               // Check for single isolated point
-              if (series[i][j + 1] === null) {
+              if (series[i][j + 1] === null || typeof series[i][j + 1] === 'undefined') {
                 linePaths.push(linePath)
                 areaPaths.push(areaPath)
                 // Stay in pathState = 0;
@@ -1042,7 +1042,7 @@ class Line {
               areaPath = graphics.move(pX, pY)
 
               // Check for single isolated point
-              if (series[i][j + 1] === null) {
+              if (series[i][j + 1] === null || typeof series[i][j + 1] === 'undefined') {
                 linePaths.push(linePath)
                 areaPaths.push(areaPath)
                 // Stay in pathState = 0


### PR DESCRIPTION

With a Line chart representing a time series, isolated points were trying to close a path. This PR fixes this issue by checking that the point is unique using the already present logic that was handling isolated points in between `null` values.

Current version (4.0.0) jsfiddle showcasing the issue: https://jsfiddle.net/kocz16s2/ 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] My branch is up to date with any changes from the main branch
