### PR TITLE
fixes #4811

### DIFF
--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -237,6 +237,7 @@ export default class Labels {
 
     if (typeof yLbTitleFormatter !== 'function') {
       yLbTitleFormatter = function (label) {
+        // refrence used from line: 966 in Options.js
          return label ? label + ': ' : ''
       }
     }

--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -237,7 +237,7 @@ export default class Labels {
 
     if (typeof yLbTitleFormatter !== 'function') {
       yLbTitleFormatter = function (label) {
-        return label
+         return label ? label + ': ' : ''
       }
     }
 


### PR DESCRIPTION


# New Pull Request

This PR addresses an inconsistency in the tooltip label behavior. Previously, on configuring tooltip for multiple y series, when a formatter function was provided only for the tooltip value, the title's default formatter applied differed from when no formatter was provided. Now, the title will maintain a consistent default format regardless of whether a value formatter is used alone.

Fixes #4811

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
