### PR TITLE
fix: include brush autoScaleYaxis boundary points within one rendered pixel (#5251)

### DIFF
--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -102,11 +102,21 @@ class Range {
       let lastXIndex = series[i].length - 1
       if (autoScaleYaxis) {
         // Scale the Y axis to the min..max within the possibly zoomed X axis domain.
+        // Subpixel rounding in brush selection may produce a pixel→timestamp
+        // conversion that is slightly off exact data point timestamps, causing
+        // boundary points to be excluded from the Y range. (#5251)
+        let onePixelInDomain = 0
+        if (
+          gl.maxX !== gl.minX &&
+          this.w.layout.gridWidth > 0
+        ) {
+          onePixelInDomain = (gl.maxX - gl.minX) / this.w.layout.gridWidth
+        }
         if (cnf.xaxis.min) {
           for (
             ;
             firstXIndex < lastXIndex &&
-            this.w.seriesData.seriesX[i][firstXIndex] < cnf.xaxis.min;
+            this.w.seriesData.seriesX[i][firstXIndex] < cnf.xaxis.min - onePixelInDomain;
             firstXIndex++
           ) {
             // Intentionally empty - just incrementing firstXIndex
@@ -116,7 +126,7 @@ class Range {
           for (
             ;
             lastXIndex > firstXIndex &&
-            this.w.seriesData.seriesX[i][lastXIndex] > cnf.xaxis.max;
+            this.w.seriesData.seriesX[i][lastXIndex] > cnf.xaxis.max + onePixelInDomain;
             lastXIndex--
           ) {
             // Intentionally empty - just decrementing lastXIndex

--- a/tests/unit/brush-autoscaleyaxis-boundary.spec.js
+++ b/tests/unit/brush-autoscaleyaxis-boundary.spec.js
@@ -1,0 +1,136 @@
+import { createChartWithOptions } from './utils/utils.js'
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe('Brush autoScaleYaxis boundary inclusion (#5251)', () => {
+  beforeEach(() => {
+    window.Apex = {}
+  })
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = ''
+  })
+
+  it('includes a boundary point within one rendered pixel of the brush max', async () => {
+    const start = Date.UTC(2026, 5, 15)
+
+    // 12 data points — the last one has the highest Y value (540)
+    const data = [
+      [start + 0 * DAY, 483],
+      [start + 1 * DAY, 438],
+      [start + 2 * DAY, 438],
+      [start + 3 * DAY, 438],
+      [start + 4 * DAY, 438],
+      [start + 5 * DAY, 390],
+      [start + 6 * DAY, 388],
+      [start + 7 * DAY, 437],
+      [start + 8 * DAY, 448],
+      [start + 9 * DAY, 448],
+      [start + 10 * DAY, 450],
+      [start + 11 * DAY, 540],
+    ]
+
+    const lastX = data[data.length - 1][0]
+    const lastY = data[data.length - 1][1]
+
+    // The brush selection max is slightly before the last data point,
+    // simulating a subpixel rounding error in the DOM pixel→timestamp conversion.
+    const subpixelTimestampError = 1 // 1 ms before the last point
+    const brushMax = lastX - subpixelTimestampError
+
+    const chart = createChartWithOptions({
+      chart: {
+        id: 'main-chart',
+        type: 'area',
+        height: 240,
+        width: '800px',
+        zoom: {
+          enabled: true,
+          type: 'x',
+          autoScaleYaxis: true,
+        },
+        toolbar: {
+          autoSelected: 'pan',
+        },
+      },
+      series: [
+        {
+          name: 'Price',
+          data,
+        },
+      ],
+      stroke: {
+        curve: 'smooth',
+        width: 3,
+      },
+      markers: {
+        size: 4,
+      },
+      xaxis: {
+        type: 'datetime',
+        min: data[0][0],
+        max: lastX,
+      },
+    })
+
+    // Simulate a brush selection that ends slightly before the last data point
+    chart.zoomX(data[0][0], brushMax)
+
+    // The Y-axis max should include the last point (540) even though
+    // brushMax is slightly before lastX, because the difference is
+    // less than one rendered pixel in the X domain.
+    expect(chart.w.globals.yAxisScale[0].niceMax).toBeGreaterThanOrEqual(lastY)
+  })
+
+  it('excludes a point far outside the brush range (no false positive)', async () => {
+    const start = Date.UTC(2026, 5, 15)
+
+    const data = [
+      [start + 0 * DAY, 100],
+      [start + 1 * DAY, 200],
+      [start + 2 * DAY, 300],
+      [start + 3 * DAY, 400],
+      [start + 4 * DAY, 500],
+    ]
+
+    const chart = createChartWithOptions({
+      chart: {
+        id: 'main-chart',
+        type: 'area',
+        height: 240,
+        zoom: {
+          enabled: true,
+          type: 'x',
+          autoScaleYaxis: true,
+        },
+        toolbar: {
+          autoSelected: 'pan',
+        },
+      },
+      series: [
+        {
+          name: 'Price',
+          data,
+        },
+      ],
+      stroke: {
+        curve: 'smooth',
+        width: 3,
+      },
+      markers: {
+        size: 4,
+      },
+      xaxis: {
+        type: 'datetime',
+        min: data[0][0],
+        max: data[data.length - 1][0],
+      },
+    })
+
+    // Zoom to first 2 points only — the last point (500) is far outside
+    chart.zoomX(data[0][0], data[1][0])
+
+    // The Y-axis max should be based on the max of the first 2 points (200),
+    // not the last point (500) which is far outside the range.
+    expect(chart.w.globals.yAxisScale[0].niceMax).toBeLessThan(500)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #5251 — When a datetime chart is controlled by a brush chart with `autoScaleYaxis` enabled, the Y-axis range may exclude the rightmost (or leftmost) boundary data point.

### Problem

The brush selection boundary is reconstructed from the selection rectangle using its DOM pixel bounds (`selectionRect.node.getBoundingClientRect()` → `AxisMapping.pxToDataX`). The pixel→timestamp round-trip can produce a value slightly smaller than the exact data point timestamp (e.g. `lastPointTimestamp - 1ms`).

In `Range.getMinYMaxY()`, when selecting points for Y auto-scaling, the loop uses a **strict** comparison:

```js
while (
  lastXIndex > firstXIndex &&
  seriesX[lastXIndex] > config.xaxis.max   // <-- strict
) {
  lastXIndex--
}
```

So even a tiny sub-pixel rounding error causes the boundary point to be **excluded** from the Y extrema calculation, even though the line segment leading to it is still rendered inside the plot area. As a result the line can leave the visible Y range or be clipped.

Brush selection and main-chart panning produce different Y ranges for the same effective X window.

### Fix

Compute a one-rendered-pixel tolerance in the X domain and apply it to both boundary comparisons:

```js
const onePixelInDomain = (gl.maxX - gl.minX) / this.w.layout.gridWidth
// min side:  seriesX[firstXIndex] < cnf.xaxis.min - onePixelInDomain
// max side:  seriesX[lastXIndex]  > cnf.xaxis.max + onePixelInDomain
```

A data point whose timestamp differs from the brush boundary by less than one rendered pixel is now treated as being inside the window, matching what is actually rendered. Points far outside the range are still excluded (no false positives).

The tolerance is derived from the live X-domain-to-pixel ratio, as suggested in the issue, rather than a fixed timestamp epsilon.

### Verification

- New regression test: `brush-autoscaleyaxis-boundary.spec.js`
  - Includes a boundary point within one pixel of the brush max in `autoScaleYaxis`
  - Confirms a point far outside the range is still excluded (no false positive)
- Full unit suite: **1978 tests pass** (the 3 pre-existing `No such built-in module: node:` failures are unrelated to this change)