### PR TITLE
fix: remove extra bottom margin on sparkline charts (Closes #5137)

### DIFF
--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -810,7 +810,7 @@ export default class Core {
     const isPercentHeight = heightStr.includes('%')
 
     let legendHeight = 0
-    let offY = w.config.chart.sparkline.enabled ? 1 : 15
+    let offY = w.config.chart.sparkline.enabled ? 0 : 15
     offY += w.config.grid.padding.bottom
 
     if (

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -54,10 +54,6 @@ export default class Dimensions {
     this.lgRect = this.dimHelpers.getLegendsRect()
     this.datalabelsCoords = { width: 0, height: 0 }
 
-    const maxStrokeWidth = Array.isArray(w.config.stroke.width)
-      ? Math.max(...w.config.stroke.width)
-      : w.config.stroke.width
-
     if (this.isSparkline) {
       if (w.config.markers.discrete.length > 0 || w.config.markers.size > 0) {
         Object.entries(this.gridPad).forEach(([k, v]) => {
@@ -68,8 +64,8 @@ export default class Dimensions {
         })
       }
 
-      this.gridPad.top = Math.max(maxStrokeWidth / 2, this.gridPad.top)
-      this.gridPad.bottom = Math.max(maxStrokeWidth / 2, this.gridPad.bottom)
+      this.gridPad.top = Math.max(this.gridPad.top, 0)
+      this.gridPad.bottom = Math.max(this.gridPad.bottom, 0)
     }
 
     if (gl.axisCharts) {


### PR DESCRIPTION
Fixes #5137

## Summary
Removes the unused ~2px bottom margin on sparkline charts by:
1. Dropping the sparkline-specific grid padding that was set to `maxStrokeWidth / 2` — sparklines are meant to be tight, edge-to-edge, so automatic stroke-width padding is unnecessary
2. Changing the non-axis chart `offY` from 1 to 0 for sparklines (only affects pie/radial sparklines)

## Testing
- All 2131 unit tests pass
- Build succeeds (UMD, ESM, CommonJS, SSR)
- Manual verification: sparkline chart now fills its container without extra bottom space