### PR TITLE
When the numeric range is small, show one tick for every integer, ins…

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -428,7 +428,8 @@ class Range {
         if (gl.isXNumeric) {
           const diff = Math.round(gl.maxX - gl.minX)
           if (diff < 30) {
-            ticks = diff - 1
+            // When numeric range is small, show a tick for every integer
+            ticks = diff
           }
         }
       } else {


### PR DESCRIPTION
fixes #5015

The code is quite hairy, so I'm not sure this is the proper fix. 

And there may be additional bugs in addition to this one (even with the odd values passed as `xaxisLabels`, it should probably never show a tick with a label that does not match its position).

@junedchhipa
