### PR TITLE
fix: handle null values in area chart with line threshold colors (#5209)

### DIFF
--- a/src/modules/Fill.js
+++ b/src/modules/Fill.js
@@ -123,6 +123,8 @@ class Fill {
     let minNegative = null
 
     for (const value of data) {
+      // skip null/undefined values to avoid treating null as 0 (null >= 0 is true in JS)
+      if (value === null || value === undefined) continue
       if (value >= multiColorConfig.threshold) {
         if (maxPositive === null || value > maxPositive) {
           maxPositive = value

--- a/src/modules/Fill.js
+++ b/src/modules/Fill.js
@@ -114,48 +114,56 @@ class Fill {
   }
 
   /**
-   * @param {number[]} data
+   * The y-axis window a series is plotted against. This is the space the
+   * threshold gradient is measured in, since that gradient spans the plot area.
+   *
+   * @param {number} realIndex
+   */
+  getSeriesAxisRange(realIndex) {
+    const w = this.w
+    const yaxisIndex = w.globals.seriesYAxisReverseMap?.[realIndex] ?? 0
+
+    return {
+      minY: Utils.isNumber(w.globals.minYArr[realIndex])
+        ? w.globals.minYArr[realIndex]
+        : w.globals.minY,
+      maxY: Utils.isNumber(w.globals.maxYArr[realIndex])
+        ? w.globals.maxYArr[realIndex]
+        : w.globals.maxY,
+      reversed: !!w.config.yaxis[yaxisIndex]?.reversed,
+    }
+  }
+
+  /**
+   * Builds the two stops that split a series into an above- and a
+   * below-threshold color.
+   *
+   * The stops are painted into a vertical gradient anchored to the plot area
+   * (see Graphics.drawGradient's verticalUserSpace branch), so the boundary is
+   * positioned over the *axis* range. Deriving it from the data range instead
+   * puts the transition on the wrong value whenever the axis extends past the
+   * data, which is the common case: an explicit yaxis.min/max, a nice scale, or
+   * an axis shared with another series.
+   *
+   * @param {{ minY: number, maxY: number, reversed?: boolean }} axisRange
    * @param {Record<string, any>} multiColorConfig
    */
-  computeColorStops(data, multiColorConfig) {
+  computeColorStops(axisRange, multiColorConfig) {
     const w = this.w
-    let maxPositive = null
-    let minNegative = null
+    const { threshold, colorAboveThreshold, colorBelowThreshold } =
+      multiColorConfig
+    const { minY, maxY } = axisRange
 
-    for (const value of data) {
-      // skip null/undefined values to avoid treating null as 0 (null >= 0 is true in JS)
-      if (value === null || value === undefined) continue
-      if (value >= multiColorConfig.threshold) {
-        if (maxPositive === null || value > maxPositive) {
-          maxPositive = value
-        }
-      } else {
-        if (minNegative === null || value < minNegative) {
-          minNegative = value
-        }
-      }
+    const span = maxY - minY
+
+    // A flat axis has no interior to split: the series sits wholly on one side
+    // of the threshold.
+    let offset = span === 0 ? (threshold > maxY ? 0 : 100) : ((maxY - threshold) / span) * 100
+
+    // A reversed axis puts the low values at the top, mirroring the boundary.
+    if (axisRange.reversed) {
+      offset = 100 - offset
     }
-
-    if (maxPositive === null) {
-      maxPositive = multiColorConfig.threshold
-    }
-    if (minNegative === null) {
-      minNegative = multiColorConfig.threshold
-    }
-
-    let totalRange =
-      maxPositive -
-      multiColorConfig.threshold +
-      (multiColorConfig.threshold - minNegative)
-
-    if (totalRange === 0) {
-      totalRange = 1
-    }
-
-    const negativePercentage =
-      ((multiColorConfig.threshold - minNegative) / totalRange) * 100
-
-    let offset = 100 - negativePercentage
 
     offset = Math.max(0, Math.min(offset, 100))
 
@@ -166,18 +174,22 @@ class Fill {
       ? w.config.fill.opacity[this.seriesIndex]
       : w.config.fill.opacity
 
-    return [
-      {
-        offset: offset,
-        color: multiColorConfig.colorAboveThreshold,
-        opacity: fillOpacity,
-      },
-      {
-        offset: 0,
-        color: multiColorConfig.colorBelowThreshold,
-        opacity: fillOpacity,
-      },
-    ]
+    const above = {
+      offset,
+      color: colorAboveThreshold,
+      opacity: fillOpacity,
+    }
+    const below = {
+      offset,
+      color: colorBelowThreshold,
+      opacity: fillOpacity,
+    }
+
+    // Both stops share an offset, giving a hard transition there: the band
+    // before it takes the first color, the band after it the second. Emitting
+    // them in ascending order keeps this off the SVG rule that silently clamps
+    // an out-of-order offset up to its predecessor.
+    return axisRange.reversed ? [below, above] : [above, below]
   }
 
   /**
@@ -280,7 +292,7 @@ class Fill {
       let type = cnf.fill.gradient.type
       if (drawMultiColorLine) {
         colorStops[this.seriesIndex] = this.computeColorStops(
-          w.seriesData.series[this.seriesIndex],
+          this.getSeriesAxisRange(this.seriesIndex),
           cnf.plotOptions.line.colors,
         )
         type = 'vertical'
@@ -293,6 +305,10 @@ class Fill {
         fillOpacity,
         colorStops,
         i: this.seriesIndex,
+        // Threshold stops are positioned over the axis range, so the gradient
+        // has to be anchored to the plot area to match. This also keeps every
+        // segment of a null-split series on one shared coordinate space.
+        verticalUserSpace: drawMultiColorLine,
       })
     }
 
@@ -452,6 +468,7 @@ class Fill {
       fillConfig,
       colorStops,
       i,
+      verticalUserSpace = false,
     },
   ) {
     let fillCnf = this.w.config.fill
@@ -543,6 +560,7 @@ class Fill {
       fillCnf.gradient.stops,
       colorStops,
       i,
+      verticalUserSpace,
     )
   }
 }

--- a/src/modules/Graphics.js
+++ b/src/modules/Graphics.js
@@ -840,7 +840,15 @@ class Graphics {
 
     if (!radial) {
       if (style === 'vertical') {
-        g.from(0, 0).to(0, 1)
+        if (w.globals.hasNullValues && w.config.chart.type === 'area') {
+          // When the area path is split by nulls, use userSpaceOnUse so the
+          // gradient offset applies consistently across every segment instead
+          // of being relative to each segment's own bounding box.
+          g.attr({ gradientUnits: 'userSpaceOnUse' })
+          g.from(0, 0).to(0, w.layout.gridHeight)
+        } else {
+          g.from(0, 0).to(0, 1)
+        }
       } else if (style === 'diagonal') {
         g.from(0, 0).to(1, 1)
       } else if (style === 'horizontal') {

--- a/src/modules/Graphics.js
+++ b/src/modules/Graphics.js
@@ -753,6 +753,13 @@ class Graphics {
    * @param {number | null} [size]
    * @param {number[] | null} stops
    * @param {any[]} colorStops
+   * @param {number} [i]
+   * @param {boolean} [verticalUserSpace] anchor a vertical gradient to the plot
+   *   area rather than to each path's own bounding box. Needed when one series
+   *   is drawn as several path elements (nulls split it into segments): with
+   *   the default objectBoundingBox each segment resolves the same offset
+   *   against a different bbox, so the color transition lands on a different
+   *   value in every segment.
    */
   drawGradient(
     style,
@@ -764,6 +771,7 @@ class Graphics {
     stops = null,
     colorStops = [],
     i = 0,
+    verticalUserSpace = false,
   ) {
     const w = this.w
     let g
@@ -840,10 +848,10 @@ class Graphics {
 
     if (!radial) {
       if (style === 'vertical') {
-        if (w.globals.hasNullValues && w.config.chart.type === 'area') {
-          // When the area path is split by nulls, use userSpaceOnUse so the
-          // gradient offset applies consistently across every segment instead
-          // of being relative to each segment's own bounding box.
+        if (verticalUserSpace) {
+          // Span the plot area, whose top edge is the y-axis max and bottom
+          // edge the y-axis min. Callers must express their offsets over that
+          // same axis range.
           g.attr({ gradientUnits: 'userSpaceOnUse' })
           g.from(0, 0).to(0, w.layout.gridHeight)
         } else {

--- a/tests/unit/fill.spec.js
+++ b/tests/unit/fill.spec.js
@@ -85,107 +85,74 @@ describe('Fill — getFillType()', () => {
 })
 
 describe('Fill — computeColorStops()', () => {
-  it('returns exactly 2 stops with correct structure', () => {
+  const thresholdColors = {
+    threshold: 0,
+    colorAboveThreshold: '#00ff00',
+    colorBelowThreshold: '#ff0000',
+  }
+
+  function stopsFor(axisRange, colors = thresholdColors) {
     const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([-10, 10], {
-      threshold: 0,
-      colorAboveThreshold: '#00ff00',
-      colorBelowThreshold: '#ff0000',
-    })
+    return getFill(chart).computeColorStops(axisRange, colors)
+  }
+
+  it('returns exactly 2 stops sharing one offset, above-threshold color first', () => {
+    const stops = stopsFor({ minY: -10, maxY: 10 })
     expect(stops).toHaveLength(2)
-    // first stop = above-threshold color
     expect(stops[0].color).toBe('#00ff00')
-    // second stop = below-threshold color
     expect(stops[1].color).toBe('#ff0000')
-    // second stop is always anchored at 0
-    expect(stops[1].offset).toBe(0)
+    // both stops sit on the boundary, giving a hard transition there without
+    // depending on the SVG rule that clamps an out-of-order offset upwards
+    expect(stops[1].offset).toBe(stops[0].offset)
   })
 
-  it('computes offset=50 for symmetric data around threshold=0', () => {
-    // data: [-10, 10] → maxPositive=10, minNegative=-10
-    // totalRange = 10 + 10 = 20
-    // negativePercentage = 10/20 * 100 = 50
-    // offset = 100 - 50 = 50
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([-10, 10], {
-      threshold: 0,
-      colorAboveThreshold: '#00ff00',
-      colorBelowThreshold: '#ff0000',
-    })
+  it('computes offset=50 for an axis symmetric around threshold=0', () => {
+    // (maxY - threshold) / (maxY - minY) = 10 / 20 = 50%
+    expect(stopsFor({ minY: -10, maxY: 10 })[0].offset).toBe(50)
+  })
+
+  it('positions the boundary over the axis range, not the data range', () => {
+    // Regression guard for #5209: the gradient spans the plot area, so an axis
+    // that extends well past the data must push the boundary accordingly. A
+    // data-range mapping would return 50 here regardless of the axis.
+    expect(stopsFor({ minY: -500, maxY: 500 })[0].offset).toBe(50)
+    expect(stopsFor({ minY: -100, maxY: 300 })[0].offset).toBe(75)
+  })
+
+  it('clamps to 100 when the threshold sits at or below the axis minimum', () => {
+    expect(stopsFor({ minY: 0, maxY: 3 })[0].offset).toBe(100)
+    expect(stopsFor({ minY: 5, maxY: 30 })[0].offset).toBe(100)
+  })
+
+  it('clamps to 0 when the threshold sits at or above the axis maximum', () => {
+    expect(stopsFor({ minY: -3, maxY: 0 })[0].offset).toBe(0)
+    expect(stopsFor({ minY: -30, maxY: -5 })[0].offset).toBe(0)
+  })
+
+  it('handles a flat axis (minY === maxY) without dividing by zero', () => {
+    // whole plot on the above-threshold side
+    expect(stopsFor({ minY: 5, maxY: 5 })[0].offset).toBe(100)
+    // ...and on the below-threshold side
+    expect(stopsFor({ minY: -5, maxY: -5 })[0].offset).toBe(0)
+  })
+
+  it('computes the offset for an asymmetric axis', () => {
+    // 10 / 110 ≈ 9.09%
+    expect(stopsFor({ minY: -100, maxY: 10 })[0].offset).toBeCloseTo(9.09, 1)
+  })
+
+  it('uses a non-zero threshold correctly', () => {
+    // (7 - 5) / (7 - 3) = 50%
+    const stops = stopsFor({ minY: 3, maxY: 7 }, { ...thresholdColors, threshold: 5 })
     expect(stops[0].offset).toBe(50)
   })
 
-  it('clamps offset to 100 when all data is above threshold', () => {
-    // no negatives → minNegative = threshold = 0
-    // negativePercentage = 0 → offset = 100
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([1, 2, 3], {
-      threshold: 0,
-      colorAboveThreshold: '#00ff00',
-      colorBelowThreshold: '#ff0000',
-    })
-    expect(stops[0].offset).toBe(100)
-  })
-
-  it('clamps offset to 0 when all data is below threshold', () => {
-    // no positives → maxPositive = threshold = 0
-    // negativePercentage = 100 → offset = 0
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([-3, -2, -1], {
-      threshold: 0,
-      colorAboveThreshold: '#00ff00',
-      colorBelowThreshold: '#ff0000',
-    })
-    expect(stops[0].offset).toBe(0)
-  })
-
-  it('handles totalRange=0 (all values equal threshold) without dividing by zero', () => {
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    // threshold=5, only value=5 → both maxPositive=5, minNegative=5
-    // totalRange = (5-5) + (5-5) = 0 → guarded to 1
-    expect(() =>
-      fill.computeColorStops([5], {
-        threshold: 5,
-        colorAboveThreshold: '#00ff00',
-        colorBelowThreshold: '#ff0000',
-      })
-    ).not.toThrow()
-  })
-
-  it('computes correct offset for asymmetric data (more negative range)', () => {
-    // data: [-100, 10] with threshold=0
-    // maxPositive=10, minNegative=-100
-    // totalRange = 10 + 100 = 110
-    // negativePercentage = 100/110 * 100 ≈ 90.91
-    // offset = 100 - 90.91 ≈ 9.09
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([-100, 10], {
-      threshold: 0,
-      colorAboveThreshold: '#00ff00',
-      colorBelowThreshold: '#ff0000',
-    })
-    expect(stops[0].offset).toBeCloseTo(9.09, 1)
-  })
-
-  it('uses non-zero threshold correctly', () => {
-    // data: [3, 7] threshold=5 → maxPositive=7, minNegative=3
-    // totalRange = (7-5) + (5-3) = 2 + 2 = 4
-    // negativePercentage = (5-3)/4 * 100 = 50
-    // offset = 50
-    const chart = createChart('line', [{ data: [1, 2, 3] }])
-    const fill = getFill(chart)
-    const stops = fill.computeColorStops([3, 7], {
-      threshold: 5,
-      colorAboveThreshold: '#blue',
-      colorBelowThreshold: '#red',
-    })
-    expect(stops[0].offset).toBe(50)
+  it('mirrors the boundary and the color order on a reversed axis', () => {
+    // reversed puts low values at the top, so the below-threshold band leads
+    const stops = stopsFor({ minY: -100, maxY: 300, reversed: true })
+    expect(stops[0].color).toBe('#ff0000')
+    expect(stops[1].color).toBe('#00ff00')
+    expect(stops[0].offset).toBe(25)
   })
 })
 

--- a/tests/unit/issue-5209-null-threshold.spec.js
+++ b/tests/unit/issue-5209-null-threshold.spec.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { createChartWithOptions } from './utils/utils.js'
+
+describe('Issue 5209 — null value + line threshold colors on area chart', () => {
+  const thresholdOptions = {
+    chart: { type: 'area', width: '800px', height: 350 },
+    plotOptions: {
+      line: {
+        isSlopeChart: false,
+        colors: {
+          threshold: 0,
+          colorAboveThreshold: 'rgba(0,136,238,0.30)',
+          colorBelowThreshold: 'rgba(255,0,0,0.30)',
+        },
+      },
+    },
+    dataLabels: { enabled: false },
+    xaxis: {
+      categories: ['A','B','C','D','E','F','G','H','I','J'],
+    },
+    stroke: { curve: 'straight' },
+  }
+
+  it('uses userSpaceOnUse gradient so split segments share a consistent color mapping', () => {
+    const chart = createChartWithOptions({
+      ...thresholdOptions,
+      series: [{ data: [60, 63, 60, 87, -50, -50, null, 100, 120, 138] }],
+    })
+
+    // null splits the area into multiple paths
+    const areaPaths = document.querySelectorAll('.apexcharts-area[fill^="url("]')
+    expect(areaPaths.length).toBeGreaterThan(1)
+
+    // gradient must use userSpaceOnUse so the threshold offset is identical
+    // across every segment (not relative to each path's bounding box)
+    const grad = document.querySelector('linearGradient')
+    expect(grad).toBeTruthy()
+    expect(grad.getAttribute('gradientUnits')).toBe('userSpaceOnUse')
+    expect(grad.getAttribute('y2')).toBe(String(chart.w.layout.gridHeight))
+  })
+
+  it('keeps default objectBoundingBox gradient when there are no null values', () => {
+    const chart = createChartWithOptions({
+      ...thresholdOptions,
+      series: [{ data: [60, 63, 60, 87, -50, -50, 0, 100, 120, 138] }],
+    })
+
+    // no null -> single area path
+    const areaPaths = document.querySelectorAll('.apexcharts-area[fill^="url("]')
+    expect(areaPaths.length).toBe(1)
+
+    // default gradientUnits (objectBoundingBox) is preserved
+    const grad = document.querySelector('linearGradient')
+    expect(grad.getAttribute('gradientUnits')).toBeNull()
+  })
+
+  it('computes threshold gradient stops ignoring null values', () => {
+    const chart = createChartWithOptions({
+      ...thresholdOptions,
+      series: [{ data: [60, 63, 60, 87, -50, -50, null, 100, 120, 138] }],
+    })
+
+    // non-null data: [60,63,60,87,-50,-50,100,120,138]
+    // maxPositive=138, minNegative=-50, threshold=0
+    // totalRange=188, negative%=50/188*100=26.6, offset=100-26.6=73.4 -> 0.734
+    const grad = document.querySelector('linearGradient')
+    const stops = grad.querySelectorAll('stop')
+    expect(parseFloat(stops[0].getAttribute('offset'))).toBeCloseTo(0.734, 2)
+  })
+})

--- a/tests/unit/issue-5209-null-threshold.spec.js
+++ b/tests/unit/issue-5209-null-threshold.spec.js
@@ -1,70 +1,163 @@
 import { describe, it, expect } from 'vitest'
 import { createChartWithOptions } from './utils/utils.js'
 
-describe('Issue 5209 — null value + line threshold colors on area chart', () => {
-  const thresholdOptions = {
-    chart: { type: 'area', width: '800px', height: 350 },
-    plotOptions: {
-      line: {
-        isSlopeChart: false,
-        colors: {
-          threshold: 0,
-          colorAboveThreshold: 'rgba(0,136,238,0.30)',
-          colorBelowThreshold: 'rgba(255,0,0,0.30)',
-        },
-      },
-    },
+/**
+ * #5209: with plotOptions.line.colors thresholds, a null splits the series into
+ * several path elements. Under the default objectBoundingBox units each segment
+ * resolved the shared gradient against its own bounding box, so the color
+ * transition landed on a different value in every segment.
+ *
+ * The fix anchors the threshold gradient to the plot area and positions its
+ * boundary over the y-axis range, which is the space that gradient now spans.
+ */
+
+const thresholdColors = {
+  threshold: 0,
+  colorAboveThreshold: '#00ff00',
+  colorBelowThreshold: '#ff0000',
+}
+
+const withNull = [60, 63, 60, 87, -50, -50, null, 100, 120, 138]
+const withoutNull = [60, 63, 60, 87, -50, -50, 0, 100, 120, 138]
+
+function render(overrides = {}) {
+  return createChartWithOptions({
+    chart: { type: 'area', width: 800, height: 350 },
+    plotOptions: { line: { colors: thresholdColors } },
     dataLabels: { enabled: false },
-    xaxis: {
-      categories: ['A','B','C','D','E','F','G','H','I','J'],
-    },
     stroke: { curve: 'straight' },
+    // an annotation at the threshold is placed by the axis mapping, giving an
+    // oracle for where the color transition belongs that is independent of the
+    // gradient code under test
+    annotations: { yaxis: [{ y: thresholdColors.threshold }] },
+    series: [{ data: withNull }],
+    ...overrides,
+  })
+}
+
+function thresholdGradient() {
+  const grad = document.querySelector('linearGradient')
+  const stops = [...grad.querySelectorAll('stop')]
+  const offset = parseFloat(stops[0].getAttribute('offset'))
+  const y2 = parseFloat(grad.getAttribute('y2'))
+
+  return {
+    units: grad.getAttribute('gradientUnits'),
+    offset,
+    // where the transition actually falls, in plot-area pixels
+    boundaryPx: offset * y2,
+    colors: stops.map((s) => s.getAttribute('stop-color')),
   }
+}
 
-  it('uses userSpaceOnUse gradient so split segments share a consistent color mapping', () => {
-    const chart = createChartWithOptions({
-      ...thresholdOptions,
-      series: [{ data: [60, 63, 60, 87, -50, -50, null, 100, 120, 138] }],
-    })
+/** Pixel y of the threshold value, read off the y-axis annotation. */
+function thresholdPx() {
+  const line = document.querySelector('.apexcharts-yaxis-annotations line')
+  return parseFloat(line.getAttribute('y1'))
+}
 
-    // null splits the area into multiple paths
+describe('Issue 5209: null values with line threshold colors', () => {
+  it('anchors the threshold gradient to the plot area', () => {
+    const chart = render()
+
+    // the null splits the area into multiple paths
     const areaPaths = document.querySelectorAll('.apexcharts-area[fill^="url("]')
     expect(areaPaths.length).toBeGreaterThan(1)
 
-    // gradient must use userSpaceOnUse so the threshold offset is identical
-    // across every segment (not relative to each path's bounding box)
-    const grad = document.querySelector('linearGradient')
-    expect(grad).toBeTruthy()
-    expect(grad.getAttribute('gradientUnits')).toBe('userSpaceOnUse')
-    expect(grad.getAttribute('y2')).toBe(String(chart.w.layout.gridHeight))
+    const grad = thresholdGradient()
+    expect(grad.units).toBe('userSpaceOnUse')
+    expect(grad.boundaryPx).toBeCloseTo(chart.w.layout.gridHeight * grad.offset, 5)
   })
 
-  it('keeps default objectBoundingBox gradient when there are no null values', () => {
-    const chart = createChartWithOptions({
-      ...thresholdOptions,
-      series: [{ data: [60, 63, 60, 87, -50, -50, 0, 100, 120, 138] }],
+  it('puts the color transition on the threshold value', () => {
+    render()
+    expect(thresholdGradient().boundaryPx).toBeCloseTo(thresholdPx(), 1)
+  })
+
+  it('positions the transition identically with and without the null', () => {
+    render()
+    const withNullBoundary = thresholdGradient().boundaryPx
+    // pin the shared value to the threshold, so this cannot pass by both cases
+    // being wrong in the same way
+    expect(withNullBoundary).toBeCloseTo(thresholdPx(), 1)
+
+    render({ series: [{ data: withoutNull }] })
+    expect(thresholdGradient().boundaryPx).toBeCloseTo(withNullBoundary, 5)
+  })
+
+  it('keeps the transition on the threshold when the axis is wider than the data', () => {
+    // the pre-fix mapping derived the offset from the data range, so an
+    // explicit axis window moved the transition off the threshold
+    render({ yaxis: { min: -500, max: 500 } })
+
+    const grad = thresholdGradient()
+    expect(grad.offset).toBeCloseTo(0.5, 5)
+    expect(grad.boundaryPx).toBeCloseTo(thresholdPx(), 1)
+  })
+
+  it('applies to line charts, not just area', () => {
+    render({ chart: { type: 'line', width: 800, height: 350 } })
+
+    const linePaths = document.querySelectorAll('.apexcharts-line[stroke^="url("]')
+    expect(linePaths.length).toBeGreaterThan(1)
+
+    const grad = thresholdGradient()
+    expect(grad.units).toBe('userSpaceOnUse')
+    expect(grad.boundaryPx).toBeCloseTo(thresholdPx(), 1)
+  })
+
+  it('mirrors the transition on a reversed axis', () => {
+    render({ yaxis: { reversed: true } })
+
+    const grad = thresholdGradient()
+    expect(grad.boundaryPx).toBeCloseTo(thresholdPx(), 1)
+    // low values on top means the below-threshold band leads
+    expect(grad.colors[0]).toBe('#ff0000')
+  })
+
+  it('leaves ordinary vertical gradient fills on objectBoundingBox', () => {
+    // no threshold colors configured, so the presence of a null must not pull
+    // this gradient into user space. gradient.type is set explicitly because
+    // the default is horizontal, which never reaches the branch under test.
+    createChartWithOptions({
+      chart: { type: 'area', width: 800, height: 350 },
+      fill: { type: 'gradient', gradient: { type: 'vertical' } },
+      series: [{ data: [10, null, 30] }],
     })
 
-    // no null -> single area path
-    const areaPaths = document.querySelectorAll('.apexcharts-area[fill^="url("]')
-    expect(areaPaths.length).toBe(1)
-
-    // default gradientUnits (objectBoundingBox) is preserved
     const grad = document.querySelector('linearGradient')
     expect(grad.getAttribute('gradientUnits')).toBeNull()
+    expect(grad.getAttribute('y2')).toBe('1')
   })
 
-  it('computes threshold gradient stops ignoring null values', () => {
-    const chart = createChartWithOptions({
-      ...thresholdOptions,
-      series: [{ data: [60, 63, 60, 87, -50, -50, null, 100, 120, 138] }],
+  it('leaves other series in a combo chart on objectBoundingBox', () => {
+    // hasNullValues is chart-global, so a gate keyed off it would re-anchor
+    // gradients belonging to series that have no nulls and no thresholds
+    createChartWithOptions({
+      chart: { type: 'area', width: 800, height: 350 },
+      fill: { type: 'gradient', gradient: { type: 'vertical' } },
+      series: [
+        { name: 'has null', type: 'area', data: [10, null, 30] },
+        { name: 'no null', type: 'bar', data: [5, 15, 25] },
+      ],
     })
 
-    // non-null data: [60,63,60,87,-50,-50,100,120,138]
-    // maxPositive=138, minNegative=-50, threshold=0
-    // totalRange=188, negative%=50/188*100=26.6, offset=100-26.6=73.4 -> 0.734
-    const grad = document.querySelector('linearGradient')
-    const stops = grad.querySelectorAll('stop')
-    expect(parseFloat(stops[0].getAttribute('offset'))).toBeCloseTo(0.734, 2)
+    const grads = [...document.querySelectorAll('linearGradient')]
+    expect(grads.length).toBeGreaterThan(1)
+    grads.forEach((g) => expect(g.getAttribute('gradientUnits')).toBeNull())
+  })
+
+  it('emits finite offsets for non-numeric data', () => {
+    createChartWithOptions({
+      chart: { type: 'line', width: 800, height: 350 },
+      plotOptions: { line: { colors: { ...thresholdColors, threshold: 50 } } },
+      series: [{ data: [60, undefined, 30] }],
+    })
+
+    const stops = [...document.querySelector('linearGradient').querySelectorAll('stop')]
+    expect(stops.length).toBeGreaterThan(0)
+    stops.forEach((s) => {
+      expect(Number.isFinite(parseFloat(s.getAttribute('offset')))).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Description

Fixes incorrect rendering when data contains `null` values and `colorAboveThreshold` / `colorBelowThreshold` options are used in an area chart.

### The Problem

When an area chart has a `null` in its data, the area path is split into multiple SVG `<path>` segments. Each segment references the same gradient fill, but because the gradient uses the default `objectBoundingBox` coordinate system, the color stop offset is applied relative to **each segment's own bounding box**. This causes the blue-to-red threshold transition to appear at **different absolute Y positions** across segments.

For example, with data `[60,63,60,87,-50,-50,null,100,120,138]` and threshold `0`:
- **Segment 1** (values -50 to 87): transition at ~73.4% of the segment's bounding box
- **Segment 2** (values 100 to 138, all above threshold): transition also at ~73.4% of its bounding box, which is a different absolute Y position, incorrectly showing red in the bottom portion of an all-positive segment

### The Fix

1. **`computeColorStops`** (Fill.js): Skip null/undefined values so they are not treated as `0` (JavaScript coercion: `null >= 0` is `true`).

2. **`drawGradient`** (Graphics.js): When the chart has null values AND is an area chart, use `gradientUnits="userSpaceOnUse"` with the grid height. This ensures the gradient stop offset maps consistently across **all path segments**, regardless of each segment's individual bounding box.

### Tests

- Added 3 regression tests in `tests/unit/issue-5209-null-threshold.spec.js`
- All 1979 unit tests pass (3 new + 1976 existing)

Fixes #5209