### PR TITLE
fix(graphics): bind point listeners to Graphics context

### DIFF
--- a/src/charts/Pie.js
+++ b/src/charts/Pie.js
@@ -786,7 +786,7 @@ class Pie {
    * @param {Record<string, any>} dataLabels
    */
   addListeners(elPath, dataLabels) {
-    const graphics = new Graphics(this.w)
+    const graphics = new Graphics(this.w, this.ctx)
     // append filters on mouseenter and mouseleave
     elPath.node.addEventListener(
       'mouseenter',
@@ -803,7 +803,7 @@ class Pie {
     )
     elPath.node.addEventListener(
       'mousedown',
-      graphics.pathMouseDown.bind(this, elPath),
+      graphics.pathMouseDown.bind(graphics, elPath),
     )
 
     if (!this.donutDataLabels.total.showAlways) {

--- a/src/modules/Markers.js
+++ b/src/modules/Markers.js
@@ -18,7 +18,7 @@ export default class Markers {
    */
   constructor(w, ctx) {
     this.w = w
-    this.ctx = ctx // kept for .bind(this.ctx, ...) in pathMouse* event handlers
+    this.ctx = ctx // forwarded to public event callbacks by Graphics and seriesEmitter
 
     this._filters = new Filters(this.w)
     this._graphics = new Graphics(this.w, this.ctx)
@@ -354,16 +354,16 @@ export default class Markers {
 
     marker.node.addEventListener(
       'mouseenter',
-      this._graphics.pathMouseEnter.bind(this.ctx, marker),
+      this._graphics.pathMouseEnter.bind(this._graphics, marker),
     )
     marker.node.addEventListener(
       'mouseleave',
-      this._graphics.pathMouseLeave.bind(this.ctx, marker),
+      this._graphics.pathMouseLeave.bind(this._graphics, marker),
     )
 
     marker.node.addEventListener(
       'mousedown',
-      this._graphics.pathMouseDown.bind(this.ctx, marker),
+      this._graphics.pathMouseDown.bind(this._graphics, marker),
     )
 
     marker.node.addEventListener('click', w.config.markers.onClick)
@@ -371,7 +371,7 @@ export default class Markers {
 
     marker.node.addEventListener(
       'touchstart',
-      this._graphics.pathMouseDown.bind(this.ctx, marker),
+      this._graphics.pathMouseDown.bind(this._graphics, marker),
       { passive: true },
     )
   }

--- a/tests/unit/path-mouse-down.spec.js
+++ b/tests/unit/path-mouse-down.spec.js
@@ -1,5 +1,6 @@
 import { createChartWithOptions } from './utils/utils.js'
 import Graphics from '../../src/modules/Graphics.js'
+import Markers from '../../src/modules/Markers.js'
 
 // Behavior-lock harness for Graphics.pathMouseDown (the data-point click
 // selection state machine). pathMouseDown is otherwise only exercised by the
@@ -27,6 +28,36 @@ function makeBarChart(extra = {}) {
   return { chart, onSelect }
 }
 
+function makeDonutChart() {
+  const onSelect = vi.fn()
+  const chart = createChartWithOptions({
+    chart: {
+      type: 'donut',
+      id: 'pmd-donut-' + Math.random().toString(36).slice(2),
+      events: { dataPointSelection: onSelect },
+    },
+    labels: ['A', 'B'],
+    series: [3, 5],
+  })
+  return { chart, onSelect }
+}
+
+function makeScatterChart() {
+  const onSelect = vi.fn()
+  const chart = createChartWithOptions({
+    chart: {
+      type: 'scatter',
+      id: 'pmd-scatter-' + Math.random().toString(36).slice(2),
+      events: { dataPointSelection: onSelect },
+    },
+    dataLabels: { enabled: false },
+    markers: { size: 4 },
+    series: [{ name: 'A', data: [[1, 3], [2, 5]] }],
+    xaxis: { type: 'numeric' },
+  })
+  return { chart, onSelect }
+}
+
 /** Find the rendered bar path wrapper with the given series/data-point index. */
 function bar(chart, index, j) {
   const paths = chart.w.dom.Paper.find(
@@ -44,6 +75,34 @@ const g = (chart) => new Graphics(chart.w, chart.ctx)
 const evt = { type: 'mousedown' }
 
 describe('Graphics.pathMouseDown selection state machine', () => {
+  it('handles a donut slice mousedown through its DOM listener', () => {
+    const { chart, onSelect } = makeDonutChart()
+    const slice = document.querySelector('.apexcharts-pie-area[j="0"]')
+
+    slice.dispatchEvent(new MouseEvent('mousedown'))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+    const [, ctx, options] = onSelect.mock.calls[0]
+    expect(ctx).toBe(chart)
+    expect(options.dataPointIndex).toBe(0)
+    chart.destroy()
+  })
+
+  it('handles a marker mousedown through its direct DOM listener', () => {
+    const { chart, onSelect } = makeScatterChart()
+    const marker = document.querySelector('.apexcharts-marker[index="0"][j="0"]')
+    const markers = new Markers(chart.w, chart.ctx)
+    markers.addEvents(marker.instance)
+
+    marker.dispatchEvent(new MouseEvent('mousedown'))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+    const [, ctx, options] = onSelect.mock.calls[0]
+    expect(ctx).toBe(chart)
+    expect(options.dataPointIndex).toBe(0)
+    chart.destroy()
+  })
+
   it('selects a point on first click and fires dataPointSelection', () => {
     const { chart, onSelect } = makeBarChart()
     const b0 = bar(chart, 0, 0)


### PR DESCRIPTION
# New Pull Request

(I did code this with codex, but it seems tight)

Fixes a regression where selecting pie/donut data points or markers could throw `TypeError: this._togglePointSelection is not a function`.

Mouse event handlers were invoking `Graphics.pathMouseDown` with the pie or chart object as `this`, even though the selection state and `_togglePointSelection` method belong to the `Graphics` instance. This change binds those handlers to their owning `Graphics` instance while preserving the chart context supplied to public event callbacks.

Regression tests dispatch events through the real DOM listeners for both donut slices and markers.

No additional dependencies are required.

Fixes: N/A — no matching existing issue was found for this regression. I can create one if it helps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch