### PR TITLE
bugfix #4767 Get 'NaN' in tooltip of Timeline Series. Get 'undefined'…

### DIFF
--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -641,7 +641,7 @@ class Line {
         }
       }
 
-      if (typeof w.globals.seriesX[realIndex][j + 1] === 'undefined') {
+      if (typeof w.globals.seriesX[realIndex][j + 1] !== 'undefined') {
         // push current X
         xArrj.push(x)
       }

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -387,7 +387,7 @@ class Line {
     if (forecast.count > 0 && type !== 'rangeArea') {
       const forecastCutoff =
         w.globals.seriesXvalues[realIndex][
-          w.globals.seriesXvalues[realIndex].length - forecast.count - 1
+        w.globals.seriesXvalues[realIndex].length - forecast.count - 1
         ]
       const elForecastMask = graphics.drawRect(
         forecastCutoff,
@@ -641,8 +641,10 @@ class Line {
         }
       }
 
-      // push current X
-      xArrj.push(x)
+      if (typeof w.globals.seriesX[realIndex][j + 1] === 'undefined') {
+        // push current X
+        xArrj.push(x)
+      }
 
       // push current Y that will be used as next series's bottom position
       if (

--- a/tests/unit/xaxis.spec.js
+++ b/tests/unit/xaxis.spec.js
@@ -254,3 +254,81 @@ describe('User defined X-axis min/max', () => {
     expect(xRange.maxX).toEqual(40)
   })
 })
+
+describe('Timeline Series', () => {
+  it.only('globals.seriesXvalues[index] should have a correct length', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+      },
+      series: [
+        {
+          name: "blue",
+          data: [[1697511654207, 2.46]]
+        },
+        {
+          name: "green",
+          data: [[1697511328360, 2.53]]
+        },
+        {
+          name: "yellow",
+          data: [[1697511328360, 2.33]]
+        }
+      ],
+      xaxis: {
+        type: 'datetime',
+        max: 1697522893476,
+        min: 1697263693476,
+        tickAmount: 10,
+        convertedCatToNumeric: false,
+        labels: {
+          datetimeUTC: false,
+          formatter: undefined,
+          datetimeFormatter: {
+            year: 'yyyy',
+            month: 'MMM yyyy',
+            day: 'dd MMM',
+            hour: 'HH:mm'
+          }
+        }
+      },
+      yaxis: {
+        tickAmount: 10,
+        title: {
+          text: 'Odds'
+        },
+        labels: {
+          formatter: (val) => {
+            return parseFloat(val).toFixed(2)
+          }
+        },
+        min: (min) => min - 0.5,
+        max: 3.03
+      },
+      grid: {
+        xaxis: {
+          lines: {
+            show: true
+          }
+        },
+        yaxis: {
+          lines: {
+            show: true
+          }
+        }
+      },
+      stroke: {
+        width: 3,
+        curve: 'stepline',
+        dashArray: [0, 0, 0, 4],
+        show: true
+      }
+    })
+    const iterations = chart.w.globals.dataPoints > 1
+      ? chart.w.globals.dataPoints - 1
+      : chart.w.globals.dataPoints
+    chart.w.globals.seriesXvalues.forEach(item => {
+      expect(item.length === iterations)
+    })
+  })
+})

--- a/tests/unit/xaxis.spec.js
+++ b/tests/unit/xaxis.spec.js
@@ -256,7 +256,7 @@ describe('User defined X-axis min/max', () => {
 })
 
 describe('Timeline Series', () => {
-  it.only('globals.seriesXvalues[index] should have a correct length', () => {
+  it('globals.seriesXvalues[index] should have a correct length', () => {
     const chart = createChartWithOptions({
       chart: {
         type: 'line',


### PR DESCRIPTION
… at tooltip.y.formatter first arguments

# New Pull Request
Bugfix #4767 Get 'NaN' in tooltip of Timeline Series. Get 'undefined' at tooltip.y.formatter first arguments
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
#4767 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
