### PR TITLE
Fix render bar when initialPositions start from almost zero

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -138,7 +138,7 @@ export default class Helpers {
 
       x =
         w.globals.padHorizontal +
-        (xDivision - barWidth * this.barCtx.seriesLen) / 2
+        this.roundTooSmallerValue(xDivision - barWidth * this.barCtx.seriesLen) / 2
     }
 
     w.globals.barHeight = barHeight
@@ -801,5 +801,10 @@ export default class Helpers {
       columnGroupIndex = cGI.length - 1
     }
     return { groupIndex, columnGroupIndex }
+  }
+
+  roundTooSmallerValue(value) {
+    if (value < 0.000001) return 0;
+    return value;
   }
 }


### PR DESCRIPTION
# New Pull Request

When `plotOptions.bar.columnWidth = '100%'`, sometime `xDivision - barWidth * this.barCtx.seriesLen` makes almost zero value(for example, `7.105427357601002e-15`).
For result, SVG path data contains exponential notation values and broken.

This PR round value to zero if smaller than `0.000001`.

Fixes #4879

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
