### PR TITLE
fix(pie): cycle stroke.colors across slices instead of indexing off t…

### DIFF
--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -303,8 +303,15 @@ class Pie {
 
       const elPath = graphics.drawPath({
         d: path,
+        // Pie/donut/polarArea data is a single series, so a user-supplied
+        // `stroke.colors` shorter than the slice count is NOT padded by the
+        // theme engine (unlike fill colors, which cycle). Without this, only
+        // slice 0 gets the requested color and the rest fall back to a grey
+        // default. Cycle the array — matching fill-color behaviour — so a
+        // single `stroke.colors: ['#fff']` borders every slice as expected.
         stroke: Array.isArray(this.lineColorArr)
-          ? this.lineColorArr[i]
+          ? this.lineColorArr[i] ??
+            this.lineColorArr[i % this.lineColorArr.length]
           : this.lineColorArr,
         strokeWidth: 0,
         fill: pathFill,


### PR DESCRIPTION
…he end

Pie/donut/polarArea data is a single series, so a user-supplied `stroke.colors` shorter than the slice count was not padded by the theme engine (unlike fill colors, which already cycle via pushExtraColors). The per-slice draw indexed `lineColorArr[i]` directly, so only slice 0 got the requested color and the remaining slices fell back to a grey default — e.g. `stroke: { colors: ['#fff'] }` left all but the first border grey.

Cycle the array with `lineColorArr[i % length]` so a single color borders every slice, matching fill-color behaviour. Backward compatible: callers passing a full-length array still hit `[i]`; an empty array stays undefined.

# New Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My branch is up to date with any changes from the main branch
