### PR TITLE
fix: clamp column data labels X to prevent covering y-axis labels (Closes #5056)

### DIFF
--- a/src/charts/common/bar/DataLabels.js
+++ b/src/charts/common/bar/DataLabels.js
@@ -387,6 +387,30 @@ export default class BarDataLabels {
       }
     }
 
+    // Clamp dataLabelsX to prevent labels from extending past the grid
+    // edges and covering the y-axis labels or spilling off the right side.
+    // This mirrors the left-edge/right-edge clipping already present in
+    // calculateBarsDataLabelsPosition (horizontal bars) at lines 562-590.
+    if (dataLabelsConfig.textAnchor === 'middle') {
+      if (dataLabelsX - textRects.width / 2 < 0) {
+        dataLabelsX = textRects.width / 2 + strokeWidth
+      } else if (dataLabelsX + textRects.width / 2 > w.layout.gridWidth) {
+        dataLabelsX = w.layout.gridWidth - textRects.width / 2 - strokeWidth
+      }
+    } else if (dataLabelsConfig.textAnchor === 'start') {
+      if (dataLabelsX < 0) {
+        dataLabelsX = strokeWidth
+      } else if (dataLabelsX + textRects.width > w.layout.gridWidth) {
+        dataLabelsX = w.layout.gridWidth - textRects.width - strokeWidth
+      }
+    } else if (dataLabelsConfig.textAnchor === 'end') {
+      if (dataLabelsX < 1) {
+        dataLabelsX = textRects.width + strokeWidth
+      } else if (dataLabelsX + 1 > w.layout.gridWidth) {
+        dataLabelsX = w.layout.gridWidth - textRects.width - strokeWidth
+      }
+    }
+
     return {
       bcx,
       bcy: y,


### PR DESCRIPTION
Closes #5056

## Problem
When a vertical (column) bar chart has multiple series with data labels enabled, the data label for the leftmost bar can extend past the plot area's left edge and cover the y-axis labels. The rightmost label can similarly spill off the right edge.

## Root Cause
`calculateColumnsDataLabelsPosition` in `src/charts/common/bar/DataLabels.js` clamps the **Y** position (lines 382-388) but does **not** clamp the **X** position. The horizontal-bar counterpart `calculateBarsDataLabelsPosition` already clamps X (lines 562-590), so vertical columns were missing this protection.

## Fix
Added `textAnchor`-aware X-edge clamping to `calculateColumnsDataLabelsPosition`, mirroring the existing horizontal-bar logic:
- `middle` → keep `dataLabelsX ± width/2` inside `[0, gridWidth]`
- `start` → keep `dataLabelsX` and `dataLabelsX + width` inside the grid
- `end` → keep the label inside the grid

## Testing
- Existing unit suite passes (1976 tests).
- The 3 failing suites (`license-*`, `unit-chart`) are pre-existing Node built-in module failures unrelated to this change.
