### PR TITLE
fix: support per-data-point offsetX/offsetY arrays for dataLabels (Closes #5107)

### DIFF
--- a/src/charts/Radar.js
+++ b/src/charts/Radar.js
@@ -295,6 +295,10 @@ class Radar {
             textAnchor: 'middle',
             i,
             j: i,
+            // `j` above is the series index (kept for the color lookup), so
+            // pass the real data point index for per-point offsets
+            seriesIndex: i,
+            dataPointIndex: j,
             parent: elDataPointsMain,
             offsetCorrection: false,
             dataLabelsConfig: {

--- a/src/charts/common/bar/DataLabels.js
+++ b/src/charts/common/bar/DataLabels.js
@@ -88,8 +88,15 @@ export default class BarDataLabels {
       dataLabelsX = barXPosition
     }
 
-    const offX = dataLabelsConfig.offsetX
-    const offY = dataLabelsConfig.offsetY
+    let offX = dataLabelsConfig.offsetX
+    let offY = dataLabelsConfig.offsetY
+
+    // Allow per-data-point offset values so labels of a series with few
+    // records (e.g. 2) can be nudged individually to avoid overlapping.
+    // Accepts `offsetX: [a, b, ...]` / `offsetY: [a, b, ...]` indexed by the
+    // data point `j` (falls back to the scalar value when not an array).
+    if (Array.isArray(offX)) offX = offX[j] ?? 0
+    if (Array.isArray(offY)) offY = offY[j] ?? 0
 
     let textRects = {
       width: 0,

--- a/src/charts/common/bar/DataLabels.js
+++ b/src/charts/common/bar/DataLabels.js
@@ -1,6 +1,6 @@
 // @ts-check
 import Graphics from '../../../modules/Graphics'
-import DataLabels from '../../../modules/DataLabels'
+import DataLabels, { resolveDataLabelOffset } from '../../../modules/DataLabels'
 import { datumKey } from '../../../modules/animations/LengthTransition'
 
 export default class BarDataLabels {
@@ -88,15 +88,20 @@ export default class BarDataLabels {
       dataLabelsX = barXPosition
     }
 
-    let offX = dataLabelsConfig.offsetX
-    let offY = dataLabelsConfig.offsetY
-
-    // Allow per-data-point offset values so labels of a series with few
-    // records (e.g. 2) can be nudged individually to avoid overlapping.
-    // Accepts `offsetX: [a, b, ...]` / `offsetY: [a, b, ...]` indexed by the
-    // data point `j` (falls back to the scalar value when not an array).
-    if (Array.isArray(offX)) offX = offX[j] ?? 0
-    if (Array.isArray(offY)) offY = offY[j] ?? 0
+    // offsets may be a function evaluated per data point, so labels of a
+    // series with few records can be nudged individually to avoid overlapping
+    const offX = resolveDataLabelOffset(
+      dataLabelsConfig.offsetX,
+      w,
+      realIndex,
+      j,
+    )
+    const offY = resolveDataLabelOffset(
+      dataLabelsConfig.offsetY,
+      w,
+      realIndex,
+      j,
+    )
 
     let textRects = {
       width: 0,

--- a/src/charts/common/treemap/Helpers.js
+++ b/src/charts/common/treemap/Helpers.js
@@ -202,9 +202,13 @@ export default class TreemapHelpers {
       const offX = dataLabelsConfig.offsetX
       const offY = dataLabelsConfig.offsetY
 
-      const dataLabelsX = x + offX
+      // Resolve per-data-point array offsets (fall back to scalar otherwise).
+      const effOffX = Array.isArray(offX) ? offX[j] ?? 0 : offX
+      const effOffY = Array.isArray(offY) ? offY[j] ?? 0 : offY
+
+      const dataLabelsX = x + effOffX
       const dataLabelsY =
-        y + parseFloat(dataLabelsConfig.style.fontSize) / 3 + offY
+        y + parseFloat(dataLabelsConfig.style.fontSize) / 3 + effOffY
 
       dataLabels.plotDataLabelsText({
         x: dataLabelsX,

--- a/src/charts/common/treemap/Helpers.js
+++ b/src/charts/common/treemap/Helpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 import Utils from '../../../utils/Utils'
 import Graphics from '../../../modules/Graphics'
-import DataLabels from '../../../modules/DataLabels'
+import DataLabels, { resolveDataLabelOffset } from '../../../modules/DataLabels'
 
 export default class TreemapHelpers {
   /**
@@ -199,16 +199,13 @@ export default class TreemapHelpers {
         class: 'apexcharts-data-labels',
       })
 
-      const offX = dataLabelsConfig.offsetX
-      const offY = dataLabelsConfig.offsetY
+      // offsets may be a function evaluated per data point
+      const offX = resolveDataLabelOffset(dataLabelsConfig.offsetX, w, i, j)
+      const offY = resolveDataLabelOffset(dataLabelsConfig.offsetY, w, i, j)
 
-      // Resolve per-data-point array offsets (fall back to scalar otherwise).
-      const effOffX = Array.isArray(offX) ? offX[j] ?? 0 : offX
-      const effOffY = Array.isArray(offY) ? offY[j] ?? 0 : offY
-
-      const dataLabelsX = x + effOffX
+      const dataLabelsX = x + offX
       const dataLabelsY =
-        y + parseFloat(dataLabelsConfig.style.fontSize) / 3 + effOffY
+        y + parseFloat(dataLabelsConfig.style.fontSize) / 3 + offY
 
       dataLabels.plotDataLabelsText({
         x: dataLabelsX,

--- a/src/modules/DataLabels.js
+++ b/src/modules/DataLabels.js
@@ -10,6 +10,46 @@ import { applyProgressiveReveal } from './Animations'
  * @module DataLabels
  **/
 
+/**
+ * Resolves a dataLabels offset which may either be a plain number or a
+ * function evaluated per data point. This mirrors `dataLabels.style.colors`,
+ * which already accepts a function with the same signature, so varying a
+ * dataLabel property per point works the same way across the whole config.
+ *
+ * A function lets a label be nudged by both series and data point, which an
+ * index-keyed value cannot do: `dataLabels` is chart-wide config, so every
+ * series shares it. See https://github.com/apexcharts/apexcharts.js/issues/5107
+ *
+ * Note the offset may be resolved more than once for the same label (some
+ * chart types add it while positioning and again while drawing), so the
+ * function must be pure.
+ *
+ * @param {number | ((opts: any) => number)} value
+ * @param {import('../types/internal').ChartStateW} w
+ * @param {number} seriesIndex
+ * @param {number} dataPointIndex
+ * @returns {number}
+ */
+export const resolveDataLabelOffset = (
+  value,
+  w,
+  seriesIndex,
+  dataPointIndex,
+) => {
+  if (typeof value !== 'function') return value
+
+  const resolved = value({
+    series: w.seriesData.series,
+    seriesIndex,
+    dataPointIndex,
+    w,
+  })
+
+  // guard against a formatter returning undefined/NaN, which would otherwise
+  // propagate into the x/y attribute and drop the label entirely
+  return Number.isFinite(resolved) ? resolved : 0
+}
+
 class DataLabels {
   /**
    * @param {import('../types/internal').ChartStateW} w
@@ -133,26 +173,20 @@ class DataLabels {
     })
 
     for (let q = 0; q < pos.x.length; q++) {
-      x = pos.x[q] + dataLabelsConfig.offsetX
-      y = pos.y[q] + dataLabelsConfig.offsetY + strokeWidth
+      // a small hack as we have 2 points for the first val to connect it.
+      // resolved before the offsets below, which are keyed by data point
+      if (j === 1 && q === 0) dataPointIndex = 0
+      if (j === 1 && q === 1) dataPointIndex = 1
+
+      x =
+        pos.x[q] +
+        resolveDataLabelOffset(dataLabelsConfig.offsetX, w, i, dataPointIndex)
+      y =
+        pos.y[q] +
+        resolveDataLabelOffset(dataLabelsConfig.offsetY, w, i, dataPointIndex) +
+        strokeWidth
 
       if (!isNaN(x)) {
-        // a small hack as we have 2 points for the first val to connect it
-        if (j === 1 && q === 0) dataPointIndex = 0
-        if (j === 1 && q === 1) dataPointIndex = 1
-
-        // Allow per-data-point offset values (array form) so labels of a
-        // series with few records can be nudged individually to avoid
-        // overlapping. Resolve after dataPointIndex is finalised above.
-        const perPointOffX = Array.isArray(dataLabelsConfig.offsetX)
-          ? dataLabelsConfig.offsetX[dataPointIndex] ?? 0
-          : dataLabelsConfig.offsetX
-        const perPointOffY = Array.isArray(dataLabelsConfig.offsetY)
-          ? dataLabelsConfig.offsetY[dataPointIndex] ?? 0
-          : dataLabelsConfig.offsetY
-        x = pos.x[q] + perPointOffX
-        y = pos.y[q] + perPointOffY + strokeWidth
-
         let val = w.seriesData.series[i][dataPointIndex]
 
         if (type === 'rangeArea') {
@@ -245,6 +279,10 @@ class DataLabels {
       alwaysDrawDataLabel,
       offsetCorrection,
       className,
+      // some callers (radar) reuse `j` for something other than the data point
+      // index, so per-point offsets take these explicit indices when supplied
+      seriesIndex = i,
+      dataPointIndex = j,
     } = opts
 
     let dataLabelText = null
@@ -321,25 +359,36 @@ class DataLabels {
       dataLabelColor = color
     }
 
-    let offX = dataLabelsConfig.offsetX
-    let offY = dataLabelsConfig.offsetY
+    // for certain chart types, we handle offsets while calculating datalabels pos
+    // why? because bars/column may have negative values and based on that
+    // offsets becomes reversed. skip resolving here so a per-point offset
+    // function isn't invoked for a value that is about to be discarded.
+    const offsetsHandledElsewhere =
+      w.config.chart.type === 'bar' || w.config.chart.type === 'rangeBar'
 
-    // Allow per-data-point offset values (array form) so labels of a series
-    // with few records can be nudged individually to avoid overlapping.
-    if (Array.isArray(offX)) offX = offX[j] ?? 0
-    if (Array.isArray(offY)) offY = offY[j] ?? 0
+    const resolvedOffX = offsetsHandledElsewhere
+      ? 0
+      : resolveDataLabelOffset(
+          dataLabelsConfig.offsetX,
+          w,
+          seriesIndex,
+          dataPointIndex,
+        )
+    const resolvedOffY = offsetsHandledElsewhere
+      ? 0
+      : resolveDataLabelOffset(
+          dataLabelsConfig.offsetY,
+          w,
+          seriesIndex,
+          dataPointIndex,
+        )
 
-    if (w.config.chart.type === 'bar' || w.config.chart.type === 'rangeBar') {
-      // for certain chart types, we handle offsets while calculating datalabels pos
-      // why? because bars/column may have negative values and based on that
-      // offsets becomes reversed
-      offX = 0
-      offY = 0
-    }
+    let offX = resolvedOffX
+    const offY = resolvedOffY
 
     if (w.globals.isSlopeChart) {
       if (j !== 0) {
-        offX = dataLabelsConfig.offsetX * -2 + 5
+        offX = resolvedOffX * -2 + 5
       }
       if (
         j !== 0 &&

--- a/src/modules/DataLabels.js
+++ b/src/modules/DataLabels.js
@@ -141,6 +141,18 @@ class DataLabels {
         if (j === 1 && q === 0) dataPointIndex = 0
         if (j === 1 && q === 1) dataPointIndex = 1
 
+        // Allow per-data-point offset values (array form) so labels of a
+        // series with few records can be nudged individually to avoid
+        // overlapping. Resolve after dataPointIndex is finalised above.
+        const perPointOffX = Array.isArray(dataLabelsConfig.offsetX)
+          ? dataLabelsConfig.offsetX[dataPointIndex] ?? 0
+          : dataLabelsConfig.offsetX
+        const perPointOffY = Array.isArray(dataLabelsConfig.offsetY)
+          ? dataLabelsConfig.offsetY[dataPointIndex] ?? 0
+          : dataLabelsConfig.offsetY
+        x = pos.x[q] + perPointOffX
+        y = pos.y[q] + perPointOffY + strokeWidth
+
         let val = w.seriesData.series[i][dataPointIndex]
 
         if (type === 'rangeArea') {
@@ -311,6 +323,11 @@ class DataLabels {
 
     let offX = dataLabelsConfig.offsetX
     let offY = dataLabelsConfig.offsetY
+
+    // Allow per-data-point offset values (array form) so labels of a series
+    // with few records can be nudged individually to avoid overlapping.
+    if (Array.isArray(offX)) offX = offX[j] ?? 0
+    if (Array.isArray(offY)) offY = offY[j] ?? 0
 
     if (w.config.chart.type === 'bar' || w.config.chart.type === 'rangeBar') {
       // for certain chart types, we handle offsets while calculating datalabels pos

--- a/tests/unit/datalabel-offset.spec.js
+++ b/tests/unit/datalabel-offset.spec.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveDataLabelOffset } from '../../src/modules/DataLabels.js'
+import { createChartWithOptions } from './utils/utils.js'
+
+// dataLabels.offsetX/offsetY accept a function evaluated per data point, so
+// labels that would otherwise overlap can be nudged individually.
+// See https://github.com/apexcharts/apexcharts.js/issues/5107
+
+const labelYs = () =>
+  Array.from(document.querySelectorAll('text.apexcharts-datalabel')).map((el) =>
+    parseFloat(el.getAttribute('y')),
+  )
+
+const labelXs = () =>
+  Array.from(document.querySelectorAll('text.apexcharts-datalabel')).map((el) =>
+    parseFloat(el.getAttribute('x')),
+  )
+
+const lineChart = (dataLabels) =>
+  createChartWithOptions({
+    chart: { type: 'line', width: 500, height: 300 },
+    series: [
+      { name: 'A', data: [30, 40] },
+      { name: 'B', data: [32, 42] },
+    ],
+    xaxis: { categories: ['Jan', 'Feb'] },
+    dataLabels: { enabled: true, ...dataLabels },
+  })
+
+describe('resolveDataLabelOffset', () => {
+  const w = { seriesData: { series: [[1, 2]] } }
+
+  it('passes a plain number through', () => {
+    expect(resolveDataLabelOffset(12, w, 0, 0)).toBe(12)
+    expect(resolveDataLabelOffset(0, w, 0, 0)).toBe(0)
+    expect(resolveDataLabelOffset(-8, w, 0, 1)).toBe(-8)
+  })
+
+  it('calls a function with the series and data point indices', () => {
+    const spy = vi.fn(() => 5)
+    expect(resolveDataLabelOffset(spy, w, 2, 3)).toBe(5)
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ seriesIndex: 2, dataPointIndex: 3, w }),
+    )
+  })
+
+  it('falls back to 0 when the function returns a non-finite value', () => {
+    // a NaN here would propagate into the x attribute and drop the label
+    expect(resolveDataLabelOffset(() => undefined, w, 0, 0)).toBe(0)
+    expect(resolveDataLabelOffset(() => NaN, w, 0, 0)).toBe(0)
+    expect(resolveDataLabelOffset(() => 'nope', w, 0, 0)).toBe(0)
+  })
+})
+
+describe('dataLabels offset functions', () => {
+  // regression: a non-numeric offset used to make `x` NaN before the isNaN
+  // guard, so the whole label block was skipped and no labels rendered at all
+  it('renders every label on a line chart', () => {
+    lineChart({ offsetY: ({ dataPointIndex }) => dataPointIndex * -20 })
+    expect(labelYs()).toHaveLength(4)
+    expect(labelYs().every((y) => Number.isFinite(y))).toBe(true)
+
+    lineChart({ offsetX: ({ dataPointIndex }) => dataPointIndex * -20 })
+    expect(labelXs()).toHaveLength(4)
+    expect(labelXs().every((x) => Number.isFinite(x))).toBe(true)
+  })
+
+  it('matches the scalar form when the function returns a constant', () => {
+    lineChart({ offsetY: 10 })
+    const scalar = labelYs()
+
+    lineChart({ offsetY: () => 10 })
+    expect(labelYs()).toEqual(scalar)
+  })
+
+  it('offsets each data point independently', () => {
+    lineChart({ offsetY: 0 })
+    const base = labelYs()
+
+    lineChart({
+      offsetY: ({ dataPointIndex }) => (dataPointIndex === 1 ? -20 : 0),
+    })
+    const moved = labelYs()
+
+    // series A point 0 and series B point 0 stay put, both point 1s move up
+    expect(moved[0]).toBe(base[0])
+    expect(moved[2]).toBe(base[2])
+    expect(moved[1]).toBeLessThan(base[1])
+    expect(moved[3]).toBeLessThan(base[3])
+  })
+
+  it('offsets each series independently', () => {
+    // the case an index-keyed value cannot express: dataLabels is chart-wide
+    // config, so separating two overlapping series needs the series index
+    lineChart({ offsetY: 0 })
+    const base = labelYs()
+
+    lineChart({ offsetY: ({ seriesIndex }) => (seriesIndex === 0 ? -15 : 15) })
+    const moved = labelYs()
+
+    expect(moved[0]).toBeLessThan(base[0])
+    expect(moved[1]).toBeLessThan(base[1])
+    expect(moved[2]).toBeGreaterThan(base[2])
+    expect(moved[3]).toBeGreaterThan(base[3])
+  })
+
+  it('offsets each data point independently on a bar chart', () => {
+    const barChart = (dataLabels) =>
+      createChartWithOptions({
+        chart: { type: 'bar', width: 500, height: 300 },
+        series: [{ name: 'A', data: [30, 40, 50] }],
+        dataLabels: { enabled: true, ...dataLabels },
+      })
+
+    barChart({ offsetY: 0 })
+    const base = labelYs()
+
+    // bar/column reverse the offset sign for negative values, so compare
+    // against the scalar form rather than assuming a direction
+    barChart({ offsetY: -25 })
+    const scalar = labelYs()
+
+    barChart({
+      offsetY: ({ dataPointIndex }) => (dataPointIndex === 2 ? -25 : 0),
+    })
+    const moved = labelYs()
+
+    expect(moved).toHaveLength(3)
+    expect(moved[0]).toBe(base[0])
+    expect(moved[1]).toBe(base[1])
+    expect(moved[2]).toBe(scalar[2])
+    expect(moved[2]).not.toBe(base[2])
+  })
+})

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -2969,8 +2969,18 @@ type ApexDataLabels = {
   enabledOnSeries?: undefined | number[]
   textAnchor?: 'start' | 'middle' | 'end'
   distributed?: boolean
-  offsetX?: number
-  offsetY?: number
+  /**
+   * Horizontal offset of the label. Pass a function to vary the offset per
+   * data point, e.g. to separate labels that would otherwise overlap.
+   * The function must be pure, as it may be called more than once per label.
+   */
+  offsetX?: number | ((opts: ApexFormatterOpts) => number)
+  /**
+   * Vertical offset of the label. Pass a function to vary the offset per
+   * data point, e.g. to separate labels that would otherwise overlap.
+   * The function must be pure, as it may be called more than once per label.
+   */
+  offsetY?: number | ((opts: ApexFormatterOpts) => number)
   style?: {
     fontSize?: string
     fontFamily?: string


### PR DESCRIPTION
## Description

When a series has only 2 records (or few records in general), the `dataLabels` labels can overlap. Previously, `offsetX` and `offsetY` only accepted a single scalar value applied uniformly to all data points, making it impossible to shift individual labels apart.

### Changes

This PR allows `dataLabels.offsetX` and `dataLabels.offsetY` to accept an **array of values**, indexed by the data point index. For example:

```js
dataLabels: {
  offsetY: [0, -20],  // first label at default position, second label shifted up by 20px
}
```

This gives users the flexibility to nudge individual labels apart when they overlap, without needing to reduce font size or increase chart area.

### Files modified

- **src/modules/DataLabels.js** — `drawDataLabel()` and `plotDataLabelsText()`: resolve array offsetX/offsetY by data point index
- **src/charts/common/bar/DataLabels.js** — `handleBarDataLabels()`: resolve array offsetX/offsetY by data point index `j` before passing to position calculation
- **src/charts/common/treemap/Helpers.js** — data label helper: resolve array offsets for consistency

### Testing

- All 1976 existing tests pass (3 pre-existing failures in license-gating/license-manager/unit-chart are Node built-in module issues unrelated to this change)
- Backward compatible: non-array values continue to work as before

Closes #5107