### PR TITLE
Fix y-axis formatter retrieval by series name

### DIFF
--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -202,10 +202,30 @@ export default class Labels {
     }
   }
 
+  getFormatterBySeriesName(seriesIndex, w) {
+    const seriesName = w.config.series[seriesIndex].name
+    const yAxis = w.config.yaxis
+
+    for (let i = 0; i < yAxis.length; i++) {
+      const yAxisItem = yAxis[i]
+
+      if (Array.isArray(yAxisItem.seriesName)) {
+        if (yAxisItem.seriesName.includes(seriesName)) {
+          return yAxisItem.labels.formatter
+        }
+      } else if (yAxisItem.seriesName === seriesName) {
+        return yAxisItem.labels.formatter
+      }
+    }
+
+    return (val) => val
+  }
+
   getFormatters(i) {
     const w = this.w
 
-    let yLbFormatter = w.globals.yLabelFormatters[i]
+    // let yLbFormatter = w.globals.yLabelFormatters[i]
+    let yLbFormatter = this.getFormatterBySeriesName(i, w)
     let yLbTitleFormatter
 
     if (w.globals.ttVal !== undefined) {

--- a/src/modules/tooltip/Labels.js
+++ b/src/modules/tooltip/Labels.js
@@ -224,7 +224,6 @@ export default class Labels {
   getFormatters(i) {
     const w = this.w
 
-    // let yLbFormatter = w.globals.yLabelFormatters[i]
     let yLbFormatter = this.getFormatterBySeriesName(i, w)
     let yLbTitleFormatter
 


### PR DESCRIPTION
# New Pull Request

Fix #4966 

This PR modifies the way the y-axis formatter is retrieved in getFormatters(i).

Previously, the formatter was obtained from w.globals.yLabelFormatters[i], which relied on the index. This approach caused issues when the yaxis array was shorter than the series array, especially in cases where some yaxis items had seriesName values in an array format (as seen in the issue example).

To resolve this, I introduced a new function, getFormatterBySeriesName(seriesIndex, w), which finds the appropriate formatter by matching the seriesName within the yaxis array. This ensures that the correct formatter is applied based on the series name rather than relying on array indices.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
