### PR TITLE
fix: Point annotation text x-overflow

### DIFF
--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -65,6 +65,23 @@ export default class PointAnnotations {
         } ${anno.id ? anno.id : ''}`,
       })
 
+      const gridWidth = this?.w?.globals?.gridWidth;
+      const textWidth = elText?.node?.getBBox()?.width;
+      const textLeft = elText?.node?.getBBox()?.x;
+      const textRight = textLeft + textWidth;
+      const overflowOffset = textRight - x;
+      const exceedsGrid = textRight > gridWidth;
+
+      if (x === 0) {
+        elText.attr({
+          x: x + overflowOffset,
+        })
+      } else if (x > 0 && exceedsGrid) {
+        elText.attr({
+          x: x - overflowOffset,
+        })
+      }
+
       elText.attr({
         rel: index,
       })


### PR DESCRIPTION
# New Pull Request

This PR fixes point annotation text overflow near chart edges & adjusts X positioning to keep labels within the grid.

Fixes https://github.com/apexcharts/apexcharts.js/issues/5106

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch

**Annotation text after the fix**

<img width="1512" height="829" alt="Screenshot 2025-12-25 at 9 14 50 PM" src="https://github.com/user-attachments/assets/e69cd295-3cc4-40ac-8eee-8b116db7dc4f" />

**Existing annotation chart after the fix**

<img width="1512" height="829" alt="Screenshot 2025-12-25 at 9 14 40 PM" src="https://github.com/user-attachments/assets/20d088e9-5803-416c-9a21-eb1eaca508f3" />
