### PR TITLE
fix: align x-axis ticks with bar positions for numeric bar charts with >10 bars (#5086)

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -626,6 +626,19 @@ class Range {
           ticks = gl.dataPoints - 1
         }
 
+        // For bar charts with numeric x-axis data, generate ticks that align
+        // with data points (integer steps) rather than svgWidth-based steps
+        // that can produce non-integer positions (e.g. 11 bars → step 1.111).
+        // (See #5086)
+        if (
+          this.w.axisFlags.isXNumeric &&
+          !gl.isBarHorizontal &&
+          this.w.config.chart.type === 'bar' &&
+          gl.dataPoints < 30
+        ) {
+          ticks = gl.dataPoints - 1
+        }
+
         // this check is for when ticks exceeds total datapoints and that would result in duplicate labels
         if (ticks > gl.dataPoints && gl.dataPoints !== 0) {
           ticks = gl.dataPoints - 1

--- a/tests/unit/xaxis.spec.js
+++ b/tests/unit/xaxis.spec.js
@@ -1195,3 +1195,55 @@ describe('x-axis axisTicks configuration', () => {
     expect(w.config.xaxis.axisTicks.color).toBe('#333')
   })
 })
+
+describe('x-axis ticks for numeric bar charts with >10 bars (#5086)', () => {
+  it('should generate integer-aligned ticks for 11 bars', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: '800px' },
+      series: [{
+        data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(x => ({ x, y: x }))
+      }],
+      dataLabels: { enabled: false },
+    })
+
+    const result = chart.w.globals.xAxisScale.result
+    // All 11 integer ticks should be present (step=1, not non-integer steps)
+    expect(result.length).toBe(11)
+    expect(result).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    chart.destroy()
+  })
+
+  it('should generate integer-aligned ticks for 25 bars', () => {
+    const data = Array.from({ length: 25 }, (_, i) => ({ x: i + 1, y: Math.random() * 100 }))
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: '1000px' },
+      series: [{ data }],
+      dataLabels: { enabled: false },
+    })
+
+    const result = chart.w.globals.xAxisScale.result
+    // 25 bars should show all 25 ticks (step=1)
+    expect(result.length).toBe(25)
+    expect(result[0]).toBe(1)
+    expect(result[result.length - 1]).toBe(25)
+    chart.destroy()
+  })
+
+  it('should not affect non-bar chart types', () => {
+    // Line charts with numeric x data already get integer ticks from
+    // the existing `xaxis.type === 'numeric'` path. Verify the fix
+    // doesn't change this behavior.
+    const chart = createChartWithOptions({
+      chart: { type: 'line', width: '800px' },
+      series: [{
+        data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(x => ({ x, y: x }))
+      }],
+      dataLabels: { enabled: false },
+    })
+
+    const result = chart.w.globals.xAxisScale.result
+    // Line charts with numeric type already get dataPoints-1 ticks
+    expect(result.length).toBe(11)
+    chart.destroy()
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe)

## What is the current behavior?

For bar charts with numeric x-axis data (e.g. `{x, y}` format), the x-axis tick amount is computed from `Math.round(svgWidth / 150)`. With 11+ bars this can produce a non-integer step (e.g. 11 bars over a 600px chart → `ticks=4` → `step=2.5` → ticks `[1, 3.5, 6, 8.5, 11]`), so the tick labels land at non-integer positions that don't align with the bars.

Closes #5086

## What is the new behavior?

For vertical bar charts with numeric x-axis data and fewer than 30 data points, the tick amount is set to `dataPoints - 1`, so the step is exactly 1 and every tick lands on an integer position aligned with a bar. This matches matplotlib's approach of always generating ticks at a regular interval that falls on actual data points.

Before: 11 bars on a 600px chart → ticks `[1, 3.5, 6, 8.5, 11]` (misaligned)
After: 11 bars on a 600px chart → ticks `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]` (aligned)

## What does this PR do?

- In `src/modules/Range.js`, when the chart is a vertical bar chart with numeric x-axis data (`isXNumeric`) and `dataPoints < 30`, sets `ticks = dataPoints - 1` so the scale uses integer steps.
- Adds unit tests covering 11-bar and 25-bar numeric bar charts, plus a check that non-bar chart types are unaffected.

## Screenshots (if appropriate)

N/A — verified via unit tests that `xAxisScale.result` produces integer-aligned ticks.

## Other information

All 2140 unit tests pass (94 test files).