### PR TITLE
Feature/single data area chart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,4 +157,16 @@ This way, when later working on a feature or fix, `npm run test` command will de
 
 We'd love for you to contribute your changes back to `apexcharts.js`! To do that, it would be great if you could commit your changes to a separate feature branch and open a Pull Request for those changes.
 
-Point your feature branch to use the `main`
+Point your feature branch to use the `main` branch as the base of this PR. The exact commands used depends on how you've setup your local git copy, but the flow could look like this:
+
+```sh
+# Inside your own copy of `apexcharts.js` package...
+git checkout --branch feature/branch-name-here upstream/main
+# Then hack away, and commit your changes:
+git add -A
+git commit -m "Few words about the changes I did"
+# Push your local changes back to your fork
+git push --set-upstream origin feature/branch-name-here
+```
+
+After these steps, you should be able to create a new Pull Request for this repository. If you hit any issues following these instructions, please open an issue and we'll see if we can improve these instructions even further.

--- a/samples/react/area/area-single-data.html
+++ b/samples/react/area/area-single-data.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Area Chart with Single Data Point - React</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      .chart-container {
+        max-width: 650px;
+        margin: 35px auto;
+        padding: 20px;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+      }
+
+      .chart-title {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 10px;
+        text-align: center;
+        color: #333;
+      }
+
+      .chart-description {
+        font-size: 14px;
+        color: #666;
+        margin-bottom: 15px;
+        text-align: center;
+      }
+
+      .main-title {
+        text-align: center;
+        font-size: 24px;
+        font-weight: bold;
+        margin: 20px 0;
+        color: #333;
+      }
+
+      .info-box {
+        background-color: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 5px;
+        padding: 15px;
+        margin: 20px auto;
+        max-width: 650px;
+      }
+
+      .info-box h3 {
+        margin: 0 0 10px 0;
+        color: #495057;
+      }
+
+      .info-box p {
+        margin: 5px 0;
+        color: #6c757d;
+      }
+    </style>
+
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+    ></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <script type="text/babel">
+      class LegendCSSInjectionDemo extends React.Component {
+        constructor(props) {
+          super(props)
+
+          this.state = {
+            baseOptions: {
+              series: [
+                {
+                  name: 'Revenue',
+                  type: 'column',
+                  data: [
+                    440, 505, 414, 671, 227, 413, 201, 352, 752, 320, 257, 160,
+                  ],
+                },
+                {
+                  name: 'Profit',
+                  type: 'area',
+                  data: [23, 42, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16],
+                },
+                {
+                  name: 'Single data Area chart',
+                  type: 'area',
+                  data: [223],
+                },
+                {
+                  name: 'Two data Area chart',
+                  type: 'area',
+                  data: [453, 120],
+                },
+                {
+                  name: 'Free Cash Flow',
+                  type: 'line',
+                  data: [35, 41, 36, 26, 45, 48, 52, 53, 41, 35, 25, 18],
+                },
+              ],
+              chart: {
+                height: 350,
+                type: 'line',
+                stacked: false,
+              },
+              stroke: {
+                width: [0, 2, 2, 2, 2],
+                curve: 'smooth',
+              },
+              plotOptions: {
+                bar: {
+                  columnWidth: '50%',
+                },
+                area: {},
+              },
+              fill: {
+                type: 'gradient',
+                opacity: [0.85, 0.25, 1],
+                gradient: {
+                  inverseColors: false,
+                  shade: 'light',
+                  type: 'vertical',
+                  opacityFrom: 0.85,
+                  opacityTo: 0.55,
+                  stops: [0, 100, 100, 100],
+                },
+              },
+              labels: [
+                'Jan',
+                'Feb',
+                'Mar',
+                'Apr',
+                'May',
+                'Jun',
+                'Jul',
+                'Aug',
+                'Sep',
+                'Oct',
+                'Nov',
+                'Dec',
+              ],
+              markers: {
+                size: 4,
+              },
+              xaxis: {
+                type: 'category',
+              },
+              yaxis: {
+                title: {
+                  text: 'Amount ($)',
+                },
+              },
+              tooltip: {
+                shared: true,
+                intersect: false,
+                y: {
+                  formatter: function (y) {
+                    if (typeof y !== 'undefined') {
+                      return '$' + y.toFixed(0) + 'k'
+                    }
+                    return y
+                  },
+                },
+              },
+              legend: {
+                position: 'bottom',
+                horizontalAlign: 'left',
+                floating: true,
+                offsetY: 25,
+                offsetX: -5,
+              },
+            },
+          }
+        }
+
+        componentDidMount() {
+          // Chart 1: With forceSingleDataAsArea = true
+          const options1 = JSON.parse(JSON.stringify(this.state.baseOptions))
+          options1.plotOptions.area.forceSingleDataAsArea = true
+          this.chart1 = new ApexCharts(this.refs.chart1, options1)
+          this.chart1.render()
+
+          // Chart 2: With forceSingleDataAsArea = false
+          const options2 = JSON.parse(JSON.stringify(this.state.baseOptions))
+          options2.plotOptions.area.forceSingleDataAsArea = false
+          this.chart2 = new ApexCharts(this.refs.chart2, options2)
+          this.chart2.render()
+
+          // Chart 3: With forceSingleDataAsArea = undefined
+          const options3 = JSON.parse(JSON.stringify(this.state.baseOptions))
+          this.chart3 = new ApexCharts(this.refs.chart3, options3)
+          this.chart3.render()
+        }
+
+        componentWillUnmount() {
+          if (this.chart1) {
+            this.chart1.destroy()
+          }
+          if (this.chart2) {
+            this.chart2.destroy()
+          }
+          if (this.chart3) {
+            this.chart3.destroy()
+          }
+        }
+
+        render() {
+          return (
+            <div>
+              <div className="main-title">
+                Area Chart with Single Data Point - React
+              </div>
+
+              <div className="info-box">
+                <h3>About this demo</h3>
+                <p>
+                  This demo shows the{' '}
+                  <code>plotOptions.area.forceSingleDataAsArea</code> option in
+                  action using React.
+                </p>
+                <p>
+                  • <strong>true</strong>: Single data point is shown as an area
+                </p>
+                <p>
+                  • <strong>false</strong>: Single data point is shown as a
+                  marker
+                </p>
+              </div>
+
+              <div className="chart-container">
+                <div className="chart-title">
+                  Chart with forceSingleDataAsArea = true
+                </div>
+                <div className="chart-description">
+                  plotOptions.area.forceSingleDataAsArea: true
+                </div>
+                <div ref="chart1"></div>
+              </div>
+
+              <div className="chart-container">
+                <div className="chart-title">
+                  Chart with forceSingleDataAsArea = false
+                </div>
+                <div className="chart-description">
+                  plotOptions.area.forceSingleDataAsArea: false
+                </div>
+                <div ref="chart2"></div>
+              </div>
+
+              <div className="chart-container">
+                <div className="chart-title">
+                  Chart with forceSingleDataAsArea = undefined
+                </div>
+                <div className="chart-description">
+                  plotOptions.area.forceSingleDataAsArea: undefined
+                </div>
+                <div ref="chart3"></div>
+              </div>
+            </div>
+          )
+        }
+      }
+
+      ReactDOM.render(
+        <LegendCSSInjectionDemo />,
+        document.getElementById('app')
+      )
+    </script>
+  </body>
+</html>

