### PR TITLE
Fix chart.group sync corrupting/crashing sibling charts with different series/axis counts

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -912,16 +912,9 @@ export default class ApexCharts {
    * @returns {ApexCharts[]}
    */
   getSyncedCharts() {
-    const chartGroups = this.getGroupedCharts()
-    let allCharts = /** @type {ApexCharts[]} */ ([this])
-    if (chartGroups.length) {
-      allCharts = []
-      chartGroups.forEach((ch) => {
-        allCharts.push(ch)
-      })
-    }
-
-    return allCharts
+    const group = /** @type {ApexCharts[]} */ (this.getGroupedCharts())
+    group.splice(0, 0, this)
+    return group
   }
 
   /**
@@ -931,20 +924,12 @@ export default class ApexCharts {
    * @returns {ApexCharts[]}
    */
   getGroupedCharts() {
-    return (
-      Apex._chartInstances
-        .filter((/** @type {any} */ ch) => {
-          if (ch.group) {
-            return true
-          }
-        })
-        /**
-         * @param {Record<string, any>} ch
-         */
-        .map((/** @type {any} */ ch) =>
-          this.w.config.chart.group === ch.group ? ch.chart : this,
-        )
-    )
+    return Apex._chartInstances
+      .filter(
+        (/** @type {any} */ ch) =>
+          this !== ch.chart && this.w.config.chart.group === ch.group,
+      )
+      .map((/** @type {any} */ ch) => ch.chart)
   }
 
   /**

--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -128,6 +128,13 @@ export default class UpdateHelpers {
           if (ch.w.globals.chartID !== this.w.globals.chartID) {
             // don't overwrite series of synchronized charts
             delete options.series
+            // don't overwrite yaxis of synchronized charts - a chart's own
+            // yaxis count/shape may differ from the chart that triggered
+            // this sync (e.g. differing series counts per chart), and
+            // applying a mismatched yaxis array here leaves w.config.yaxis
+            // out of sync with this chart's own series-to-axis indices,
+            // which can throw in Scales.setYScaleForIndex on next render
+            delete options.yaxis
           }
 
           w.config = Utils.extend(w.config, options)

--- a/tests/unit/group.spec.js
+++ b/tests/unit/group.spec.js
@@ -1,0 +1,80 @@
+import { createChartsWithOptions } from "./utils/utils"
+
+beforeAll(() => {
+  Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+    writable: true,
+    value: () => ({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    }),
+  });
+});
+
+function expectSameElements(a, b) {
+
+  expect(a).toHaveLength(b.length);
+  expect(a.every(el => b.includes(el))).toBe(true);
+  expect(b.every(el => a.includes(el))).toBe(true);
+}
+
+describe('charts can be grouped in several independent groups', () => {
+  it('should return the right list of graph in the same group', () => {
+    const charts =
+      createChartsWithOptions({
+        chart: {
+          type: 'line',
+          id: 'id0',
+        },
+        series: [
+        ],
+      }, {
+        chart: {
+          type: 'line',
+          id: 'id1',
+          group: 'group0',
+        },
+        series: [
+        ],
+      }, {
+        chart: {
+          type: 'line',
+          id: 'id2',
+          group: 'group0',
+        },
+        series: [
+        ],
+      }, {
+        chart: {
+          type: 'line',
+          id: 'id3',
+          group: 'group1',
+        },
+        series: [
+        ],
+      }, {
+        chart: {
+          type: 'line',
+          id: 'id4',
+          group: 'group1',
+        },
+        series: [
+        ],
+      }
+    )
+
+    expectSameElements(charts[0].getGroupedCharts(), [])
+    expectSameElements(charts[1].getGroupedCharts(), [charts[2]])
+    expectSameElements(charts[2].getGroupedCharts(), [charts[1]])
+    expectSameElements(charts[3].getGroupedCharts(), [charts[4]])
+    expectSameElements(charts[4].getGroupedCharts(), [charts[3]])
+
+
+    expectSameElements(charts[0].getSyncedCharts(), [charts[0]])
+    expectSameElements(charts[1].getSyncedCharts(), [charts[1], charts[2]])
+    expectSameElements(charts[2].getSyncedCharts(), [charts[2], charts[1]])
+    expectSameElements(charts[3].getSyncedCharts(), [charts[4], charts[3]])
+    expectSameElements(charts[4].getSyncedCharts(), [charts[3], charts[4]])
+  })
+})

--- a/tests/unit/utils/utils.js
+++ b/tests/unit/utils/utils.js
@@ -33,3 +33,18 @@ export function createChartWithOptions(options) {
 
   return chart
 }
+
+export function createChartsWithOptions(/*optionsList...*/) {
+
+  let content = ''
+  for(let i = 0; i < arguments.length; ++i){
+    content += '<div id="chart-' + i + '" />'
+  }
+  document.body.innerHTML = content
+
+  return Array.prototype.map.call(arguments, (options, i) => {
+    const chart = new ApexCharts(document.querySelector('#chart-' + i), options)
+    chart.render()
+    return chart
+  })
+}


### PR DESCRIPTION
Fixes #5232.

Two fixes for the same underlying problem — cross-chart `chart.group` sync doesn't correctly isolate a chart's own shape (series count, y-axis count) from its synced siblings':

### 1. `getGroupedCharts()` / `getSyncedCharts()` matching logic

Cherry-picked and adapted from the original (unmerged) fix at #5114 by @hl037, which stalled after a maintainer requested removing `dist/` build artifacts that were accidentally included — never addressed before the PR went stale and was auto-closed. This re-applies the same source fix and test against current `main`, without the `dist/` files.

`getGroupedCharts()` filtered chart instances by "does this chart belong to *any* group" instead of "does this chart belong to *my* group," and substituted `this` for non-matching entries instead of excluding them. `getSyncedCharts()` then included that incorrect result plus `this` again.

Rewritten to properly filter by matching group and exclude self, then have `getSyncedCharts()` explicitly prepend self to the correctly-filtered list. Adds a unit test (`group.spec.js`) exercising multiple independent groups to confirm each chart only syncs with its own group.

### 2. Also protect `yaxis` from cross-chart sync overwrite

`_updateOptions` already deletes `options.series` before merging a synced chart's own `w.config` (fixes #914, #623) — protecting against exactly this class of cross-chart contamination for series data. It never extended the same protection to `yaxis`.

When grouped charts have a different number of series/y-axes, updating the first chart propagates its `yaxis` array onto every synced chart via `getSyncedCharts()`. The receiving chart's own series-to-axis index mapping no longer matches its (now overwritten) `yaxis` array length, and `Scales.setYScaleForIndex` throws `Cannot read properties of undefined (reading 'logarithmic')` on the next scale computation — intermittently, depending on update timing, matching long-standing "random"/hard-to-reproduce reports of this exact error (e.g. #1179).

### Testing

- The matching-logic fix alone does **not** resolve the corruption — confirmed via standalone reproduction (see #5232). This is what led to finding the `yaxis` fix; they're a matched pair, not independent alternatives.
- Both fixes together: reproduction runs 100+ updates with no corruption or throw.
- Full existing test suite passes with no regressions (1770/1770 → 1771/1771 with the new `group.spec.js` test added).
- Verified live in a real integration: two `chart.group`-synced charts inside a Home Assistant dashboard, wrapped by a templating card driving a dynamic time-range selector — the exact real-world scenario this was found in.

Authorship on the #5114-derived commit preserved for @hl037 via `--author`; the second commit (yaxis fix) is mine.