### PR TITLE
Fix datetime stackbar width

### DIFF
--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -262,11 +262,11 @@ class BarStacked extends Bar {
       barWidth = xDivision
 
       let userColumnWidth = w.config.plotOptions.bar.columnWidth
-      if (w.globals.isXNumeric && w.globals.dataPoints > 1) {
+      if (String(userColumnWidth).indexOf('%') === -1) {
+        barWidth = parseInt(userColumnWidth, 10)
+      } else if (w.globals.isXNumeric && w.globals.dataPoints > 1) {
         xDivision = w.globals.minXDiff / this.xRatio
         barWidth = (xDivision * parseInt(this.barOptions.columnWidth, 10)) / 100
-      } else if (String(userColumnWidth).indexOf('%') === -1) {
-        barWidth = parseInt(userColumnWidth, 10)
       } else if (w.config.xaxis.type === 'datetime') {
         const dateTimeUtil = new DateTime(this.ctx)
         const timescaleTimestamps = w.globals.timescaleLabels.map((label) =>

--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -301,6 +301,8 @@ class BarStacked extends Bar {
           minimumInterval / (w.globals.maxX - w.globals.minX)
         barWidth =
           (xDivision * intervalRatio * parseInt(userColumnWidth, 10)) / 100
+
+        barWidth = Math.max(barWidth, 1)
       } else {
         barWidth *= parseInt(userColumnWidth, 10) / 100
       }

--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -266,6 +266,14 @@ class BarStacked extends Bar {
         barWidth = (xDivision * parseInt(this.barOptions.columnWidth, 10)) / 100
       } else if (String(userColumnWidth).indexOf('%') === -1) {
         barWidth = parseInt(userColumnWidth, 10)
+      } else if (
+        w.config.xaxis.type === 'datetime' &&
+        w.globals.dataPoints == 1
+      ) {
+        barWidth =
+          ((xDivision / w.globals.timescaleLabels.length) *
+            parseInt(userColumnWidth, 10)) /
+          100
       } else {
         barWidth *= parseInt(userColumnWidth, 10) / 100
       }


### PR DESCRIPTION
# New Pull Request

Fixes #4885 

Fixed a bug where bar widths in stacked bar charts became abnormally large when using a DateTime axis.
Updated the bar width calculation logic so that the bars no longer overlap.
When columnwidth is explicitly set, it now takes precedence and is applied first before any other logic.

- before
![image](https://github.com/user-attachments/assets/4c91af1e-2ef6-46a4-a087-cad2eff3ccdb)

- after
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/9810f664-8f54-4b2e-a817-d2a71d14f57c" />

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
