### PR TITLE
fix(types): also use ApexParsing for ApexAxisChartSeries parsing prop

### DIFF
--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -306,10 +306,7 @@ type ApexAxisChartSeries = {
  group?: string
  hidden?: boolean
  zIndex?: number
- parsing?: {
-   x?: string;
-   y?: string;
- };
+ parsing?: ApexParsing;
  data:
  | (number | null)[]
  | {


### PR DESCRIPTION
The issue is with the type of the series property in Angular (prob. React as well) using the `ApexAxisChartSeries` type where `parsing` is still two string props, so an array for `y` isn't accepted even though it works just fine:
<img width="633" height="248" alt="image" src="https://github.com/user-attachments/assets/24a34c26-981f-4135-bbf7-6036b7210bb9" />

Noticed `ApexOptions.parsing` is using a different type that allows this so I unified the `parsing` in both places to use it. Didn't see any tests for this that should be updated and as far as I can tell Angular/React wrappers use the base types directly, so this should reflect everywhere.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
