### PR TITLE
fix(annotations): measure the label background from the grid origin (closes #5270)

### DIFF
--- a/src/modules/annotations/Helpers.js
+++ b/src/modules/annotations/Helpers.js
@@ -79,10 +79,22 @@ export default class Helpers {
       ;[ptop, pbottom, pleft, pright] = [pleft, pright, ptop, pbottom]
     }
 
-    const x1 = (coords.left - elGridRect.left) / zoom - pleft
-    const y1 = (coords.top - elGridRect.top) / zoom - ptop
+    // The rect is drawn in the annotation group's LOCAL coordinates, so these
+    // client-space deltas have to be measured from the grid's local (0, 0) --
+    // not from the left/top edge of whatever the grid group happens to render.
+    // Those are the same point only while the grid draws nothing outside its
+    // own box, and it draws outside on both axis types this file serves: a
+    // datetime axis whose first timescale tick is floored to the calendar
+    // boundary before minX (DateTime.js ceilToBoundary), and a numeric bar
+    // chart, whose gridlines run out to -barPadForNumericAxis so edge bars are
+    // not clipped. bbox.x/y are in local units, hence the zoom multiply.
+    const gridLeft = elGridRect.left - gridBBox.x * zoom
+    const gridTop = elGridRect.top - gridBBox.y * zoom
+
+    const x1 = (coords.left - gridLeft) / zoom - pleft
+    const y1 = (coords.top - gridTop) / zoom - ptop
     const elRect = this.annoCtx.graphics.drawRect(
-      x1 - w.globals.barPadForNumericAxis,
+      x1,
       y1,
       coords.width / zoom + pleft + pright,
       coords.height / zoom + ptop + pbottom,

--- a/tests/unit/annotation-helpers.spec.js
+++ b/tests/unit/annotation-helpers.spec.js
@@ -160,6 +160,68 @@ describe('Annotation Helpers', () => {
       const result = helpers.addBackgroundToAnno(annoEl, anno)
       expect(result).toBeDefined()
     })
+
+    it('measures from the grid origin, not the grid element edge', () => {
+      // The rect is drawn in the annotation group's local coordinates, so the
+      // offset to it has to be measured from the grid's local (0, 0). That is
+      // NOT the grid element's rendered left edge whenever the grid draws
+      // outside its own box -- a datetime axis whose first timescale tick is
+      // floored to before minX, or a numeric bar chart whose gridlines run out
+      // to -barPadForNumericAxis.
+      //
+      // getBBox is stubbed to x: 0 in tests/unit/setup.js, which is precisely
+      // the value at which measuring from either point gives the same answer,
+      // so it has to be overridden here or this test cannot fail.
+      chart = createChartWithOptions({
+        chart: { type: 'line' },
+        series: [{ data: [10, 20, 30, 40, 50] }],
+        annotations: {
+          yaxis: [{ y: 30, label: { text: 'Label', position: 'left' } }],
+        },
+      })
+      const annoCtx2 = new Annotations(chart.w)
+      const helpers2 = new Helpers(annoCtx2)
+
+      const baseEl = chart.w.dom.baseEl
+      const gridEl = baseEl.querySelector('.apexcharts-grid')
+      const annoEl = baseEl.querySelector('.apexcharts-yaxis-annotation-label')
+
+      // The grid renders 20px left and 5px above its own origin, so that origin
+      // sits at client (100, 15) while the element's edge is at (80, 10).
+      vi.spyOn(gridEl, 'getBBox').mockReturnValue({
+        x: -20,
+        y: -5,
+        width: 720,
+        height: 400,
+      })
+      vi.spyOn(gridEl, 'getBoundingClientRect').mockReturnValue({
+        left: 80,
+        top: 10,
+        width: 720, // width / bbox width => a zoom of 1
+        height: 400,
+      })
+      vi.spyOn(annoEl, 'getBoundingClientRect').mockReturnValue({
+        left: 150,
+        top: 30,
+        width: 40,
+        height: 12,
+      })
+
+      const anno = {
+        label: {
+          text: 'Label',
+          style: { padding: { left: 4, right: 4, top: 2, bottom: 2 } },
+        },
+      }
+
+      const elRect = helpers2.addBackgroundToAnno(annoEl, anno)
+
+      // (150 - 100) - 4 = 46, and (30 - 15) - 2 = 13. Measuring from the
+      // element edge instead gives 66 and 18: the background drawn a full
+      // overhang right of, and below, the text it belongs behind.
+      expect(Number(elRect.node.getAttribute('x'))).toBeCloseTo(46, 5)
+      expect(Number(elRect.node.getAttribute('y'))).toBeCloseTo(13, 5)
+    })
   })
 
   describe('getY1Y2', () => {


### PR DESCRIPTION
`addBackgroundToAnno()` draws an annotation's label background in the annotation group's LOCAL coordinates, but measured the offset to it from the grid group's RENDERED left edge. Those are the same point only while `.apexcharts-grid` draws nothing outside its own box, and it draws outside on both axis types this function serves, so the background lands to the right of its own text by whatever the grid overhangs.

On a datetime axis, `DateTime.js` `ceilToBoundary()` floors a step-1 interval to the calendar boundary at or before the first data point, so `TimeScale` gives that tick a negative position and `Grid.js` `datetimeLines()` draws the gridline there verbatim. A 13-year monthly series starting 21 May 2013 puts a year line 20.5px left of the plot on an 800px chart, and every annotation background is drawn 20.5px right of the text it belongs behind. Since label text is commonly light on a coloured background, the characters that fall outside paint onto the page and the whole thing reads as a background clipped on its left edge.

`AxisMapping`'s header and `ZoomPanSelection._screenXToPlotPx` already name this hazard: measuring from the `.apexcharts-grid` box and subtracting `barPadForNumericAxis` is "a fragile pair that only cancels while the grid box happens to extend exactly barPad". The datetime overhang is the predicted failure: the grid box stops extending exactly `barPad`, so the pair stops cancelling.

Two other sites still pair the same two corrections and are **left for a follow-up** (tracked separately, out of scope here):

- `tooltip/Utils.js` `getNearestValues()`, where the grid element rect supplies both the origin *and* the `hoverWidth` divisor, so the same overhang skews the hover hit-test near the plot edges;
- `tooltip/Position.js` `_datapointCenterXFromBars()`.

Derive the origin from the grid's own bbox, which is already in scope for the zoom factor, and drop the `barPad` term rather than moving it: `bbox.x` is the measured overhang where `barPad` is an assumed one, so keeping both would double-count and shift the box a bar-width left on a numeric bar chart that renders correctly today. Where `bbox.x` is 0 the arithmetic is unchanged, so no chart that renders correctly can move.

The new form is also the correct one in two cases the old pair got wrong in the *other* direction, both of which it now fixes:

- a numeric bar chart with `grid.yaxis.lines.show: false` draws no widened horizontal gridline, so `bbox.x` is 0 while `barPad` is not;
- a category axis with `padHorizontal > 0` and yaxis lines off has a positive `bbox.x`.

Both were previously drawn left of their text.

Adds a unit test that overrides the `getBBox` stub in `tests/unit/setup.js`, which returns `x: 0` -- precisely the value at which measuring from either point gives the same answer, and the reason the existing coverage could not have caught this. The e2e spec `line-with-annotations-zoom-level` already asserts the exact invariant (`rect.x <= label.x + maxPadding`); it passes today because its sample leaves `grid.xaxis.lines.show` at the default `false`, so nothing renders at the floored tick and the grid bbox stays at 0.

Fixes #5270

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
