### PR TITLE
#4763 bugfix Display error Date when set xaxis frist label close to next day.

### DIFF
--- a/src/modules/TimeScale.js
+++ b/src/modules/TimeScale.js
@@ -635,6 +635,8 @@ class TimeScale {
       hour = 0
       date += 1
       unit = 'day'
+      // Unit changed to day , Value should align unit 
+      firstTickValue = date
     }
 
     const checkNextMonth = changeDate(date, currentMonth)


### PR DESCRIPTION
# New Pull Request
bugfix Display error Date when set xaxis first label close to next day


Fixes # (issue)
#4763 

## Type of change
Align the timeScale value where set timeScale unit to 'day' in generateHourScale
- [x] Bug fix (#4763)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
