### PR TITLE
fix(ci): unblock CI — puppeteer --no-sandbox + drop EOL Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout repository

--- a/tests/e2e/samples.js
+++ b/tests/e2e/samples.js
@@ -298,6 +298,12 @@ async function processSamples(command, paths, isCI) {
   const cluster = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_BROWSER,
     maxConcurrency: Math.min(os.availableParallelism(), 4),
+    // CI runners (GitHub Actions) can't start Chromium under the SUID
+    // sandbox, so the browser fails to launch without these flags. They
+    // are rendering-neutral, so snapshots are unaffected.
+    puppeteerOptions: {
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    },
   })
 
   await cluster.task(async ({ page, data: sample }) => {


### PR DESCRIPTION
## Problem

Every CI run has failed since ~early May 2026 (all dependabot PRs and merged fixes included). Two independent, pre-existing breakages:

### 1. Chromium can't launch on CI runners
The e2e snapshot step dies before any test runs:
```
Error: Unable to launch browser for worker...
[FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! ... try using --no-sandbox.
```
GitHub Actions runners can't start modern Chromium under the SUID sandbox. `puppeteer-cluster` in `tests/e2e/samples.js` was launched with no `puppeteerOptions`, so no flags were passed. Works locally on macOS, which is why it went unnoticed.

**Fix:** pass `--no-sandbox` / `--disable-setuid-sandbox`. These are rendering-neutral (the sandbox is an OS security boundary, not part of the render pipeline), so snapshots are unaffected.

### 2. Node 18 is unsupported by the dep tree
`yarn install --frozen-lockfile` fails on the 18.x matrix jobs:
```
error undici@7.28.0: The engine "node" is incompatible with this module. Expected version ">=20.18.1". Got "18.20.8"
```
vitest@4 also requires node `^20 || ^22 || >=24`. Node 18 hit EOL in April 2025.

**Fix:** drop `18.x` from the test matrix; test on 20.x and 22.x.

## Verification

On this PR's CI run, **Test Reproducibility (20.x) and (22.x) pass fully green** — install, build samples, generate snapshots, and run tests all succeed. Those jobs execute entirely on this PR's code, proving the fix works end-to-end.

## Note on the "Test & Build" jobs

The "Test & Build" jobs will remain **red on this PR** and that is expected: their first step regenerates baseline snapshots by checking out `apexcharts:main` (the base branch), which does not yet contain this fix, so it still hits the sandbox crash. This self-resolves the moment this PR merges — every subsequent PR will have a green "Test & Build" too. The green "Test Reproducibility" jobs are the reliable signal that the code is correct.

**Recommend merging despite the red "Test & Build" checks on this PR.**