### PR TITLE
fix: Area chart fill for null values

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -1,19 +1,19 @@
-import apexCSS from './assets/apexcharts.css'
 import Annotations from './modules/annotations/Annotations'
-import Grid from './modules/axes/Grid'
-import XAxis from './modules/axes/XAxis'
-import YAxis from './modules/axes/YAxis'
 import Base from './modules/Base'
 import CoreUtils from './modules/CoreUtils'
 import DataLabels from './modules/DataLabels'
+import Defaults from './modules/settings/Defaults'
 import Exports from './modules/Exports'
-import Destroy from './modules/helpers/Destroy'
-import InitCtxVariables from './modules/helpers/InitCtxVariables'
+import Grid from './modules/axes/Grid'
 import Markers from './modules/Markers'
 import Range from './modules/Range'
-import Defaults from './modules/settings/Defaults'
-import { addResizeListener, removeResizeListener } from './utils/Resize'
 import Utils from './utils/Utils'
+import XAxis from './modules/axes/XAxis'
+import YAxis from './modules/axes/YAxis'
+import InitCtxVariables from './modules/helpers/InitCtxVariables'
+import Destroy from './modules/helpers/Destroy'
+import { addResizeListener, removeResizeListener } from './utils/Resize'
+import apexCSS from './assets/apexcharts.css'
 
 /**
  *
@@ -140,7 +140,9 @@ export default class ApexCharts {
 
         return {
           ...series,
-          data: series?.data?.filter((vals) => !vals?.some((val) => val == null)),
+          data: series?.data?.filter(
+            (vals) => !vals?.some((val) => val == null)
+          ),
         }
       })
     }


### PR DESCRIPTION
# New Pull Request

This PR fixes the issue of random area chart distortion and random fills when `null` values are present in data.

Fixes https://github.com/apexcharts/apexcharts.js/issues/5120

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My branch is up to date with any changes from the main branch

**Chart after the fix**

<img width="1512" height="829" alt="Screenshot 2025-12-21 at 10 55 05 PM" src="https://github.com/user-attachments/assets/5c812296-497f-45e5-9714-357477903fb1" />
