### PR TITLE
Unhide pan/zoomselect for mobile/touch devices

### DIFF
--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -90,9 +90,7 @@ export default class Toolbar {
               : icoSelect,
           title:
             this.localeValues[z === 'zoom' ? 'selectionZoom' : 'selection'],
-          class: w.globals.isTouchDevice
-            ? 'apexcharts-element-hidden'
-            : `apexcharts-${z}-icon`,
+          class: `apexcharts-${z}-icon`,
         })
       }
     }
@@ -104,9 +102,7 @@ export default class Toolbar {
         el: this.elPan,
         icon: typeof this.t.pan === 'string' ? this.t.pan : icoPan,
         title: this.localeValues.pan,
-        class: w.globals.isTouchDevice
-          ? 'apexcharts-element-hidden'
-          : 'apexcharts-pan-icon',
+        class: 'apexcharts-pan-icon',
       })
     }
 


### PR DESCRIPTION
# New Pull Request

With release 4.1.0 a functionality was introduced to enable the toolbar items for pan and zoomselect. However, due to the toolbar.js code they remained invisible. This fixes that. 

Fixes a already closed issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