--- a/samples/vanilla-js/area/area-single-data.html
+++ b/samples/vanilla-js/area/area-single-data.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Area Chart with Single Data Point</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      .chart-container {
+        max-width: 650px;
+        margin: 35px auto;
+        padding: 20px;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+      }
+
+      .chart-title {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 10px;
+        text-align: center;
+        color: #333;
+      }
+
+      .chart-description {
+        font-size: 14px;
+        color: #666;
+        margin-bottom: 15px;
+        text-align: center;
+      }
+
+      .main-title {
+        text-align: center;
+        font-size: 24px;
+        font-weight: bold;
+        margin: 20px 0;
+        color: #333;
+      }
+
+      .info-box {
+        background-color: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 5px;
+        padding: 15px;
+        margin: 20px auto;
+        max-width: 650px;
+      }
+
+      .info-box h3 {
+        margin: 0 0 10px 0;
+        color: #495057;
+      }
+
+      .info-box p {
+        margin: 5px 0;
+        color: #6c757d;
+      }
+    </style>
+
+    <script>
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/eligrey-classlist-js-polyfill@1.2.20171210/classList.min.js"><\/script>'
+        )
+      window.Promise ||
+        document.write(
+          '<script src="https://cdn.jsdelivr.net/npm/findindex_polyfill_mdn"><\/script>'
+        )
+    </script>
+
+    <script src="../../../dist/apexcharts.js"></script>
+  </head>
+
+  <body>
+    <div class="main-title">Area Chart with Single Data Point</div>
+
+    <div class="info-box">
+      <h3>About this demo</h3>
+      <p>
+        This demo shows the
+        <code>plotOptions.area.forceSingleDataAsArea</code> option in action
+        using Vanilla JS.
+      </p>
+      <p>• <strong>true</strong>: Single data point is shown as an area</p>
+      <p>• <strong>false</strong>: Single data point is shown as a marker</p>
+    </div>
+
+    <div class="chart-container">
+      <div class="chart-title">Chart with forceSingleDataAsArea = true</div>
+      <div class="chart-description">
+        plotOptions.area.forceSingleDataAsArea: true
+      </div>
+      <div id="chart1"></div>
+    </div>
+
+    <div class="chart-container">
+      <div class="chart-title">Chart with forceSingleDataAsArea = false</div>
+      <div class="chart-description">
+        plotOptions.area.forceSingleDataAsArea: false
+      </div>
+      <div id="chart2"></div>
+    </div>
+
+    <div class="chart-container">
+      <div class="chart-title">
+        Chart with forceSingleDataAsArea = undefined
+      </div>
+      <div class="chart-description">
+        plotOptions.area.forceSingleDataAsArea: undefined
+      </div>
+      <div id="chart3"></div>
+    </div>
+
+    <script>
+      // Common chart configuration
+      var baseOptions = {
+        series: [
+          {
+            name: 'Revenue',
+            type: 'column',
+            data: [440, 505, 414, 671, 227, 413, 201, 352, 752, 320, 257, 160],
+          },
+          {
+            name: 'Profit',
+            type: 'area',
+            data: [23, 42, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16],
+          },
+          {
+            name: 'Single data Area chart',
+            type: 'area',
+            data: [223],
+          },
+          {
+            name: 'Two data Area chart',
+            type: 'area',
+            data: [453, 120],
+          },
+          {
+            name: 'Free Cash Flow',
+            type: 'line',
+            data: [35, 41, 36, 26, 45, 48, 52, 53, 41, 35, 25, 18],
+          },
+        ],
+        chart: {
+          height: 350,
+          type: 'line',
+          stacked: false,
+        },
+        stroke: {
+          width: [0, 2, 2, 2, 2],
+          curve: 'smooth',
+        },
+        plotOptions: {
+          bar: {
+            columnWidth: '50%',
+          },
+          area: {},
+        },
+        fill: {
+          type: 'gradient',
+          opacity: [0.85, 0.25, 1],
+          gradient: {
+            inverseColors: false,
+            shade: 'light',
+            type: 'vertical',
+            opacityFrom: 0.85,
+            opacityTo: 0.55,
+            stops: [0, 100, 100, 100],
+          },
+        },
+        labels: [
+          'Jan',
+          'Feb',
+          'Mar',
+          'Apr',
+          'May',
+          'Jun',
+          'Jul',
+          'Aug',
+          'Sep',
+          'Oct',
+          'Nov',
+          'Dec',
+        ],
+        markers: {
+          size: 4,
+        },
+        xaxis: {
+          type: 'category',
+        },
+        yaxis: {
+          title: {
+            text: 'Amount ($)',
+          },
+        },
+        tooltip: {
+          shared: true,
+          intersect: false,
+          y: {
+            formatter: function (y) {
+              if (typeof y !== 'undefined') {
+                return '$' + y.toFixed(0) + 'k'
+              }
+              return y
+            },
+          },
+        },
+        legend: {
+          position: 'bottom',
+          horizontalAlign: 'left',
+          floating: true,
+          offsetY: 25,
+          offsetX: -5,
+        },
+      }
+
+      // Chart 1: With forceSingleDataAsArea = true
+      var options1 = JSON.parse(JSON.stringify(baseOptions))
+      options1.plotOptions.area.forceSingleDataAsArea = true
+      var chart1 = new ApexCharts(document.querySelector('#chart1'), options1)
+      chart1.render()
+
+      // Chart 2: With forceSingleDataAsArea = false
+      var options2 = JSON.parse(JSON.stringify(baseOptions))
+      options2.plotOptions.area.forceSingleDataAsArea = false
+      var chart2 = new ApexCharts(document.querySelector('#chart2'), options2)
+      chart2.render()
+
+      // Chart 3: With forceSingleDataAsArea = undefined
+      var options3 = JSON.parse(JSON.stringify(baseOptions))
+      var chart3 = new ApexCharts(document.querySelector('#chart3'), options3)
+      chart3.render()
+    </script>
+  </body>
+</html>

