### PR TITLE
fix: prevent NaN when xaxis label fontSize is set to inherit

### DIFF
--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -185,7 +185,7 @@ export default class Dimensions {
     if (w.globals.isBarHorizontal) {
       w.layout.rotateXLabels = false
       w.layout.translateXAxisY =
-        -1 * (parseInt(w.config.xaxis.labels.style.fontSize, 10) / 1.5)
+        -1 * ((parseInt(w.config.xaxis.labels.style.fontSize, 10) || 12) / 1.5)
     }
 
     w.layout.translateXAxisY =


### PR DESCRIPTION
## Description

When setting `xaxis.labels.style.fontSize` to `"inherit"`, `parseInt("inherit", 10)` returns `NaN`, causing the warning:

> Unexpected value translate(0, NaN) parsing transform attribute

## Fix

Fall back to the default font size of 12 when the parsed value is NaN, using the same pattern already used in `Pie.js` and `Sunburst.js`.

## Related Issue

Closes #5064

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)