### PR TITLE
Enable rendering negative area chart with lines of any color

### DIFF
--- a/samples/react/area/area-with-negative-and-lines.html
+++ b/samples/react/area/area-with-negative-and-lines.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Area with different negative color</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      #chart {
+        max-width: 650px;
+        margin: 35px auto;
+      }
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prop-types@15.8.1/prop-types.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-apexcharts@1.7.0/dist/react-apexcharts.iife.min.js"></script>
+
+    <script>
+      // Replace Math.random() with a pseudo-random number generator to get reproducible results in e2e tests
+      // Based on https://gist.github.com/blixt/f17b47c62508be59987b
+      var _seed = 42
+      Math.random = function () {
+        _seed = (_seed * 16807) % 2147483647
+        return (_seed - 1) / 2147483646
+      }
+    </script>
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <div id="html">
+      &lt;div id=&quot;chart&quot;&gt; &lt;ReactApexChart
+      options={state.options} series={state.series} type=&quot;area&quot;
+      height={350} /&gt; &lt;/div&gt;
+    </div>
+
+    <script type="text/babel">
+      const ApexChart = () => {
+        const [state, setState] = React.useState({
+          series: [
+            {
+              data: [0, -41, 35, -51, 0, 62, -69, 32, -32, 54, 16, -50],
+              type: 'area',
+              color: '#ff0000',
+            },
+            {
+              data: [1, 10, 20, -10, -15, -20, -30, 22, 60, 30, 36, 45],
+              type: 'line',
+              color: '#0000FF',
+            },
+            {
+              data: [-15, -25, -40, -10, 15, 40, 59, 32, 0, -30, 36, 45],
+              type: 'line',
+              color: '#000000',
+            },
+          ],
+          options: {
+            chart: {
+              height: 350,
+              type: 'area',
+              zoom: {
+                enabled: false,
+              },
+            },
+            dataLabels: {
+              enabled: false,
+            },
+            title: {
+              text: 'Negative color for values less than 0',
+              align: 'left',
+            },
+            xaxis: {
+              categories: [
+                'Jan',
+                'Feb',
+                'Mar',
+                'Apr',
+                'May',
+                'Jun',
+                'Jul',
+                'Aug',
+                'Sep',
+                'Oct',
+                'Nov',
+                'Dec',
+              ],
+            },
+            stroke: {
+              width: [0, 2, 2],
+            },
+            fill: {
+              opacity: 1,
+              type: 'solid',
+            },
+            plotOptions: {
+              line: {
+                // Add new prop to define which series the plot option should be applied.
+                enabledOnSeries: [0],
+                colors: {
+                  threshold: 0,
+                  colorAboveThreshold: '#00FF00',
+                  colorBelowThreshold: '#ff0000',
+                },
+              },
+            },
+          },
+        })
+
+        return (
+          <div>
+            <div id="chart">
+              <ReactApexChart
+                options={state.options}
+                series={state.series}
+                type="area"
+                height={350}
+              />
+            </div>
+            <div id="html-dist"></div>
+          </div>
+        )
+      }
+
+      const domContainer = document.querySelector('#app')
+      ReactDOM.render(<ApexChart />, domContainer)
+    </script>
+  </body>
+</html>

--- a/src/modules/Fill.js
+++ b/src/modules/Fill.js
@@ -164,7 +164,7 @@ class Fill {
     const drawMultiColorLine =
       cnf.plotOptions.line.colors.colorAboveThreshold &&
       cnf.plotOptions.line.colors.colorBelowThreshold &&
-      // undefined enabledOnnSeries means enabled on all series.
+      // undefined enabledOnSeries means enabled on all series.
       (!cnf.plotOptions.line.enabledOnSeries ||
         (Array.isArray(cnf.plotOptions.line.enabledOnSeries) &&
           cnf.plotOptions.line.enabledOnSeries.indexOf(this.seriesIndex) >= 0))

--- a/src/modules/Fill.js
+++ b/src/modules/Fill.js
@@ -163,7 +163,11 @@ class Fill {
 
     const drawMultiColorLine =
       cnf.plotOptions.line.colors.colorAboveThreshold &&
-      cnf.plotOptions.line.colors.colorBelowThreshold
+      cnf.plotOptions.line.colors.colorBelowThreshold &&
+      // undefined enabledOnnSeries means enabled on all series.
+      (!cnf.plotOptions.line.enabledOnSeries ||
+        (Array.isArray(cnf.plotOptions.line.enabledOnSeries) &&
+          cnf.plotOptions.line.enabledOnSeries.indexOf(this.seriesIndex) >= 0))
 
     let fillColors = this.getFillColors()
     let fillColor = fillColors[this.seriesIndex]

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -514,6 +514,7 @@ type ApexLocale = {
  */
 type ApexPlotOptions = {
   line?: {
+    enabledOnSeries?: undefined | number[]
     isSlopeChart?: boolean
     colors?: {
       threshold?: number,


### PR DESCRIPTION
The negative area chart is very useful, but currently it cannot be combined with other series because all series are painted with the same pattern.

# New Pull Request

To enable drawing other series (indicator and signal lines) next to negative area chart, the negative area coloring should be only applied to specific series and not all of them. To enable this feature, enabledOnSeries prop was added to the plotOptions.line.

Bunch of unit tests are breaking on main without my change, so I am not sure how to cleanly test it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
      Unit tests don't pass on clean main.
- [X] My branch is up to date with any changes from the main branch