### PR TITLE
Remove use of global `ApexCharts` class

### DIFF
--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -561,7 +561,7 @@ export default class Core {
   }
 
   setupBrushHandler() {
-    const { w } = this
+    const { ctx, w } = this
 
     if (!w.config.chart.brush.enabled) return
 
@@ -570,7 +570,7 @@ export default class Core {
         ? w.config.chart.brush.targets
         : [w.config.chart.brush.target]
       targets.forEach((target) => {
-        const targetChart = ApexCharts.getChartByID(target)
+        const targetChart = ctx.constructor.getChartByID(target)
         targetChart.w.globals.brushSource = this.ctx
 
         if (typeof targetChart.w.config.chart.events.zoomed !== 'function') {
@@ -585,7 +585,7 @@ export default class Core {
 
       w.config.chart.events.selection = (chart, e) => {
         targets.forEach((target) => {
-          const targetChart = ApexCharts.getChartByID(target)
+          const targetChart = ctx.constructor.getChartByID(target)
           targetChart.ctx.updateHelpers._updateOptions(
             {
               xaxis: {


### PR DESCRIPTION
# New Pull Request

The `setupBrushHandler` method of the `Core` class relies on the `ApexCharts` class' static `getChartByID` method. It calls this static method on the `ApexCharts` class directly without importing it currently.

This is fine if consuming `apexcharts` via
CDN / script tag as that places the exported `ApexCharts` class in the global scope, but it becomes an issue when users want to consume `apexcharts` via a package manager.

Update the `setupBrushHandler` method to call `ApexCharts.getChartByID` the `Core` class' `ctx` field instead.

Fixes https://github.com/apexcharts/react-apexcharts/issues/666


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- - e2e tests passed locally
- - I haven't been able to verify that the unit test suite passes because they seem to be broken. I get the `getBBox is not a function` error when I run them, which I can see has been occurring in your `Node.js CI` action. I'm not sure if that's related to the browser API or one of your internal utils but let me know if you want me to rebase / merge changes in once that's fixed and run the unit tests.
- [x] My branch is up to date with any changes from the main branch