### PR TITLE
 Remove old chart instance when screen resizes to prevent memory leak

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -399,15 +399,9 @@ export default class ApexCharts {
     window.removeEventListener('resize', this.windowResizeHandler)
 
     removeResizeListener(this.el.parentNode, this.parentResizeHandler)
-    // remove the chart's instance from the global Apex._chartInstances
-    const chartID = this.w.config.chart.id
-    if (chartID) {
-      Apex._chartInstances.forEach((c, i) => {
-        if (c.id === Utils.escapeString(chartID)) {
-          Apex._chartInstances.splice(i, 1)
-        }
-      })
-    }
+
+    this._removeOldChartInstance()
+
     new Destroy(this.ctx).clear({ isUpdating: false })
   }
 
@@ -544,6 +538,8 @@ export default class ApexCharts {
         // Options are identical, skip the update
         return resolve(this)
       }
+
+      this._removeOldChartInstance()
 
       this.lastUpdateOptions = Utils.clone(options)
 
@@ -795,7 +791,19 @@ export default class ApexCharts {
       this._windowResize()
     }
   }
-
+  /**
+   * Remove the chart's old instance from the global Apex._chartInstances
+   */
+  _removeOldChartInstance() {
+    const chartID = this.w.config.chart.id
+    if (chartID) {
+      Apex._chartInstances.forEach((c, i) => {
+        if (c.id === Utils.escapeString(chartID)) {
+          Apex._chartInstances.splice(i, 1)
+        }
+      })
+    }
+  }
   /**
    * Handle window resize and re-draw the whole chart.
    */


### PR DESCRIPTION
# New Pull Request

This PR fixes the issue of the memory leak described in #5028 . 

Each time the screen is resized, a new chart is created and added to the global `Apex._chartInstances` array. However, old chart instances were not being cleaned up on window resize, which led to a significant increase in memory usage over multiple resizes.

I extracted the logic used in the `ApexCharts ` class’s `destroy()` method to remove old chart instances, moved it into a private method (`_removeOldChartInstance()`), and now call that method from both `update()` and `destroy()`.

Fixes #5028

Below is a comparison of the memory after resizing the window 7 times. After multiple tests the average is a ~97% reduction in memory usage.

Before:
<img src="https://github.com/user-attachments/assets/9cd48e3e-2e92-420b-8773-2f2697f5aff9" width="600" />

After:
<img src="https://github.com/user-attachments/assets/a1612a55-1d8f-4799-81c7-a3691cb993e1" width="600" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
