### PR TITLE
fix(exports): honour columnDelimiter in unequal-x CSV rows

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -570,10 +570,10 @@ class Exports {
       Array.from(categories)
         .sort()
         .forEach((cat) => {
-          rows.push([
-            getFormattedCategory(cat),
-            /** @type {Record<string,any>} */ (data)[cat].join(columnDelimiter),
-          ])
+          // Join here: pushing the array would leave rows.join() to stringify
+          // it, which always uses a comma between category and values.
+          const values = /** @type {Record<string,any>} */ (data)[cat]
+          rows.push([getFormattedCategory(cat), ...values].join(columnDelimiter))
         })
     }
 

--- a/tests/unit/download-csv.spec.js
+++ b/tests/unit/download-csv.spec.js
@@ -221,6 +221,53 @@ describe('Export Csv', () => {
       expect.stringContaining('.csv')
     )
   })
+  it('export csv from simple line chart with two distinct x y series and a custom column delimiter should call triggerDownload with csv encoded file data', () => {
+    const series = [
+      {
+        name: 'series 1',
+        data: [
+          {
+            x: 0,
+            y: 0,
+          },
+          {
+            x: 1,
+            y: 1,
+          },
+        ],
+      },
+      {
+        name: 'series 2',
+        data: [
+          {
+            x: 1,
+            y: 1,
+          },
+          {
+            x: 2,
+            y: 2,
+          },
+        ],
+      },
+    ]
+    const csvData =
+      'category;series 1;series 2\n' + '0;0;\n' + '1;1;1\n' + '2;;2'
+
+    const chart = createChart('line', series)
+    const exports = new Exports(chart.ctx.w, chart.ctx)
+    vi.spyOn(Exports.prototype, 'triggerDownload')
+    exports.exportToCSV({
+      series: chart.w.config.series,
+      fileName: 'fileName',
+      columnDelimiter: ';',
+    })
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledTimes(1)
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(csvData)),
+      'fileName',
+      expect.stringContaining('.csv')
+    )
+  })
   it('export csv from simple line chart with first series collapsed should call triggerDownload with csv encoded file data', () => {
     const series = [
       { name: 'series 1', data: [0, 1] },


### PR DESCRIPTION
### The bug

When series have different x values, `exportToCSV` takes the `handleUnequalXValues()` branch (added in b9fcf66 for #2584). That branch pushes an **array** onto `rows`:

```js
rows.push([
  getFormattedCategory(cat),
  data[cat].join(columnDelimiter),
])
```

Every other branch pushes an already-joined string. The final `rows.join(lineDelimiter)` therefore stringifies this one via `Array.prototype.toString`, which is hard-wired to a comma — so in each data row the category is separated from the values by `,` while the header row and the values among themselves use the configured `columnDelimiter`.

With `columnDelimiter: ';'` (the default in many European locales, and settable through `chart.toolbar.export.csv.columnDelimiter` or `chart.exportToCSV({ columnDelimiter })`):

```
category;series 1;series 2
0,0;
1,1;1
2,;2
```

The header declares three `;`-separated columns and every data row has two, so the file no longer parses: a spreadsheet reads `0,0` as one text cell and the series values land under the wrong headers. The equal-x path is unaffected:

```
category;series 1;series 2
0;0;3
1;1;4
```

The default `,` makes the two spellings identical, which is why this has been invisible since 2023 — every case in `download-csv.spec.js`, including the two that exercise this exact branch, uses the default delimiter.

### The fix

Join the row with `columnDelimiter` like every other `rows.push()` in the function. No behaviour change for the default delimiter.

### Verification

- Added `export csv from simple line chart with two distinct x y series and a custom column delimiter …` to `tests/unit/download-csv.spec.js`, built from the existing distinct-x/y case so only the delimiter differs. It fails on current `main` (`0,0;` vs the expected `0;0;`) and passes with the fix.
- `yarn unit` → 2134 passing, 94 files, no other test changed.
- `yarn lint` clean. `npm run typecheck` reports the same 24 pre-existing errors as `main`, none in `Exports.js`.

### Noted, not fixed here

The same block sorts categories with a bare `.sort()`, so numeric x values are ordered as strings — `x` of 2, 3, 10, 20 exports as rows `10, 2, 20, 3`, i.e. in a different order than the chart draws them. That is a separate defect with a separate risk profile (string x values must keep sorting lexicographically), so I left it out of this PR. Happy to send it as a follow-up if you'd like it fixed.
