### PR TITLE
fix: honor xaxis.stepSize when xaxis.max is also set (Closes #5082)

### DIFF
--- a/src/modules/Scales.js
+++ b/src/modules/Scales.js
@@ -647,7 +647,7 @@ export default class Scales {
         maxX,
         ticks,
         0,
-        w.config.xaxis.max === undefined ? w.config.xaxis.stepSize : undefined,
+        w.config.xaxis.stepSize,
       )
     }
     return gl.xAxisScale


### PR DESCRIPTION
## Summary

Fixes #5082 — **Xaxis "max" value is ignored when also providing a "stepSize"**.

When a user sets both `xaxis.max` and `xaxis.stepSize` on a numeric (or bubble/double) chart, the `stepSize` was being silently dropped. The root cause was in `Scales.setXScale()`:

```js
// before
w.config.xaxis.max === undefined ? w.config.xaxis.stepSize : undefined,
```

The ternary discarded `stepSize` whenever `xaxis.max` was defined, so tick steps fell back to `range / ticks` instead of honoring the user's explicit step size. Both options are independent and should be respected together — `max` pins the upper bound while `stepSize` controls the tick interval.

## Change

```js
// after
w.config.xaxis.stepSize,
```

`linearScale()` already handles `step === undefined` (falls back to `range / ticksNum`), so passing `stepSize` unconditionally is safe and preserves the existing behavior for charts that don't set it.

## Tests

- All existing unit tests pass (1980 passed).
- The 3 failing suites (`license-gating`, `license-manager`, `unit-chart`) are pre-existing environment failures (`No such built-in module: node:`) and fail identically on `main` without this change.

## Verification

Given options `xaxis: { min: 0, max: 200, stepSize: 50, type: 'double' }` on a bubble chart, the x-axis now renders ticks at 0, 50, 100, 150, 200 — honoring both the `max` bound and the explicit `stepSize`.

Closes #5082