### PR TITLE
Allow pan and zoom on mobile devices

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -174,7 +174,7 @@ export default class ZoomPanSelection extends Toolbar {
         ? e.changedTouches[0].clientY
         : e.clientY
 
-    if (e.type === 'mousedown' && e.which === 1) {
+    if ((e.type === 'mousedown' && e.which === 1) || e.type === 'touchstart') {
       let gridRectDim = me.gridRect.getBoundingClientRect()
 
       me.startX = me.clientX - gridRectDim.left


### PR DESCRIPTION
# New Pull Request

Allow pan and zoom on mobile devices by also considering the `touchstart` event when attempting to zoom or pan the chart.

Fixes #3675 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
