### PR TITLE
Fixing unnecessary chart destroy on create

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -131,7 +131,6 @@ export default class ApexCharts {
 
     if (!Utils.elementExists(this.el)) {
       gl.animationEnded = true
-      this.destroy()
       return null
     }
 


### PR DESCRIPTION
# Preventing to destroy the chart on create

After [this commit](https://github.com/apexcharts/apexcharts.js/commit/5c3bba02849982cdcc5ec236ead609b50b593ae2#diff-c799981553c8e8e3e5321e944950ffef1fc4776a77b12bc138be46325bda1543R50), the `ApexChart` doesn't work with `Tabs` properly.  I made a demonstration setup  about the issue with Vue and Quasar frameworks:
https://codepen.io/siczmj/pen/vEYxBxL

You can see that the `ApexChart` appears on first rendering, but it disappears after tab switching. To reproduce it click on "Second" then on "First" tab. My investigation showed that this is caused by the invoked `destroy()` method added by the [linked commit](https://github.com/apexcharts/apexcharts.js/commit/5c3bba02849982cdcc5ec236ead609b50b593ae2#diff-c799981553c8e8e3e5321e944950ffef1fc4776a77b12bc138be46325bda1543R50).

By removing the `this.destroy()` it looks good to me.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
