### PR TITLE
fix: respect series.hidden flag on initial render by emptying collapsed series data

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -326,6 +326,21 @@ export default class ApexCharts {
       }
     })
 
+    // Empty data for hidden/collapsed series so they are not rendered
+    if (
+      gl.collapsedSeriesIndices.length > 0 ||
+      gl.ancillaryCollapsedSeriesIndices.length > 0
+    ) {
+      series.forEach((s, si) => {
+        if (
+          gl.collapsedSeriesIndices.indexOf(si) > -1 ||
+          gl.ancillaryCollapsedSeriesIndices.indexOf(si) > -1
+        ) {
+          s.data = []
+        }
+      })
+    }
+
     const combo = CoreUtils.checkComboSeries(series, w.config.chart.type)
     gl.comboCharts = combo.comboCharts
     gl.comboBarCount = combo.comboBarCount


### PR DESCRIPTION
## Description

The `series.hidden` config option was being tracked in `collapsedSeriesIndices` global state via `getSeriesAfterCollapsing()`, but the actual series data was not being emptied before rendering. This caused hidden series to still be drawn (visible) on the chart, even though the legend labels correctly showed them as dimmed.

## Root Cause

When a user sets `hidden: true` on a series config, the `create()` method in `apexcharts.js` iterates through the series and calls `getSeriesAfterCollapsing()` for each hidden series. This correctly adds the index to `collapsedSeriesIndices`, but the cloned series data returned by the function is still passed to `parseData()` with all values intact. The rendering pipeline then draws the SVG paths for those series, and while the CSS class `apexcharts-series-collapsed` (opacity: 0) is added, the paths are still present in the DOM.

## Fix

Empty the data array for all indices tracked in `collapsedSeriesIndices` and `ancillaryCollapsedSeriesIndices` after the initial `forEach` loop. This follows the same pattern already used in `LegendHelpers._getSeriesBasedOnCollapsedState()`, which is called when a series is hidden/risen via legend interaction.

## Testing

1. Create a line chart with multiple series
2. Set `hidden: true` on one or more series
3. The hidden series should not be rendered on the chart

Fixes #5213