### PR TITLE
Extend annotation label text type to array

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -367,7 +367,7 @@ type AnnotationLabel = {
   borderColor?: string
   borderWidth?: number
   borderRadius?: number
-  text?: string
+  text?: string | string[]
   textAnchor?: string
   offsetX?: number
   offsetY?: number


### PR DESCRIPTION
There is support for multiline text already but it's missing in types.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
