### PR TITLE
Guard getPreviousPaths() against a synced chart with no live DOM

### DIFF
--- a/src/modules/Series.js
+++ b/src/modules/Series.js
@@ -415,6 +415,17 @@ export default class Series {
       return
     }
 
+    // A synced sibling chart (see getSyncedCharts()) can land here mid
+    // teardown/rebuild: a wrapping component (e.g. a templating card that
+    // re-renders its child on every data-driven config change) may have
+    // already detached this chart's host element - or never finished
+    // mounting it - while this chart's own _updateOptions() call is still
+    // in flight. Either way there's no live DOM to capture paths from.
+    if (!Utils.elementExists(w.dom.baseEl)) {
+      w.globals.previousPaths = []
+      return
+    }
+
     w.globals.previousPaths = []
 
     /**

--- a/tests/unit/synced-chart-detached-dom.spec.js
+++ b/tests/unit/synced-chart-detached-dom.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import './__mocks__/ResizeObserver.js'
+import ApexCharts from '../../src/entries/full.js'
+
+function createSyncedChartPair(groupId) {
+  document.body.innerHTML = '<div id="chart-live" /><div id="chart-orphaned" />'
+
+  const live = new ApexCharts(document.querySelector('#chart-live'), {
+    chart: {
+      type: 'line',
+      id: 'liveChart',
+      group: groupId,
+      animations: { enabled: false },
+    },
+    series: [{ data: [1, 2, 3] }],
+  })
+  live.render()
+
+  const orphaned = new ApexCharts(document.querySelector('#chart-orphaned'), {
+    chart: {
+      type: 'line',
+      id: 'orphanedChart',
+      group: groupId,
+      animations: { enabled: false },
+    },
+    series: [{ data: [4, 5, 6] }],
+  })
+  orphaned.render()
+
+  return { live, orphaned }
+}
+
+describe('a synced chart with no live DOM does not break the group', () => {
+  it('should not throw when updating a chart whose synced sibling has lost its host element', async () => {
+    const { live, orphaned } = createSyncedChartPair('orphan-group')
+
+    // A wrapping component (e.g. a templating card that rebuilds its child
+    // on every data-driven config change) can tear down a chart's host
+    // element without going through chart.destroy() first - it stays
+    // registered in Apex._chartInstances, still reachable via
+    // getSyncedCharts(), but with no DOM left to operate on.
+    orphaned.w.dom.baseEl = null
+
+    await expect(
+      live.updateOptions({ series: [{ data: [7, 8, 9] }] }),
+    ).resolves.toBeDefined()
+
+    expect(orphaned.w.globals.previousPaths).toEqual([])
+  })
+
+  it('should not throw when the sibling host element was removed from the document without calling destroy()', async () => {
+    const { live, orphaned } = createSyncedChartPair('orphan-group-detached')
+
+    orphaned.w.dom.baseEl.remove()
+
+    await expect(
+      live.updateOptions({ series: [{ data: [7, 8, 9] }] }),
+    ).resolves.toBeDefined()
+
+    expect(orphaned.w.globals.previousPaths).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #5233.

### What's wrong

`_updateOptions()` calls `getPreviousPaths()` on every chart returned by `getSyncedCharts()`, including group-synced siblings that aren't the chart `update()` was actually called on. A chart instance stays in `Apex._chartInstances` — and therefore stays reachable via `getSyncedCharts()` — until its own `destroy()` runs. A host framework that rebuilds a chart's wrapping element on every data-driven config change can detach or discard that element without ever calling `destroy()` on the chart instance first, leaving a stale entry in the registry.

`getPreviousPaths()` then unconditionally does `w.dom.baseEl.querySelectorAll(...)` for that stale entry. Depending on its exact state this either throws directly (`Cannot read properties of null (reading 'querySelectorAll')`) when `baseEl` was never set or has been nulled, or — more subtly — succeeds against a detached-but-still-referenced DOM node and returns garbage path data (`NaN` coordinates), corrupting the next animation frame without ever raising an error.

### The fix

Guard with the same `Utils.elementExists()` check already used in `render()`/`create()` for this exact problem — it covers both the null and the detached-but-referenced case (checks `.isConnected`). A chart with no live DOM has nothing to capture previous paths from either way.

```js
if (!Utils.elementExists(w.dom.baseEl)) {
  w.globals.previousPaths = []
  return
}
```

### Testing

- New regression test (`tests/unit/synced-chart-detached-dom.spec.js`) covering both failure modes:
  - `baseEl` nulled directly — reproduces the crash exactly (confirmed the test fails with the original error/stack trace when run against the code without this fix).
  - `baseEl` detached via `.remove()` without `destroy()` — reproduces the silent `NaN`-path corruption (confirmed the test fails against unpatched code, asserting `previousPaths` is polluted with invalid path data instead of `[]`).
- Full existing suite passes with no regressions (1771/1771).
- Verified live in a real integration: two `chart.group`-synced charts inside a Home Assistant dashboard, wrapped by a templating card that rebuilds them on every state change. Repeated rapid rebuilds (5 in quick succession) that previously crashed with this exact error now complete cleanly with no errors.

This is independent of #5232 / the `getGroupedCharts()`/`getSyncedCharts()` matching fix — it's a separate gap in the same sync propagation path, doesn't touch chart registration timing, and reproduces on unpatched `main` regardless of whether that other fix is applied.