### PR TITLE
fix(sparkline): reserve stroke overhang only where the ink needs it (fixes #5137)

### DIFF
--- a/src/modules/Base.js
+++ b/src/modules/Base.js
@@ -162,6 +162,7 @@ export default class Base {
         xAxisLabelsWidth: 0,
         yLabelsCoords: [],
         yTitleCoords: [],
+        gridPad: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     }
 
@@ -262,6 +263,7 @@ export default class Base {
       'xAxisLabelsWidth',
       'yLabelsCoords',
       'yTitleCoords',
+      'gridPad',
     ]) {
       Object.defineProperty(globals, key, {
         get() {

--- a/src/modules/Core.js
+++ b/src/modules/Core.js
@@ -811,7 +811,10 @@ export default class Core {
 
     let legendHeight = 0
     let offY = w.config.chart.sparkline.enabled ? 1 : 15
-    offY += w.config.grid.padding.bottom
+    // Mirrors the plot's top inset (w.layout.translateY, added below) on the
+    // bottom, so the padding the layout was actually built from is reserved at
+    // both ends. Must be the resolved pad, not config.grid.padding.
+    offY += w.layout.gridPad.bottom
 
     if (
       ['top', 'bottom'].includes(w.config.legend.position) &&

--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -111,14 +111,8 @@ class Grid {
     let barWidthLeft = 0
     let barWidthRight = 0
     if (hasBar && w.axisFlags.isXNumeric && !w.globals.isBarHorizontal) {
-      barWidthLeft = Math.max(
-        w.config.grid.padding.left,
-        gl.barPadForNumericAxis,
-      )
-      barWidthRight = Math.max(
-        w.config.grid.padding.right,
-        gl.barPadForNumericAxis,
-      )
+      barWidthLeft = Math.max(w.layout.gridPad.left, gl.barPadForNumericAxis)
+      barWidthRight = Math.max(w.layout.gridPad.right, gl.barPadForNumericAxis)
     }
 
     w.dom.elGridRect = graphics.drawRect(

--- a/src/modules/dimensions/Dimensions.js
+++ b/src/modules/dimensions/Dimensions.js
@@ -34,7 +34,11 @@ export default class Dimensions {
     this.dimXAxis = new DimXAxis(this)
     this.dimGrid = new Grid(this)
     this.lgWidthForSideLegends = 0
-    this.gridPad = this.w.config.grid.padding
+    // A COPY, never the config object itself: the chart type folds its own
+    // insets into this (sparkline markers/stroke) and layout code reads them
+    // back, which must not leak into the user's config and accumulate across
+    // renders. Consumers outside Dimensions read w.layout.gridPad.
+    this.gridPad = { ...this.w.config.grid.padding }
     this.xPadRight = 0
     this.xPadLeft = 0
     this.datalabelsCoords = { width: 0, height: 0 }
@@ -54,12 +58,10 @@ export default class Dimensions {
     this.lgRect = this.dimHelpers.getLegendsRect()
     this.datalabelsCoords = { width: 0, height: 0 }
 
-    const maxStrokeWidth = Array.isArray(w.config.stroke.width)
-      ? Math.max(...w.config.stroke.width)
-      : w.config.stroke.width
-
     if (this.isSparkline) {
-      if (w.config.markers.discrete.length > 0 || w.config.markers.size > 0) {
+      // largestSize covers both markers.size (incl. the array form) and
+      // markers.discrete, so it is the one gate for "markers can overhang".
+      if (this.w.globals.markers.largestSize > 0) {
         Object.entries(this.gridPad).forEach(([k, v]) => {
           this.gridPad[k] = Math.max(
             v,
@@ -68,8 +70,9 @@ export default class Dimensions {
         })
       }
 
-      this.gridPad.top = Math.max(maxStrokeWidth / 2, this.gridPad.top)
-      this.gridPad.bottom = Math.max(maxStrokeWidth / 2, this.gridPad.bottom)
+      const strokeInset = this.dimHelpers.getSparklineStrokeInset()
+      this.gridPad.top = Math.max(strokeInset.top, this.gridPad.top)
+      this.gridPad.bottom = Math.max(strokeInset.bottom, this.gridPad.bottom)
     }
 
     if (gl.axisCharts) {
@@ -125,6 +128,7 @@ export default class Dimensions {
         xAxisLabelsWidth: w.layout.xAxisLabelsWidth,
         yLabelsCoords: w.layout.yLabelsCoords,
         yTitleCoords: w.layout.yTitleCoords,
+        gridPad: { ...this.gridPad },
       },
     }
   }

--- a/src/modules/dimensions/Helpers.js
+++ b/src/modules/dimensions/Helpers.js
@@ -174,4 +174,89 @@ export default class Helpers {
 
     return valArr
   }
+
+  /**
+   * Vertical space a sparkline has to keep free inside its SVG so the series
+   * stroke isn't clipped at the top / bottom edge.
+   *
+   * A stroke is centred on its path, so half of it hangs outside the plot
+   * wherever the path runs along an edge. Reserving that half unconditionally
+   * lifts the whole plot away from the SVG edges even when nothing is drawn
+   * there, which shows up as a strip of empty space under an area fill or a
+   * bar base (#5137). So reserve only what the ink can't absorb itself: where
+   * the stroke traces the data points, the distance between the extreme datum
+   * and the axis extreme already swallows part or all of the overhang. Fills
+   * need nothing: area fills are drawn unstroked (see Line.js renderPaths).
+   *
+   * @returns {{ top: number, bottom: number }}
+   **/
+  getSparklineStrokeInset() {
+    const w = this.w
+    const maxStrokeWidth = Array.isArray(w.config.stroke.width)
+      ? Math.max(...w.config.stroke.width)
+      : w.config.stroke.width
+    const half = maxStrokeWidth / 2
+
+    if (!w.config.stroke.show || !(half > 0)) {
+      return { top: 0, bottom: 0 }
+    }
+
+    const yRange = w.globals.maxY - w.globals.minY
+    const extremes = this._getSeriesYExtremes()
+    if (!this._strokeTracesDataPoints() || !(yRange > 0) || !extremes) {
+      // Can't reason about where the stroke runs (bars sit on the baseline,
+      // heatmap cells fill the plot, stacks aren't the raw values), so reserve
+      // the full overhang, which is what every sparkline used to get.
+      return { top: half, bottom: half }
+    }
+
+    // Room is measured against the smallest plot the insets could leave, so it
+    // is never optimistic: erring towards over-reserving keeps the stroke whole.
+    const plotHeight = Math.max(w.globals.svgHeight - maxStrokeWidth, 0)
+    const roomAbove = (plotHeight * (w.globals.maxY - extremes.max)) / yRange
+    const roomBelow = (plotHeight * (extremes.min - w.globals.minY)) / yRange
+
+    return {
+      top: Math.min(Math.max(half - roomAbove, 0), half),
+      bottom: Math.min(Math.max(half - roomBelow, 0), half),
+    }
+  }
+
+  /**
+   * Whether every drawn series is one whose stroke follows the data points, so
+   * the extreme datum marks the outermost ink. False for anything that strokes
+   * to the baseline or fills the plot (bar, heatmap, ...) and for stacked
+   * charts, where the ink is the cumulative total rather than the raw values.
+   * @returns {boolean}
+   **/
+  _strokeTracesDataPoints() {
+    const w = this.w
+    if (!w.globals.axisCharts || w.config.chart.stacked) return false
+
+    const tracesPoints = ['line', 'area', 'scatter']
+    return /** @type {any[]} */ (w.config.series).every(
+      (/** @type {any} */ s) =>
+        tracesPoints.includes(s.type || w.config.chart.type),
+    )
+  }
+
+  /**
+   * Min / max across every plotted y value, or null when nothing is plottable.
+   * @returns {{ min: number, max: number } | null}
+   **/
+  _getSeriesYExtremes() {
+    let min = Infinity
+    let max = -Infinity
+
+    this.w.seriesData.series.forEach((/** @type {any[]} */ data) => {
+      if (!Array.isArray(data)) return
+      data.forEach((/** @type {any} */ val) => {
+        if (!Number.isFinite(val)) return
+        if (val < min) min = val
+        if (val > max) max = val
+      })
+    })
+
+    return min === Infinity ? null : { min, max }
+  }
 }

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -226,6 +226,13 @@ export interface LayoutCoords {
   xAxisLabelsWidth: number
   yLabelsCoords: Array<{ width: number; index: number }>
   yTitleCoords: Array<{ width: number; height: number }>
+  /**
+   * Grid padding actually applied this render: `grid.padding` after Dimensions
+   * has folded in whatever the chart type needs on top of it (sparkline marker
+   * and stroke insets). Read this, never `config.grid.padding`, when you need
+   * the padding the layout was built from.
+   */
+  gridPad: { top: number; right: number; bottom: number; left: number }
 }
 
 /** Return type of CoreUtils.getCalculatedRatios() */

--- a/tests/unit/dimensions.spec.js
+++ b/tests/unit/dimensions.spec.js
@@ -1233,6 +1233,158 @@ describe('Dimensions integration (rendered charts)', () => {
     )
   })
 
+  // -------------------------------------------------------------------------
+  // Sparkline stroke inset: issues #5137 (no dead space) and #4216 (no clip)
+  // -------------------------------------------------------------------------
+
+  it('sparkline reserves no vertical inset when no datum reaches an axis extreme', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'area',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { width: 4 },
+      series: [{ data: [25, 66, 41, 89, 63, 9, 54] }],
+    })
+
+    const gl = chart.w.globals
+    // The area fill runs to the baseline, so any bottom inset shows up as a
+    // strip of empty space under it (#5137). Nothing is drawn at the axis
+    // extremes here, so the plot must fill the SVG.
+    expect(chart.w.layout.gridPad.bottom).toBe(0)
+    expect(chart.w.layout.gridPad.top).toBe(0)
+    expect(gl.translateY).toBe(0)
+    expect(gl.gridHeight).toBe(gl.svgHeight)
+  })
+
+  it('sparkline still reserves half the stroke where a datum sits on an axis extreme', () => {
+    const strokeWidth = 8
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { width: strokeWidth },
+      yaxis: { min: 0, max: 100 },
+      series: [{ data: [0, 50, 100, 50, 0] }],
+    })
+
+    const gl = chart.w.globals
+    // Data touches both ends of the axis, so half the stroke would hang
+    // outside the SVG and be clipped without an inset.
+    expect(gl.translateY).toBe(strokeWidth / 2)
+    expect(chart.w.layout.gridPad.bottom).toBe(strokeWidth / 2)
+    expect(gl.gridHeight).toBe(gl.svgHeight - strokeWidth)
+  })
+
+  it('sparkline riding the x-axis reserves the stroke at the bottom only', () => {
+    const strokeWidth = 6
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { width: strokeWidth },
+      series: [{ data: [0, 0, 0, 0, 12, 0, 0, 3, 0, 0, 0] }],
+    })
+
+    const gl = chart.w.globals
+    // A mostly-zero series hugs the axis min for most of its length, so the
+    // bottom overhang has no room to fall into and must be reserved in full.
+    // The peak is nowhere near the top, so that end stays free.
+    expect(chart.w.layout.gridPad.bottom).toBe(strokeWidth / 2)
+    expect(chart.w.layout.gridPad.top).toBe(0)
+    expect(gl.translateY).toBe(0)
+    expect(gl.gridHeight).toBe(gl.svgHeight - strokeWidth / 2)
+  })
+
+  it('sparkline inset follows the thickest stroke when stroke.width is an array', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { width: [2, 10] },
+      yaxis: { min: 0, max: 100 },
+      series: [{ data: [10, 50, 90] }, { data: [0, 50, 100] }],
+    })
+
+    // Guards the array-width support from #4216. The thick series is the one
+    // drawn at the extremes.
+    expect(chart.w.layout.gridPad.top).toBe(5)
+    expect(chart.w.layout.gridPad.bottom).toBe(5)
+  })
+
+  it('sparkline reserves nothing when the stroke is hidden', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'area',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { show: false, width: 6 },
+      yaxis: { min: 0, max: 100 },
+      series: [{ data: [0, 50, 100] }],
+    })
+
+    // Area fills are drawn unstroked, so with the line hidden there is no
+    // overhang to protect even at the extremes.
+    expect(chart.w.layout.gridPad.top).toBe(0)
+    expect(chart.w.layout.gridPad.bottom).toBe(0)
+  })
+
+  it('sparkline pads for markers sized with an array', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      markers: { size: [0, 8] },
+      series: [{ data: [10, 50, 90] }, { data: [20, 60, 40] }],
+    })
+
+    // markers.size accepts an array; the padding gate must not stringify it
+    // (`[0,8] > 0` is false), or edge markers get clipped.
+    expect(chart.w.layout.gridPad.bottom).toBeGreaterThan(0)
+    expect(chart.w.layout.gridPad.left).toBeGreaterThan(0)
+  })
+
+  it('does not write layout insets back into config.grid.padding', () => {
+    const chart = createChartWithOptions({
+      chart: {
+        type: 'line',
+        width: 300,
+        height: 100,
+        sparkline: { enabled: true },
+      },
+      stroke: { width: 8 },
+      yaxis: { min: 0, max: 100 },
+      series: [{ data: [0, 50, 100] }],
+    })
+
+    // The resolved inset belongs to the layout, not to the user's config:
+    // leaking it there let it accumulate across renders and be read back by
+    // Core.resizeNonAxisCharts as if the user had asked for it.
+    expect(chart.w.config.grid.padding).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    })
+    expect(chart.w.layout.gridPad.top).toBe(4)
+  })
+
   it('grid dimensions remain positive when Y axis has a title', () => {
     const chart = createChartWithOptions({
       chart: { type: 'line', width: 600, height: 400 },


### PR DESCRIPTION
Fixes #5137. Supersedes #5254, which removed the stroke padding outright (that reclaimed no space and clipped the stroke instead).

## Root cause

The gap in #5137 is on an **area** sparkline, and it is the stroke inset pushing the fill *baseline* up, not slack anywhere in the DOM. Measured in Chromium: the bordered container, `.apexcharts-canvas` and the `<svg>` are all exactly 100px, and the fill's bottom edge sits 2px above the SVG bottom, which is `stroke.width / 2` for the default 4px area stroke.

Sparklines reserved `stroke.width / 2` of grid padding at the top and bottom unconditionally. That reservation is real for a stroke, which is centred on its path and so hangs half outside the plot wherever the path runs along an edge (this is what #4216 fixed). But it was applied whether or not anything was actually drawn at the edge, and area fills are drawn **unstroked** (`stroke: 'none', strokeWidth: 0`, `src/charts/Line.js`), so the fill lost 2px at the bottom to protect a stroke that was nowhere near it.

## Fix

Reserve only what the ink cannot absorb itself (`Helpers.getSparklineStrokeInset()`):

- where the stroke traces the data points (line / area / scatter, unstacked), the distance from the extreme datum to the axis extreme already swallows part or all of the overhang, so only the remainder is reserved
- fills need nothing
- `stroke.show: false` reserves nothing
- anything that strokes to the baseline or fills the plot (bar, heatmap, candlestick, stacked) keeps the full reservation, as does every non-axis (pie / radialBar) sparkline

Room is measured against the smallest plot the insets could leave, so the estimate errs towards over-reserving and can never clip.

## Two defects found while measuring this

**`Dimensions.gridPad` aliased `config.grid.padding`.** Layout insets were written into the user's config, accumulated across renders, and were read back by `Core.resizeNonAxisCharts` (`offY += w.config.grid.padding.bottom`) as if the user had asked for them. `gridPad` is now a copy, and the resolved padding is published as `w.layout.gridPad` for Core and Grid to read. This is also what keeps pie/radial auto-heights byte-identical here.

**The sparkline marker padding gate tested `markers.size > 0`.** That is false for a multi-element array, since `[0,6] > 0` coerces to `NaN > 0`, so array-sized markers got no padding and were clipped by 6.5px on `main`. It now gates on `globals.markers.largestSize`, which folds in both `markers.size` and `markers.discrete`.

## Measured (Chromium, before = `dist` at `main`, after = same page against a rebuilt `dist`)

| case | before | after |
| --- | --- | --- |
| area sparkline bottom gap (#5137) | 2px | **0px, fill flush** |
| line sparkline, no datum at extreme | gridHeight 95, translateY 2.5 | gridHeight 100, translateY 0 |
| datum on axis min+max, stroke 8 | translateY 4, gridHeight 92 | identical |
| `stroke.width: [2,10]` (#4216) | pad 5/5, zero clip | identical |
| heatmap / bar / stacked / user padding | | identical |
| `markers.size: [0,8]` | **6.5px clipped** | 0.33px slack |
| pie / radialBar auto height | wrap 247/251 | identical |
| mostly-zero line, widths 2 / 5 / 12 | flush | flush, full half-stroke still reserved |

A stroke-inclusive clipping check (geometry bbox grown by half the painted stroke) reports no clipping at any edge across all cases, before or after.

## Tests

7 new cases in `tests/unit/dimensions.spec.js`, each verified to fail on `main` and pass here. The suite previously could not detect any of this: the only sparkline layout assertion was an inequality on `gridWidth`, and the sparkline e2e cannot fail because its pixel-diff assertion is commented out (`tests/e2e/spec/utils.js:56`).

- 2176 unit tests pass
- 211 interaction tests pass against a rebuilt `dist`
- `npm run build` succeeds across UMD / ESM / CJS / SSR and the split entries
- typecheck unchanged (same 30 pre-existing errors as `main`), eslint clean, prettier baseline unchanged

## Note for release notes

A sparkline whose data does not reach an axis extreme now draws into the full SVG height instead of being inset by half a stroke at each end, so those charts render very slightly taller. `dist/` is intentionally not rebuilt in this branch.
