### PR TITLE
fix: zoomPanSelection min & max drag values

### DIFF
--- a/dist/apexcharts.js
+++ b/dist/apexcharts.js
@@ -35570,12 +35570,23 @@
       const y2 = this.box.y2 + dy;
       let box = new Box(this.box);
       if (this.eventType.includes("l")) {
-        box.x = Math.min(x, this.box.x2);
+        box.x = Math.max(Math.min(x, this.box.x2), 0);
         box.x2 = Math.max(x, this.box.x2);
       }
       if (this.eventType.includes("r")) {
+        // Calculating max x2 value based on brush chart width
+        const chartInstances = window?.Apex?._chartInstances || []
+        const bottomChart = chartInstances?.find((cI) => cI?.id === 'chart1')
+        
+        const { lgRect, xAxisWidth, gridPad } =
+          bottomChart?.chart?.dimensions ?? {}
+        const { width: lgRectWidth = 0 } = lgRect
+        const { left: leftPadding = 0, right: rightPadding = 0 } = gridPad ?? {}
+       
+        const MaxDragValue = lgRectWidth - (leftPadding + rightPadding + xAxisWidth)
+        
         box.x = Math.min(x2, this.box.x);
-        box.x2 = Math.max(x2, this.box.x);
+        box.x2 = Math.min(Math.max(x2, this.box.x), MaxDragValue);
       }
       if (this.eventType.includes("t")) {
         box.y = Math.min(y, this.box.y2);


### PR DESCRIPTION
# New Pull Request

This PR fixes the Brush Chart data boundaries when resizing the selection area. When a user drags a selection handle beyond the minimum or maximum data limit, the selection will be constrained to the actual data range.

Fixes https://github.com/apexcharts/apexcharts.js/issues/5123

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My branch is up to date with any changes from the main branch

**Working example**

https://github.com/user-attachments/assets/99b1d071-69a9-4423-ab3f-42b21c818dcd
