### PR TITLE
range: Fix getting decimal part of numbers close to 0

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -167,8 +167,8 @@ class Range {
           }
           highestY = maxY
 
+          val = Utils.noExponents(val)
           if (Utils.isFloat(val)) {
-            val = Utils.noExponents(val)
             gl.yValueDecimal = Math.max(
               gl.yValueDecimal,
               val.toString().split('.')[1].length


### PR DESCRIPTION
# New Pull Request

Previously, isFloat was being called on val before noExponents. This meant that if a value was particularly close to zero, it might pass the isFloat check but then be stripped down to just 0 by noExponents, which meant that getting the second element after splitting around the decimal point would fail.

This patch just does noExponent first so that if the value ends up being a round number, it doesn't enter that branch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
