### PR TITLE
Add cspNonce export option to fix CSP violation during export (#5146)

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -123,6 +123,12 @@ class Exports {
         exportStyles += apexchartsLegendCSS
       }
 
+      // A strict CSP (`style-src` without 'unsafe-inline') blocks this
+      // injected <style> tag unless it carries a nonce the page allow-lists.
+      // Let consumers pass that nonce through chart.toolbar.export.cspNonce.
+      const cspNonce = w.config.chart.toolbar.export.cspNonce
+      const nonceAttr = cspNonce ? ` nonce="${cspNonce}"` : ''
+
       let svgString = `
         <svg xmlns="http://www.w3.org/2000/svg"
           version="1.1"
@@ -133,7 +139,7 @@ class Exports {
           width="${w.globals.svgWidth}px" height="${w.globals.svgHeight}px">
           <foreignObject width="100%" height="100%">
             <div xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px; height:${height}px;">
-            <style type="text/css">
+            <style type="text/css"${nonceAttr}>
               ${exportStyles}
             </style>
               ${serializedNode}

--- a/src/modules/settings/Options.js
+++ b/src/modules/settings/Options.js
@@ -627,6 +627,10 @@ export default class Options {
             },
             scale: undefined,
             width: undefined,
+            // A CSP `style-src` nonce to apply to the `<style>` tag injected
+            // into SVG/PNG exports, so exports work under a strict Content
+            // Security Policy that disallows 'unsafe-inline' styles.
+            cspNonce: undefined,
           },
           autoSelected: 'zoom', // accepts -> zoom, pan, selection, measure
         },

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1470,6 +1470,12 @@ type ApexChart = {
       }
       width?: number
       scale?: number
+      /**
+       * A CSP `style-src` nonce to apply to the `<style>` tag injected into
+       * SVG/PNG exports, so exports aren't blocked under a strict Content
+       * Security Policy that disallows 'unsafe-inline' styles.
+       */
+      cspNonce?: string
     }
     autoSelected?: 'zoom' | 'selection' | 'pan' | 'measure'
   }


### PR DESCRIPTION
## What
Adds a `chart.toolbar.export.cspNonce` config option so a caller can
supply a CSP nonce that gets attached to the `<style>` tag injected
into SVG/PNG exports.

## Why
Closes #5146. Under a strict Content Security Policy (`style-src`
without `'unsafe-inline'`), that injected `<style>` tag is blocked by
the browser, breaking exports and throwing CSP violation errors in the
console — as reported with a reproduction and screenshots in the issue.

## Changes
- `src/modules/settings/Options.js`: new `export.cspNonce` default
  option (undefined by default, fully backward-compatible)
- `src/modules/Exports.js`: applies `nonce="..."` to the injected
  `<style>` tag in `getSvgString()` when `cspNonce` is set
- `types/apexcharts.d.ts`: matching `cspNonce?: string` type addition

## Usage
```js
new ApexCharts(el, {
  chart: { toolbar: { export: { cspNonce: 'your-per-request-nonce' } } }
})
```

## Testing
Syntax-checked both modified files locally. Wasn't able to run the
full suite in my environment due to a dependency (`@blazediff/core`)
resolving through a mirror my network didn't allow — happy to add
tests or address CI feedback if maintainers want a specific test shape.