### PR TITLE
fix(legend): allow to use font-size units other than pixel

### DIFF
--- a/src/modules/legend/Legend.js
+++ b/src/modules/legend/Legend.js
@@ -244,7 +244,7 @@ class Legend {
 
       elLegendText.style.color = textColor
 
-      elLegendText.style.fontSize = parseFloat(w.config.legend.fontSize) + 'px'
+      elLegendText.style.fontSize = w.config.legend.fontSize
       elLegendText.style.fontWeight = w.config.legend.fontWeight
       elLegendText.style.fontFamily = fontFamily || w.config.chart.fontFamily
 


### PR DESCRIPTION
Currently, legend font-size is always suffixed by a 'px'.

On the other hand, documentation (<https://apexcharts.com/docs/options/legend/>) gives the impression that one could freely choose the CSS font unit (considering that the same is possible in other places of apexcharts).

```json
legend: {
      ...
      fontSize: '14px',
      ...
}
``` 

This PR removes the suffix, allowing to configure other font-units like 'rem', 'vh', etc.

Might fix #3341

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [~] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [~] I have added tests that prove my fix is effective or that my feature works
- [~] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
