### PR TITLE
Add strokeColor property to forecastDataPoints options

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -430,6 +430,9 @@ class Bar {
           renderedPath.node.setAttribute('stroke-dasharray', forecast.dashArray)
           renderedPath.node.setAttribute('stroke-width', forecast.strokeWidth)
           renderedPath.node.setAttribute('fill-opacity', forecast.fillOpacity)
+          if (forecast.strokeColor) {
+            renderedPath.node.setAttribute('stroke', forecast.strokeColor)
+          }
         }
       }
 

--- a/src/charts/Line.js
+++ b/src/charts/Line.js
@@ -524,6 +524,13 @@ class Line {
             )
           }
 
+          if (forecast.strokeColor) {
+            renderedForecastPath.node.setAttribute(
+              'stroke',
+              forecast.strokeColor
+            )
+          }
+
           this.elSeries.add(renderedForecastPath)
           renderedForecastPath.attr(
             'clip-path',

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -786,6 +786,7 @@ export default class Options {
         fillOpacity: 0.5,
         strokeWidth: undefined,
         dashArray: 4,
+        strokeColor: undefined,
       },
       grid: {
         show: true,

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1228,6 +1228,7 @@ type ApexForecastDataPoints = {
   fillOpacity?: number
   strokeWidth?: undefined | number
   dashArray?: number
+  strokeColor?: string
 }
 
 /**


### PR DESCRIPTION
# New Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Summary

 - Adds a new `strokeColor` property to `forecastDataPoints` that allows customizing the stroke color of forecast data points separately from the main series color
- Works for line, area, and bar chart types

## Motivation

Currently, forecast data points can be styled with custom `dashArray`, `strokeWidth`, and `fillOpacity`, but the stroke color always inherits from the series. This change allows users to visually distinguish forecast data with a different color. (This is a requirement for one of my project ^^)

  ## Usage

 ```javascript
  forecastDataPoints: {
    count: 7,
    dashArray: 4,
    fillOpacity: 0.5,
    strokeColor: '#ff0000'  // New property
}
```

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
