### PR TITLE
fix: make tooltip stay in the chart boundary

### DIFF
--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -1066,6 +1066,7 @@ export default class Options {
         items: {
           display: 'flex',
         },
+        keepInBoundary: true,
         fixed: {
           enabled: false,
           position: 'topRight', // topRight, topLeft, bottomRight, bottomLeft

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -1066,7 +1066,7 @@ export default class Options {
         items: {
           display: 'flex',
         },
-        keepInBoundary: true,
+        keepInBoundary: false,
         fixed: {
           enabled: false,
           position: 'topRight', // topRight, topLeft, bottomRight, bottomLeft

--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -31,7 +31,7 @@ class Intersect {
    */
   getAttr(e, attr) {
     return parseFloat(
-      /** @type {Element} */ (e.target).getAttribute(attr) ?? '',
+      /** @type {Element} */(e.target).getAttribute(attr) ?? '',
     )
   }
 
@@ -79,6 +79,18 @@ class Intersect {
           seriesBound.top -
           (y > w.layout.gridHeight / 2 ? ttCtx.tooltipRect.ttHeight : 0)
       }
+    }
+
+    if (ttCtx.w.config.tooltip.keepInBoundary) {
+      // Avoid going out of the boundaries of the chart
+      y = Math.max(0, y);
+      x = Math.max(0, x);
+    }
+
+    if (ttCtx.w.config.tooltip.keepInBoundary) {
+      // Avoid going out of the boundaries of the chart
+      y = Math.max(0, y);
+      x = Math.max(0, x);
     }
 
     return {
@@ -146,6 +158,12 @@ class Intersect {
         y = cy
       }
       ttCtx.marker.enlargeCurrentPoint(j, opt.paths, x, y)
+    }
+
+    if (ttCtx.w.config.tooltip.keepInBoundary) {
+      // Avoid going out of the boundaries of the chart
+      y = Math.max(0, y);
+      x = Math.max(0, x);
     }
 
     return {
@@ -237,6 +255,13 @@ class Intersect {
         (w.globals.isBarHorizontal && ttCtx.tooltipUtil.hasBars()))
     ) {
       y = y + w.layout.translateY - ttCtx.tooltipRect.ttHeight / 2
+      x = x + w.layout.translateX
+
+      if (w.config.tooltip.keepInBoundary) {
+        // Avoid going out of the boundaries of the chart
+        y = Math.max(0, y);
+        x = Math.max(0, x);
+      }
 
       if (tooltipEl) {
         tooltipEl.style.left = x + w.layout.translateX + 'px'

--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -82,15 +82,9 @@ class Intersect {
     }
 
     if (ttCtx.w.config.tooltip.keepInBoundary) {
-      // Avoid going out of the boundaries of the chart
-      y = Math.max(0, y);
-      x = Math.max(0, x);
-    }
-
-    if (ttCtx.w.config.tooltip.keepInBoundary) {
-      // Avoid going out of the boundaries of the chart
-      y = Math.max(0, y);
-      x = Math.max(0, x);
+      const clamped = Utils.clampToBoundary({ x, y })
+      y = clamped.y
+      x = clamped.x
     }
 
     return {
@@ -161,9 +155,9 @@ class Intersect {
     }
 
     if (ttCtx.w.config.tooltip.keepInBoundary) {
-      // Avoid going out of the boundaries of the chart
-      y = Math.max(0, y);
-      x = Math.max(0, x);
+      const clamped = Utils.clampToBoundary({ x, y })
+      y = clamped.y
+      x = clamped.x
     }
 
     return {
@@ -258,9 +252,9 @@ class Intersect {
       x = x + w.layout.translateX
 
       if (w.config.tooltip.keepInBoundary) {
-        // Avoid going out of the boundaries of the chart
-        y = Math.max(0, y);
-        x = Math.max(0, x);
+        const clamped = Utils.clampToBoundary({ x, y })
+        y = clamped.y
+        x = clamped.x
       }
 
       if (tooltipEl) {

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -202,7 +202,7 @@ export default class Position {
       x = w.layout.gridWidth - tooltipRect.ttWidth
     }
 
-    if (x < -20) {
+    if (x < -20 && !ttCtx.w.config.tooltip.keepInBoundary) {
       x = -20
     }
 
@@ -229,6 +229,12 @@ export default class Position {
 
     if (!isNaN(x)) {
       x = x + w.layout.translateX
+
+      if (ttCtx.w.config.tooltip.keepInBoundary) {
+        // Avoid going out of the boundaries of the chart
+        y = Math.max(0, y);
+        x = Math.max(0, x);
+      }
 
       if (tooltipEl) {
         tooltipEl.style.left = x + 'px'

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -1,6 +1,7 @@
 // @ts-check
 import Graphics from '../Graphics'
 import Series from '../Series'
+import Utils from '../../utils/Utils'
 
 /**
  * ApexCharts Tooltip.Position Class to move the tooltip based on x and y position.
@@ -231,9 +232,9 @@ export default class Position {
       x = x + w.layout.translateX
 
       if (ttCtx.w.config.tooltip.keepInBoundary) {
-        // Avoid going out of the boundaries of the chart
-        y = Math.max(0, y);
-        x = Math.max(0, x);
+        const clamped = Utils.clampToBoundary({ x, y })
+        y = clamped.y
+        x = clamped.x
       }
 
       if (tooltipEl) {

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -8,6 +8,7 @@ import { BrowserAPIs } from '../../ssr/BrowserAPIs.js'
 import Graphics from '../Graphics'
 import Series from '../Series'
 import XAxis from './../axes/XAxis'
+import GeneralUtils from '../../utils/Utils'
 import Utils from './Utils'
 
 /**
@@ -923,9 +924,9 @@ export default class Tooltip {
       }
 
       if (w.config.tooltip.keepInBoundary) {
-        // Avoid going out of the boundaries of the chart
-        y = Math.max(0, y)
-        x = Math.max(0, x)
+        const clamped = GeneralUtils.clampToBoundary({ x, y })
+        y = clamped.y
+        x = clamped.x
       }
 
       tooltipEl.style.left = x + 'px'

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -924,8 +924,8 @@ export default class Tooltip {
 
       if (w.config.tooltip.keepInBoundary) {
         // Avoid going out of the boundaries of the chart
-        y = Math.max(0, y);
-        x = Math.max(0, x);
+        y = Math.max(0, y)
+        x = Math.max(0, x)
       }
 
       tooltipEl.style.left = x + 'px'

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -376,8 +376,8 @@ export default class Tooltip {
         txtValue.classList.add(`apexcharts-tooltip-text-${g}-value`)
         gValText.appendChild(txtValue)
 
-        gYZ.appendChild(gValText)
-      })
+          gYZ.appendChild(gValText)
+        })
 
       gTxt.appendChild(gYZ)
 
@@ -920,6 +920,12 @@ export default class Tooltip {
           seriesBound.top -
           tooltipRect.ttHeight -
           10
+      }
+
+      if (w.config.tooltip.keepInBoundary) {
+        // Avoid going out of the boundaries of the chart
+        y = Math.max(0, y);
+        x = Math.max(0, x);
       }
 
       tooltipEl.style.left = x + 'px'

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -700,6 +700,23 @@ class Utils {
    * @param {number} a
    * @param {number} b
    */
+  /**
+   * Clamps coordinates to avoid going below (0,0) and optionally
+   * above the given upper bounds.
+   * @param {{ x: number, y: number }} pos
+   * @param {{ width: number, height: number }} [upperBound]
+   * @returns {{ x: number, y: number }}
+   */
+  static clampToBoundary(pos, upperBound) {
+    let x = Math.max(0, pos.x)
+    let y = Math.max(0, pos.y)
+    if (upperBound) {
+      x = Math.min(x, Math.max(0, upperBound.width))
+      y = Math.min(y, Math.max(0, upperBound.height))
+    }
+    return { x, y }
+  }
+
   static mod(a, b, p = 7) {
     const big = Math.pow(10, p - Math.floor(Math.log10(Math.max(a, b))))
     a = Math.round(Math.abs(a) * big)

--- a/tests/unit/tooltip-position.spec.js
+++ b/tests/unit/tooltip-position.spec.js
@@ -1,0 +1,165 @@
+require('./__mocks__/ResizeObserver.js')
+import Position from '../../src/modules/tooltip/Position.js'
+import Intersect from '../../src/modules/tooltip/Intersect.js'
+
+describe('Tooltip keepInBoundary option', () => {
+  describe('Position.moveTooltip', () => {
+    const createMockTooltipContext = () => {
+      const mockTooltipEl = {
+        style: { left: '', top: '' }
+      }
+      return {
+        w: {
+          config: {
+            tooltip: {
+              keepInBoundary: true,
+              followCursor: false
+            }
+          },
+          globals: {
+            translateX: 0,
+            translateY: 0,
+            gridWidth: 500,
+            gridHeight: 300,
+            isBarHorizontal: false
+          }
+        },
+        tooltipRect: { ttWidth: 100, ttHeight: 50 },
+        getElTooltip: () => mockTooltipEl,
+        fixedTooltip: false
+      }
+    }
+
+    it('should clamp negative position to 0 when keepInBoundary is true', () => {
+      const mockCtx = createMockTooltipContext()
+      const position = new Position(mockCtx)
+
+      position.moveTooltip(-50, -50, 1)
+
+      const tooltipEl = mockCtx.getElTooltip()
+      expect(parseFloat(tooltipEl.style.left)).toBe(0)
+      expect(parseFloat(tooltipEl.style.top)).toBe(0)
+    })
+  })
+
+  describe('Intersect.handleHeatTreeTooltip', () => {
+    const createMockIntersectContext = () => {
+      return {
+        w: {
+          config: {
+            chart: { type: 'heatmap' },
+            tooltip: {
+              keepInBoundary: true,
+              followCursor: false
+            },
+            plotOptions: {
+              bar: { rangeBarGroupRows: false }
+            }
+          },
+          globals: {
+            gridWidth: 500,
+            gridHeight: 300,
+            capturedSeriesIndex: -1,
+            capturedDataPointIndex: -1,
+            isBarHorizontal: false,
+            dom: {
+              elWrap: {
+                getBoundingClientRect: () => ({ left: 0, top: 0 })
+              }
+            }
+          }
+        },
+        tooltipRect: { ttWidth: 100, ttHeight: 50 },
+        tooltipLabels: {
+          drawSeriesTexts: () => { }
+        },
+        tooltipPosition: {
+          moveXCrosshairs: () => { }
+        }
+      }
+    }
+
+    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
+      const mockCtx = createMockIntersectContext()
+      const intersect = new Intersect(mockCtx)
+
+      // Mock event that doesn't match heatmap rect class
+      const mockEvent = {
+        target: {
+          classList: {
+            contains: () => false
+          }
+        }
+      }
+
+      const result = intersect.handleHeatTreeTooltip({
+        e: mockEvent,
+        opt: {},
+        x: -50,
+        y: -30,
+        type: 'heatmap'
+      })
+
+      expect(result.x).toBe(0)
+      expect(result.y).toBe(0)
+    })
+  })
+
+  describe('Intersect.handleMarkerTooltip', () => {
+    const createMockIntersectContext = () => {
+      return {
+        w: {
+          config: {
+            chart: { type: 'line' },
+            tooltip: {
+              keepInBoundary: true,
+              shared: false
+            },
+            plotOptions: {
+              bar: { rangeBarGroupRows: false }
+            }
+          },
+          globals: {
+            capturedSeriesIndex: -1,
+            capturedDataPointIndex: -1,
+            isBarHorizontal: false
+          }
+        },
+        tooltipRect: { ttWidth: 100, ttHeight: 50 },
+        intersect: false,
+        showOnIntersect: false,
+        tooltipLabels: {
+          drawSeriesTexts: () => { }
+        },
+        marker: {
+          enlargeCurrentPoint: () => { }
+        },
+        e: { clientY: 0 },
+        getElGrid: () => ({ getBoundingClientRect: () => ({ top: 0 }) })
+      }
+    }
+
+    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
+      const mockCtx = createMockIntersectContext()
+      const intersect = new Intersect(mockCtx)
+
+      const mockEvent = {
+        target: {
+          classList: {
+            contains: () => false
+          }
+        }
+      }
+
+      const result = intersect.handleMarkerTooltip({
+        e: mockEvent,
+        opt: { paths: null },
+        x: -50,
+        y: -30
+      })
+
+      expect(result.x).toBe(0)
+      expect(result.y).toBe(0)
+    })
+  })
+})

--- a/tests/unit/tooltip-position.spec.js
+++ b/tests/unit/tooltip-position.spec.js
@@ -1,37 +1,58 @@
-require('./__mocks__/ResizeObserver.js')
+// @vitest-environment node
 import Position from '../../src/modules/tooltip/Position.js'
 import Intersect from '../../src/modules/tooltip/Intersect.js'
+import Utils from '../../src/utils/Utils.js'
+
+describe('Utils.clampToBoundary', () => {
+  it('should clamp negative coordinates to 0', () => {
+    const clamped = Utils.clampToBoundary({ x: -50, y: -30 })
+    expect(clamped.x).toBe(0)
+    expect(clamped.y).toBe(0)
+  })
+
+  it('should leave positive coordinates unchanged', () => {
+    const clamped = Utils.clampToBoundary({ x: 100, y: 100 })
+    expect(clamped.x).toBe(100)
+    expect(clamped.y).toBe(100)
+  })
+})
 
 describe('Tooltip keepInBoundary option', () => {
   describe('Position.moveTooltip', () => {
-    const createMockTooltipContext = () => {
+    const createMockTooltipContext = (keepInBoundary) => {
       const mockTooltipEl = {
-        style: { left: '', top: '' }
+        style: { left: '', top: '' },
       }
       return {
         w: {
           config: {
             tooltip: {
-              keepInBoundary: true,
-              followCursor: false
-            }
+              keepInBoundary,
+              followCursor: false,
+            },
           },
           globals: {
             translateX: 0,
             translateY: 0,
             gridWidth: 500,
             gridHeight: 300,
-            isBarHorizontal: false
-          }
+            isBarHorizontal: false,
+          },
+          layout: {
+            gridWidth: 500,
+            gridHeight: 300,
+            translateX: 0,
+            translateY: 0,
+          },
         },
         tooltipRect: { ttWidth: 100, ttHeight: 50 },
         getElTooltip: () => mockTooltipEl,
-        fixedTooltip: false
+        fixedTooltip: false,
       }
     }
 
     it('should clamp negative position to 0 when keepInBoundary is true', () => {
-      const mockCtx = createMockTooltipContext()
+      const mockCtx = createMockTooltipContext(true)
       const position = new Position(mockCtx)
 
       position.moveTooltip(-50, -50, 1)
@@ -40,21 +61,32 @@ describe('Tooltip keepInBoundary option', () => {
       expect(parseFloat(tooltipEl.style.left)).toBe(0)
       expect(parseFloat(tooltipEl.style.top)).toBe(0)
     })
+
+    it('should allow negative position when keepInBoundary is false', () => {
+      const mockCtx = createMockTooltipContext(false)
+      const position = new Position(mockCtx)
+
+      position.moveTooltip(-50, -50, 1)
+
+      const tooltipEl = mockCtx.getElTooltip()
+      // With keepInBoundary false, x gets clamped to -20 by the existing logic
+      expect(parseFloat(tooltipEl.style.left)).toBeLessThan(0)
+    })
   })
 
   describe('Intersect.handleHeatTreeTooltip', () => {
-    const createMockIntersectContext = () => {
+    const createMockIntersectContext = (keepInBoundary) => {
       return {
         w: {
           config: {
             chart: { type: 'heatmap' },
             tooltip: {
-              keepInBoundary: true,
-              followCursor: false
+              keepInBoundary,
+              followCursor: false,
             },
             plotOptions: {
-              bar: { rangeBarGroupRows: false }
-            }
+              bar: { rangeBarGroupRows: false },
+            },
           },
           globals: {
             gridWidth: 500,
@@ -64,102 +96,142 @@ describe('Tooltip keepInBoundary option', () => {
             isBarHorizontal: false,
             dom: {
               elWrap: {
-                getBoundingClientRect: () => ({ left: 0, top: 0 })
-              }
-            }
-          }
+                getBoundingClientRect: () => ({ left: 0, top: 0 }),
+              },
+            },
+          },
+          layout: {
+            gridWidth: 500,
+            gridHeight: 300,
+          },
+          interact: {},
         },
         tooltipRect: { ttWidth: 100, ttHeight: 50 },
         tooltipLabels: {
-          drawSeriesTexts: () => { }
+          drawSeriesTexts: () => {},
         },
         tooltipPosition: {
-          moveXCrosshairs: () => { }
-        }
+          moveXCrosshairs: () => {},
+        },
       }
     }
 
-    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
-      const mockCtx = createMockIntersectContext()
-      const intersect = new Intersect(mockCtx)
+    const mockEvent = {
+      target: {
+        classList: {
+          contains: () => false,
+        },
+      },
+    }
 
-      // Mock event that doesn't match heatmap rect class
-      const mockEvent = {
-        target: {
-          classList: {
-            contains: () => false
-          }
-        }
-      }
+    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
+      const mockCtx = createMockIntersectContext(true)
+      const intersect = new Intersect(mockCtx)
 
       const result = intersect.handleHeatTreeTooltip({
         e: mockEvent,
         opt: {},
         x: -50,
         y: -30,
-        type: 'heatmap'
+        type: 'heatmap',
       })
 
       expect(result.x).toBe(0)
       expect(result.y).toBe(0)
     })
+
+    it('should not clamp when keepInBoundary is false', () => {
+      const mockCtx = createMockIntersectContext(false)
+      const intersect = new Intersect(mockCtx)
+
+      const result = intersect.handleHeatTreeTooltip({
+        e: mockEvent,
+        opt: {},
+        x: -50,
+        y: -30,
+        type: 'heatmap',
+      })
+
+      expect(result.x).toBe(-50)
+      expect(result.y).toBe(-30)
+    })
   })
 
   describe('Intersect.handleMarkerTooltip', () => {
-    const createMockIntersectContext = () => {
+    const createMockIntersectContext = (keepInBoundary) => {
       return {
         w: {
           config: {
             chart: { type: 'line' },
             tooltip: {
-              keepInBoundary: true,
-              shared: false
+              keepInBoundary,
+              shared: false,
             },
             plotOptions: {
-              bar: { rangeBarGroupRows: false }
-            }
+              bar: { rangeBarGroupRows: false },
+            },
           },
           globals: {
             capturedSeriesIndex: -1,
             capturedDataPointIndex: -1,
-            isBarHorizontal: false
-          }
+            isBarHorizontal: false,
+          },
+          layout: {
+            gridWidth: 500,
+            gridHeight: 300,
+          },
+          interact: {},
         },
         tooltipRect: { ttWidth: 100, ttHeight: 50 },
         intersect: false,
         showOnIntersect: false,
         tooltipLabels: {
-          drawSeriesTexts: () => { }
+          drawSeriesTexts: () => {},
         },
         marker: {
-          enlargeCurrentPoint: () => { }
+          enlargeCurrentPoint: () => {},
         },
         e: { clientY: 0 },
-        getElGrid: () => ({ getBoundingClientRect: () => ({ top: 0 }) })
+        getElGrid: () => ({ getBoundingClientRect: () => ({ top: 0 }) }),
       }
     }
 
-    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
-      const mockCtx = createMockIntersectContext()
-      const intersect = new Intersect(mockCtx)
+    const mockEvent = {
+      target: {
+        classList: {
+          contains: () => false,
+        },
+      },
+    }
 
-      const mockEvent = {
-        target: {
-          classList: {
-            contains: () => false
-          }
-        }
-      }
+    it('should clamp negative positions to 0 when keepInBoundary is true', () => {
+      const mockCtx = createMockIntersectContext(true)
+      const intersect = new Intersect(mockCtx)
 
       const result = intersect.handleMarkerTooltip({
         e: mockEvent,
         opt: { paths: null },
         x: -50,
-        y: -30
+        y: -30,
       })
 
       expect(result.x).toBe(0)
       expect(result.y).toBe(0)
+    })
+
+    it('should not clamp when keepInBoundary is false', () => {
+      const mockCtx = createMockIntersectContext(false)
+      const intersect = new Intersect(mockCtx)
+
+      const result = intersect.handleMarkerTooltip({
+        e: mockEvent,
+        opt: { paths: null },
+        x: -50,
+        y: -30,
+      })
+
+      expect(result.x).toBe(-50)
+      expect(result.y).toBe(-30)
     })
   })
 })


### PR DESCRIPTION
Added 'keepInBoundary' tooltip option that forces the tooltip to stay in the chart boundary. When the option is set to true, (0,0) is the new minimum allowed position.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) => i added a new option
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
