### PR TITLE
fix: compensate tooltip position for CSS zoom on the chart container (Closes #5043)

### DIFF
--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -184,13 +184,12 @@ class Intersect {
     }
     if (ttCtx.w.config.tooltip.followCursor) {
       const seriesBound = w.dom.elWrap.getBoundingClientRect()
+      const zoom = w.dom.elWrap.currentCSSZoom || 1
       x =
-        (w.interact.clientX ?? 0) -
-        seriesBound.left -
+        ((w.interact.clientX ?? 0) - seriesBound.left) / zoom -
         (x > w.layout.gridWidth / 2 ? ttCtx.tooltipRect.ttWidth : 0)
       y =
-        (w.interact.clientY ?? 0) -
-        seriesBound.top -
+        ((w.interact.clientY ?? 0) - seriesBound.top) / zoom -
         (y > w.layout.gridHeight / 2 ? ttCtx.tooltipRect.ttHeight : 0)
     }
 
@@ -266,7 +265,8 @@ class Intersect {
         const elGrid = ttCtx.getElGrid()
         if (!elGrid) return { x, y }
         const seriesBound = elGrid.getBoundingClientRect()
-        y = ttCtx.e.clientY + w.layout.translateY - seriesBound.top
+        const zoom = w.dom.elWrap.currentCSSZoom || 1
+        y = (ttCtx.e.clientY + w.layout.translateY - seriesBound.top) / zoom
       }
 
       ttCtx.marker.enlargeCurrentPoint(j, opt.paths, x, y)
@@ -632,11 +632,13 @@ class Intersect {
 
       if (w.config.tooltip.followCursor) {
         if (w.globals.isBarHorizontal) {
-          x = clientX - seriesBound.left + 15
+          const zoom = w.dom.elWrap.currentCSSZoom || 1
+          x = (clientX - seriesBound.left + 15) / zoom
           y = handleYForBars()
         } else {
+          const zoom = w.dom.elWrap.currentCSSZoom || 1
           x = handleXForColumns(x)
-          y = e.clientY - seriesBound.top - ttCtx.tooltipRect.ttHeight / 2 - 15
+          y = (e.clientY - seriesBound.top - ttCtx.tooltipRect.ttHeight / 2 - 15) / zoom
         }
       } else {
         if (w.globals.isBarHorizontal) {

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -281,14 +281,21 @@ export default class Position {
       if (!elGrid) return null
       const seriesBound = elGrid.getBoundingClientRect()
 
-      x = ttCtx.e.clientX - seriesBound.left
+      // CSS zoom compensation: when the chart container has a CSS zoom
+      // property != 1, getBoundingClientRect returns viewport-scaled values
+      // but style.left/top are applied in the container's CSS pixel space
+      // which is further scaled by the zoom factor.  Divide by zoom so the
+      // tooltip follows the cursor at the correct position.
+      const zoom = w.dom.elWrap.currentCSSZoom || 1
+
+      x = (ttCtx.e.clientX - seriesBound.left) / zoom
       if (x > w.layout.gridWidth / 2) {
         x = x - ttW
         placement = 'left'
       } else {
         placement = 'right'
       }
-      y = ttCtx.e.clientY + w.layout.translateY - seriesBound.top
+      y = (ttCtx.e.clientY + w.layout.translateY - seriesBound.top) / zoom
       if (y > w.layout.gridHeight / 2) {
         y = y - ttH
       }
@@ -692,7 +699,10 @@ export default class Position {
 
     if (!w.globals.isBarHorizontal) {
       if (w.config.tooltip.followCursor) {
-        bcy = ttCtx.e.clientY - seriesBound.top - ttCtx.tooltipRect.ttHeight / 2
+        const zoom = w.dom.elWrap.currentCSSZoom || 1
+        bcy =
+          (ttCtx.e.clientY - seriesBound.top - ttCtx.tooltipRect.ttHeight / 2) /
+          zoom
       } else {
         if (bcy + ttCtx.tooltipRect.ttHeight + 15 > w.layout.gridHeight) {
           bcy = w.layout.gridHeight

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -1052,11 +1052,12 @@ export default class Tooltip {
           tooltipRect.ttHeight -
           10
       } else {
+        const zoom = w.dom.elWrap.currentCSSZoom || 1
         x =
-          (w.interact.clientX ?? 0) - seriesBound.left - tooltipRect.ttWidth / 2
+          ((w.interact.clientX ?? 0) - seriesBound.left) / zoom -
+          tooltipRect.ttWidth / 2
         y =
-          (w.interact.clientY ?? 0) -
-          seriesBound.top -
+          ((w.interact.clientY ?? 0) - seriesBound.top) / zoom -
           tooltipRect.ttHeight -
           10
       }

--- a/tests/unit/tooltip-positioning.spec.js
+++ b/tests/unit/tooltip-positioning.spec.js
@@ -243,6 +243,66 @@ describe('Position.computeTooltipPosition (arrow mode)', () => {
   })
 })
 
+describe('Position.computeTooltipPosition (followCursor + CSS zoom)', () => {
+  it('divides followCursor position by CSS zoom factor', () => {
+    const { ttCtx, w, elGrid } = makeCtx({
+      w: {
+        config: {
+          tooltip: { followCursor: true, arrow: false, shared: false, intersect: true },
+          xaxis: { offsetY: 0, tooltip: { offsetY: 0 } },
+          yaxis: [{ opposite: false, tooltip: { offsetX: 0 } }],
+          chart: { accessibility: { enabled: false } },
+        },
+      },
+    })
+    w.dom.elWrap.currentCSSZoom = 0.5
+    // With CSS zoom 0.5, getBoundingClientRect returns viewport-scaled
+    // values: elWrap at (0,0), translateX=50/translateY=20 local px →
+    // seriesBound.left=25, top=10 in viewport px.
+    elGrid.getBoundingClientRect = () => ({
+      left: 25,
+      top: 10,
+      right: 275,
+      bottom: 160,
+      width: 250,
+      height: 150,
+    })
+    // clientX=250, clientY=120 (viewport px)
+    // x = (250 - 25)/0.5 = 450, then > gridWidth/2(250) → x - ttW(100) = 350,
+    // then + translateX(50) = 400
+    // y = (120 + 20 - 10)/0.5 = 260, then > gridHeight/2(150) → y - ttH(50) = 210
+    ttCtx.e = { clientX: 250, clientY: 120 }
+    const pos = new TooltipPosition(ttCtx)
+
+    const r = pos.computeTooltipPosition(50, 100, 5)
+    expect(r.x).toBe(400)
+    expect(r.y).toBe(210)
+  })
+
+  it('uses default zoom=1 when currentCSSZoom is undefined', () => {
+    const { ttCtx, w } = makeCtx({
+      w: {
+        config: {
+          tooltip: { followCursor: true, arrow: false, shared: false, intersect: true },
+          xaxis: { offsetY: 0, tooltip: { offsetY: 0 } },
+          yaxis: [{ opposite: false, tooltip: { offsetX: 0 } }],
+          chart: { accessibility: { enabled: false } },
+        },
+      },
+    })
+    delete w.dom.elWrap.currentCSSZoom
+    // zoom=1 → seriesBound.left=50, top=20 (makeCtx default)
+    // x = (250 - 50)/1 + translateX(50) = 250
+    // y = (120 + 20 - 20)/1 = 120
+    ttCtx.e = { clientX: 250, clientY: 120 }
+    const pos = new TooltipPosition(ttCtx)
+
+    const r = pos.computeTooltipPosition(50, 100, 5)
+    expect(r.x).toBe(250)
+    expect(r.y).toBe(120)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Position._datapointCenterXFromBars — rect-derived center for numeric x
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

When the chart container has a CSS `zoom` property set to a value other than 1 (e.g. `zoom: 0.5`), the tooltip position is skewed — to the left when zoom < 100%, to the right when zoom > 100%. This happens because `getBoundingClientRect()` returns viewport-scaled values, but `style.left`/`style.top` on the tooltip (inside the zoomed container) are in CSS pixels which are further scaled by the zoom factor.

## Fix

Divide the tooltip position by the CSS zoom factor (`element.currentCSSZoom`) wherever the position is computed from viewport coordinates (`clientX`/`clientY` - `getBoundingClientRect()`). The zoom factor is obtained from the chart's `elWrap` element via the standard `currentCSSZoom` property.

## Changes

- **Position.js**: `computeTooltipPosition()` followCursor path and `moveStickyTooltipOverBars()`
- **Intersect.js**: `handleHeatTreeTooltip()`, `handleMarkerTooltip()`, and `handleBarTooltip()` followCursor paths
- **Tooltip.js**: `nonAxisChartsTooltips()` followCursor path
- **tests/unit/tooltip-positioning.spec.js**: 2 new tests for the CSS zoom compensation behavior

## Testing

All 1978 existing tests pass. New tests verify:
1. FollowCursor position is correctly divided by the zoom factor when `currentCSSZoom` is set
2. Fallback to zoom=1 when `currentCSSZoom` is undefined (backward compatibility)

Closes #5043