### PR TITLE
Add a missing type and removes an unused type

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1072,9 +1072,9 @@ type ApexXAxis = {
   axisBorder?: {
     show?: boolean
     color?: string
+    height?: number
     offsetX?: number
     offsetY?: number
-    strokeWidth?: number
   }
   axisTicks?: {
     show?: boolean


### PR DESCRIPTION
# New Pull Request

Includes the height property to xAxis type and removes the strokeWidth property which was being unused. The documentations is currently outdated for xAxis.axisBorder and yAxis.axisBorder, so it needs an update considering the new types.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] My branch is up to date with any changes from the main branch
