### PR TITLE
Fix comparison bug in clipping calculation

### DIFF
--- a/src/modules/annotations/Helpers.js
+++ b/src/modules/annotations/Helpers.js
@@ -219,7 +219,9 @@ export default class Helpers {
         w.globals.barWidth * anno.seriesIndex
     }
 
-    if (xP.toFixed(10) > w.globals.gridWidth.toFixed(10)) {
+    if (
+      parseFloat(xP.toFixed(10)) > parseFloat(w.globals.gridWidth.toFixed(10))
+    ) {
       xP = w.globals.gridWidth
       clipped = true
     } else if (xP < 0) {


### PR DESCRIPTION
# New Pull Request

.toFixed(10) was added in #4985 to address a clipping bug, but since it returns a string, direct comparison caused incorrect clipping.

Fixed by converting values to numbers with parseFloat() before comparison.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
