### PR TITLE
fix: scope Safari borderRadius workaround to stacked charts only

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -46,9 +46,9 @@ export default class Helpers {
 
     this.arrBorderRadius = this.createBorderRadiusArr(w.seriesData.series)
 
-    if (Utils.isSafari()) {
+    if (Utils.isSafari() && w.config.chart.stacked) {
       // https://github.com/apexcharts/apexcharts.js/issues/4996
-      // to temporarily fix the above issue, border radius is disabled
+      // to temporarily fix the above issue, border radius is disabled for stacked charts
       /**
        * @param {any[]} brArr
        */

--- a/tests/unit/bar-border-radius.spec.js
+++ b/tests/unit/bar-border-radius.spec.js
@@ -1,0 +1,112 @@
+import Helpers from '../../src/charts/common/bar/Helpers.js'
+import Utils from '../../src/utils/Utils.js'
+
+// ---------------------------------------------------------------------------
+// Helper: create a minimal barCtx + w for Helpers instantiation
+// ---------------------------------------------------------------------------
+function createHelpers(overrides = {}) {
+  const stacked = overrides.stacked ?? false
+  const series = overrides.series || [[10, 20, 30]]
+
+  const w = {
+    config: {
+      chart: { type: 'bar', stacked },
+      plotOptions: {
+        bar: {
+          borderRadius: 5,
+          borderRadiusApplication: 'end',
+          borderRadiusWhenStacked: 'last',
+        },
+      },
+    },
+    globals: {
+      dataPoints: series[0].length,
+      minX: 0,
+      maxX: series[0].length + 1,
+      comboCharts: false,
+      maxValsInArrayIndex: 0,
+    },
+    axisFlags: { isXNumeric: false },
+    seriesData: {
+      series,
+      seriesX: series.map((s) => s.map((_, i) => i + 1)),
+    },
+  }
+
+  const barCtx = {
+    w,
+    series: [],
+    totalItems: 0,
+    seriesLen: 0,
+    visibleI: -1,
+    visibleItems: 1,
+    zeroSerieses: [],
+  }
+
+  const helpers = new Helpers(barCtx)
+  return { helpers, w, barCtx }
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('Bar borderRadius Safari workaround', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('non-stacked chart retains borderRadius when Safari is detected', () => {
+    vi.spyOn(Utils, 'isSafari').mockReturnValue(true)
+
+    const { helpers } = createHelpers({ stacked: false })
+    helpers.initVariables([[10, 20, 30]])
+
+    helpers.arrBorderRadius[0].forEach((val) => {
+      expect(val).toBe('top')
+    })
+  })
+
+  it('stacked chart disables borderRadius when Safari is detected', () => {
+    vi.spyOn(Utils, 'isSafari').mockReturnValue(true)
+
+    const series = [
+      [10, 20, 30],
+      [5, 15, 25],
+    ]
+    const { helpers } = createHelpers({ stacked: true, series })
+    helpers.initVariables(series)
+
+    helpers.arrBorderRadius.forEach((brArr) => {
+      brArr.forEach((val) => {
+        expect(val).toBe('none')
+      })
+    })
+  })
+
+  it('non-stacked chart retains borderRadius when not Safari', () => {
+    vi.spyOn(Utils, 'isSafari').mockReturnValue(false)
+
+    const { helpers } = createHelpers({ stacked: false })
+    helpers.initVariables([[10, 20, 30]])
+
+    helpers.arrBorderRadius[0].forEach((val) => {
+      expect(val).toBe('top')
+    })
+  })
+
+  it('stacked chart retains computed borderRadius when not Safari', () => {
+    vi.spyOn(Utils, 'isSafari').mockReturnValue(false)
+
+    const series = [
+      [10, 20, 30],
+      [5, 15, 25],
+    ]
+    const { helpers } = createHelpers({ stacked: true, series })
+    helpers.initVariables(series)
+
+    const allValues = helpers.arrBorderRadius.flat()
+    const hasNonNone = allValues.some((val) => val !== 'none')
+    expect(hasNonNone).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Narrows the Safari borderRadius workaround (from #4996) to only apply to **stacked** bar/column charts, where the rendering bug actually occurs
- Restores borderRadius rendering for non-stacked bar/column charts on Safari/iOS
- Adds 4 unit tests verifying the workaround scope

## Context
Issue #4996 reported stacked bar charts rendering inverted on first paint in Safari. The fix disabled ALL borderRadius on Safari, but the bug only manifests in stacked charts. Non-stacked charts (simple, grouped, distributed) were unnecessarily losing their borderRadius on Safari/iOS (#5076).

## Changes
- `src/charts/common/bar/Helpers.js` — Added `&& w.config.chart.stacked` condition to narrow the Safari workaround
- `tests/unit/bar-border-radius.spec.js` — New test file with 4 test cases covering Safari/non-Safari × stacked/non-stacked matrix

## Test plan
- [x] Non-stacked bar chart retains borderRadius when Safari is detected
- [x] Stacked bar chart still has borderRadius disabled on Safari (no regression on #4996)
- [x] Non-stacked bar chart retains borderRadius on non-Safari browsers
- [x] Stacked bar chart retains computed borderRadius on non-Safari browsers
- [x] `npm run unit` — all 1402 tests pass
- [x] `npm run lint` — no errors
- [x] `npm run build` — builds successfully

Fixes #5076