### PR TITLE
fix: Shared Tooltip part of series invisible

### DIFF
--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -255,10 +255,11 @@ export default class Utils {
   isInitialSeriesSameLen() {
     let sameLen = true
 
-    const initialSeries = this.w.globals.initialSeries?.filter(
-      (s, i) => this.w.globals.collapsedSeriesIndices?.indexOf(i) === -1
-    )
-    
+    const initialSeries =
+      this.w.globals.initialSeries?.filter(
+        (s, i) => !this.w.globals.collapsedSeriesIndices?.includes(i)
+      ) || []
+
     for (let i = 0; i < initialSeries.length - 1; i++) {
       if (initialSeries[i].data.length !== initialSeries[i + 1].data.length) {
         sameLen = false


### PR DESCRIPTION
# New Pull Request

isInitialSeriesSameLen returns `false` due to `hidden` series having 0-length data ininitialSeries. This forces the tooltip to be treated as non-shared, and due toisXNumericusage in categorical charts, it falls back to displaying the first series info.

Fixes https://github.com/apexcharts/apexcharts.js/issues/5140

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My branch is up to date with any changes from the main branch


**Tooltip display after the fix**

https://github.com/user-attachments/assets/41b430f5-9dd0-407a-868a-392fdf7436a1
