### PR TITLE
Fix issue with fixed Tooltip not working on nonAxisChart

### DIFF
--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -470,10 +470,6 @@ export default class Tooltip {
       }
     }
 
-    if (ttCtx.fixedTooltip) {
-      ttCtx.drawFixedTooltipRect()
-    }
-
     if (w.globals.axisCharts) {
       ttCtx.axisChartsTooltips({
         e,
@@ -487,6 +483,10 @@ export default class Tooltip {
         opt,
         tooltipRect: ttCtx.tooltipRect,
       })
+    }
+
+    if (ttCtx.fixedTooltip) {
+      ttCtx.drawFixedTooltipRect()
     }
   }
 


### PR DESCRIPTION
# New Pull Request

Fixes [#4720](https://github.com/apexcharts/apexcharts.js/issues/4720)

This PR addresses an issue where the fixed option in the tooltip configuration for Pie/Donut charts was not working as expected. When `tooltip: { fixed: { enabled: true } }` option was set, the tooltip did not remain fixed in position.

### Summary of Change

The problem was caused by the tooltip position being recalculated by the`nonAxisChartsTooltips()` function, which overwrote the fixed position of the tooltip. The issue was resolved by changing the order of function execution so that `nonAxisChartsTooltips()` runs first, followed by the `drawFixedTooltipRect()` function that fixes the tooltip position.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
