### PR TITLE
fix: prevent zoom selection dragging from triggering chart click event

### DIFF
--- a/src/modules/Events.js
+++ b/src/modules/Events.js
@@ -136,6 +136,11 @@ export default class Events {
             (e.type === 'mouseup' && e.which === 1) ||
             e.type === 'touchend'
           ) {
+            // Skip click event if the mouseup was part of a drag (zoom/pan selection)
+            if (w.interact.wasDragged) {
+              w.interact.wasDragged = false
+              return
+            }
             if (typeof w.config.chart.events.click === 'function') {
               w.config.chart.events.click(e, me, opts)
             }

--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -252,6 +252,7 @@ export default class ZoomPanSelection extends Toolbar {
       this.startY = this.clientY - gridRectDim.top
 
       this.dragged = false
+      this.w.interact.wasDragged = false
       this.w.interact.mousedown = true
     }
 
@@ -320,6 +321,7 @@ export default class ZoomPanSelection extends Toolbar {
       this.hideSelectionRect(this.selectionRect)
     }
 
+    this.w.interact.wasDragged = this.dragged
     this.dragged = false
     this.w.interact.mousedown = false
   }


### PR DESCRIPTION
## Description

When a user performs a zoom selection by dragging a rectangle on the chart (with `chart.zoom.enabled: true` and `chart.zoom.type: 'xy'`), the `mouseup` event at the end of the drag was incorrectly firing the chart's `click` event handler (`chart.events.click` and the `click` event).

## Root Cause

The `Events.js` `setupEventHandlers` method listens for `mouseup` on the chart element and fires the click event callback. At the same time, `ZoomPanSelection.js` `svgMouseEvents` also handles `mouseup` for zoom/pan selection. Since the SVG element (where zoomPanSelection listens) is a child of the chart element, `mouseup` bubbles up — but there was no flag to distinguish a drag from a simple click.

## Fix

Two small changes:

1. **ZoomPanSelection.js** (`handleMouseUp`): Set `w.interact.wasDragged = this.dragged` before resetting the drag state, so the Events handler can check whether the mouseup concluded a drag. Also reset `wasDragged` on the next `mousedown` to prevent stale flags from a `mouseleave` abort.

2. **Events.js** (`setupEventHandlers`): Skip the click event callback when `w.interact.wasDragged` is true, then reset it.

## Testing

All 2137 tests pass across 94 test files.

Closes #5060