### PR TITLE
feature: add support for custom slice thickness in Donut chart

### DIFF
--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -125,7 +125,10 @@ class Pie {
         sectorAngleArr[i] = this.fullAngle / series.length
         this.sliceSizes.push((w.globals.radialSize * series[i]) / this.maxY)
       } else {
-        this.sliceSizes.push(w.globals.radialSize)
+        let ratio = w.config.plotOptions.pie.donut.thickness?.[i] || 1
+        let adjustment = (w.globals.radialSize - this.donutSize) * ratio
+        let sliceSize = this.donutSize + adjustment
+        this.sliceSizes.push(sliceSize)
       }
     }
 

--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -170,7 +170,7 @@ class Pie {
       elSeries.add(circle)
     }
 
-    let elG = self.drawArcs(sectorAngleArr, series)
+    let elG = self.drawArcs(sectorAngleArr, this.sliceSizes, series)
 
     // add slice dataLabels at the end
     this.sliceLabels.forEach((s) => {
@@ -208,7 +208,7 @@ class Pie {
   }
 
   // core function for drawing pie arcs
-  drawArcs(sectorAngleArr, series) {
+  drawArcs(sectorAngleArr, sliceSizes, series) {
     let w = this.w
     const filters = new Filters(this.ctx)
 
@@ -303,7 +303,7 @@ class Pie {
         labelPosition = Utils.polarToCartesian(
           this.centerX,
           this.centerY,
-          (w.globals.radialSize + this.donutSize) / 2 +
+          (sliceSizes[i] + this.donutSize) / 2 +
             w.config.plotOptions.pie.dataLabels.offset,
           (startAngle + angle / 2) % this.fullAngle
         )

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -664,6 +664,7 @@ type ApexPlotOptions = {
     donut?: {
       size?: string
       background?: string
+      thickness?: number[]
       labels?: {
         show?: boolean
         name?: {


### PR DESCRIPTION
# New Pull Request

Related [#4878](https://github.com/apexcharts/apexcharts.js/issues/4878)

This PR introduces the ability to set different slice thicknesses in the Donut chart by adding a thickness option. Previously, the Donut chart used a uniform slice thickness, but with this change, users can specify varying thicknesses for each slice.

### Summary of Change

**Example usage:**
<img width="350" alt="donut chart with thickness" src="https://github.com/user-attachments/assets/3beb5570-1ef2-4380-847f-1babbe6832d5" />

```
plotOptions: {
    pie:{
        donut:{
            size: '30%',
            thickness: [0.5, 1, 1.2, 0.8, 0.2], // new option
        }
    }
}
```

With the thickness option, users can now define the thickness ratio for each slice within the donut configuration.

**Implementation Details:**

The thickness values, provided as ratios, are applied to the difference between radialSize and donutSize.(This subtraction ensures that the inner donutSize remains consistent.) The resulting adjustment is then added to the donutSize to calculate the updated sliceSize for each segment.

Additionally, the position of the data labels within the donut chart has been adjusted. The donut labelPosition in the `drawArcs()` function was updated to ensure that the data labels are centered within the slices, reflecting their new sizes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