--- a/samples/vue/area/area-single-data.html
+++ b/samples/vue/area/area-single-data.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Area Chart with Single Data Point - Vue</title>
+
+    <link href="../../assets/styles.css" rel="stylesheet" />
+
+    <style>
+      .chart-container {
+        max-width: 650px;
+        margin: 35px auto;
+        padding: 20px;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+      }
+
+      .chart-title {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 10px;
+        text-align: center;
+        color: #333;
+      }
+
+      .chart-description {
+        font-size: 14px;
+        color: #666;
+        margin-bottom: 15px;
+        text-align: center;
+      }
+
+      .main-title {
+        text-align: center;
+        font-size: 24px;
+        font-weight: bold;
+        margin: 20px 0;
+        color: #333;
+      }
+
+      .info-box {
+        background-color: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 5px;
+        padding: 15px;
+        margin: 20px auto;
+        max-width: 650px;
+      }
+
+      .info-box h3 {
+        margin: 0 0 10px 0;
+        color: #495057;
+      }
+
+      .info-box p {
+        margin: 5px 0;
+        color: #6c757d;
+      }
+    </style>
+
+    <script src="https://unpkg.com/vue@2.6.14/dist/vue.js"></script>
+    <script src="../../../dist/apexcharts.js"></script>
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="main-title">Area Chart with Single Data Point - Vue</div>
+
+      <div class="info-box">
+        <h3>About this demo</h3>
+        <p>
+          This demo shows the
+          <code>plotOptions.area.forceSingleDataAsArea</code> option in action
+          using Vue.js.
+        </p>
+        <p>• <strong>true</strong>: Single data point is shown as an area</p>
+        <p>• <strong>false</strong>: Single data point is shown as a marker</p>
+      </div>
+
+      <div class="chart-container">
+        <div class="chart-title">Chart with forceSingleDataAsArea = true</div>
+        <div class="chart-description">
+          plotOptions.area.forceSingleDataAsArea: true
+        </div>
+        <div ref="chart1"></div>
+      </div>
+
+      <div class="chart-container">
+        <div class="chart-title">Chart with forceSingleDataAsArea = false</div>
+        <div class="chart-description">
+          plotOptions.area.forceSingleDataAsArea: false
+        </div>
+        <div ref="chart2"></div>
+      </div>
+
+      <div class="chart-container">
+        <div class="chart-title">
+          Chart with forceSingleDataAsArea = undefined
+        </div>
+        <div class="chart-description">
+          plotOptions.area.forceSingleDataAsArea: undefined
+        </div>
+        <div ref="chart3"></div>
+      </div>
+    </div>
+
+    <script>
+      new Vue({
+        el: '#app',
+        data() {
+          return {
+            baseOptions: {
+              series: [
+                {
+                  name: 'Revenue',
+                  type: 'column',
+                  data: [
+                    440, 505, 414, 671, 227, 413, 201, 352, 752, 320, 257, 160,
+                  ],
+                },
+                {
+                  name: 'Profit',
+                  type: 'area',
+                  data: [23, 42, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16],
+                },
+                {
+                  name: 'Single data Area chart',
+                  type: 'area',
+                  data: [223],
+                },
+                {
+                  name: 'Two data Area chart',
+                  type: 'area',
+                  data: [453, 120],
+                },
+                {
+                  name: 'Free Cash Flow',
+                  type: 'line',
+                  data: [35, 41, 36, 26, 45, 48, 52, 53, 41, 35, 25, 18],
+                },
+              ],
+              chart: {
+                height: 350,
+                type: 'line',
+                stacked: false,
+              },
+              stroke: {
+                width: [0, 2, 2, 2, 2],
+                curve: 'smooth',
+              },
+              plotOptions: {
+                bar: {
+                  columnWidth: '50%',
+                },
+                area: {},
+              },
+              fill: {
+                type: 'gradient',
+                opacity: [0.85, 0.25, 1],
+                gradient: {
+                  inverseColors: false,
+                  shade: 'light',
+                  type: 'vertical',
+                  opacityFrom: 0.85,
+                  opacityTo: 0.55,
+                  stops: [0, 100, 100, 100],
+                },
+              },
+              labels: [
+                'Jan',
+                'Feb',
+                'Mar',
+                'Apr',
+                'May',
+                'Jun',
+                'Jul',
+                'Aug',
+                'Sep',
+                'Oct',
+                'Nov',
+                'Dec',
+              ],
+              markers: {
+                size: 4,
+              },
+              xaxis: {
+                type: 'category',
+              },
+              yaxis: {
+                title: {
+                  text: 'Amount ($)',
+                },
+              },
+              tooltip: {
+                shared: true,
+                intersect: false,
+                y: {
+                  formatter: function (y) {
+                    if (typeof y !== 'undefined') {
+                      return '$' + y.toFixed(0) + 'k'
+                    }
+                    return y
+                  },
+                },
+              },
+              legend: {
+                position: 'bottom',
+                horizontalAlign: 'left',
+                floating: true,
+                offsetY: 25,
+                offsetX: -5,
+              },
+            },
+          }
+        },
+        mounted() {
+          // Chart 1: With forceSingleDataAsArea = true
+          const options1 = JSON.parse(JSON.stringify(this.baseOptions))
+          options1.plotOptions.area.forceSingleDataAsArea = true
+          this.chart1 = new ApexCharts(this.$refs.chart1, options1)
+          this.chart1.render()
+
+          // Chart 2: With forceSingleDataAsArea = false
+          const options2 = JSON.parse(JSON.stringify(this.baseOptions))
+          options2.plotOptions.area.forceSingleDataAsArea = false
+          this.chart2 = new ApexCharts(this.$refs.chart2, options2)
+          this.chart2.render()
+
+          // Chart 3: With forceSingleDataAsArea = undefined
+          const options3 = JSON.parse(JSON.stringify(this.baseOptions))
+          this.chart3 = new ApexCharts(this.$refs.chart3, options3)
+          this.chart3.render()
+        },
+        beforeDestroy() {
+          if (this.chart1) {
+            this.chart1.destroy()
+          }
+          if (this.chart2) {
+            this.chart2.destroy()
+          }
+          if (this.chart3) {
+            this.chart3.destroy()
+          }
+        },
+      })
+    </script>
+  </body>
+</html>

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -414,6 +414,7 @@ export default class Options {
         },
         area: {
           fillTo: 'origin',
+          forceSingleDataAsArea: false,
         },
         bar: {
           horizontal: false,


### PR DESCRIPTION
# New Pull Request

## Summary

- Added a new option: `plotOptions.area.forceSingleDataAsArea`.
- When this option is enabled, area charts with only a single data point will render the area (filled region) instead of just a marker.
- Previously, area charts with a single data point would only display a marker. With `forceSingleDataAsArea: true`, the chart will visually fill the area beneath the single point, maintaining the area chart style.

## Motivation and Context

- This feature was added in response to my requesting that area charts with a single data point still display as an area, not just a marker.
- It is useful for cases where data is sparse or changes in real-time, and a consistent area chart appearance is desired.
- This change is backward compatible; the default value is `false`, so existing behavior is preserved unless the option is explicitly enabled.

## Fixes

Fixes # (issue)  
※ Please fill in the issue number if applicable.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My branch is up to date with any changes from the main branch
