### PR TITLE
Added customClass to Legend labels

### DIFF
--- a/src/modules/legend/Legend.js
+++ b/src/modules/legend/Legend.js
@@ -230,6 +230,9 @@ class Legend {
 
       let elLegendText = document.createElement('span')
       elLegendText.classList.add('apexcharts-legend-text')
+      if (w.config.legend.labels.customClass) {
+        elLegendText.classList.add(w.config.legend.labels.customClass)
+      }
       elLegendText.innerHTML = Array.isArray(text) ? text.join(' ') : text
 
       let textColor = w.config.legend.labels.useSeriesColors

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -838,6 +838,7 @@ export default class Options {
         labels: {
           colors: undefined,
           useSeriesColors: false,
+          customClass: undefined,
         },
         markers: {
           size: 7,

--- a/tests/unit/legend-label-custom-class.spec.js
+++ b/tests/unit/legend-label-custom-class.spec.js
@@ -1,0 +1,62 @@
+import { createChartWithOptions } from './utils/utils'
+
+describe('Legend Label Custom Class', () => {
+  it('should add custom classes to legend labels', () => {
+    // Create a chart instance with options that include legend label custom classes
+    const chart = createChartWithOptions({
+      series: [{
+        name: 'Series 1',
+        data: [30, 40, 45, 50, 49, 60, 70, 91, 125]
+      }, {
+        name: 'Series 2',
+        data: [20, 30, 35, 40, 39, 50, 60, 81, 115]
+      }],
+      chart: {
+        type: 'line',
+        height: 350
+      },
+      legend: {
+        labels: {
+          useSeriesColors: false,
+          customClass: 'custom-legend-class'
+        }
+      }
+    })
+
+    // Check if the legend labels will have the custom class
+    expect(chart.w.config.legend.labels.customClass).toBe('custom-legend-class')
+  })
+
+  it('should apply the custom class for specific series', () => {
+    // Create a chart instance with options that include legend label custom classes for specific series
+    const chart = createChartWithOptions({
+      series: [{
+        name: 'Series 1',
+        data: [30, 40, 45, 50, 49, 60, 70, 91, 125]
+      }, {
+        name: 'Series 2',
+        data: [20, 30, 35, 40, 39, 50, 60, 81, 115]
+      }],
+      chart: {
+        type: 'line',
+        height: 350
+      },
+      legend: {
+        labels: {
+          customClass: (seriesName) => {
+            if (seriesName === 'Series 1') {
+              return 'series-1-class'
+            }
+            return 'other-series-class'
+          }
+        }
+      }
+    })
+
+    // Test that the function in customClass works correctly
+    const legendLabels = chart.w.config.legend.labels
+    expect(typeof legendLabels.customClass).toBe('function')
+    expect(legendLabels.customClass('Series 1')).toBe('series-1-class')
+    expect(legendLabels.customClass('Series 2')).toBe('other-series-class')
+  })
+})

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -856,6 +856,7 @@ type ApexLegend = {
   labels?: {
     colors?: string | string[]
     useSeriesColors?: boolean
+    customClass?: string
   }
   markers?: {
     size?: number


### PR DESCRIPTION
# New Pull Request

Added a simple 'customClass' property to Legend.Labels which, when rendered, adds the custom class to "apexcharts-legend-text" DOM element for custom CSS.

Fixes # (issue)

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
