### PR TITLE
fix(grid): skip datetime gridlines that fall outside the plot (fixes #5273)

### DIFF
--- a/src/modules/axes/Grid.js
+++ b/src/modules/axes/Grid.js
@@ -263,6 +263,8 @@ class Grid {
         x1 = /** @type {any} */ (this.xaxisLabels[i]).position
         x2 = /** @type {any} */ (this.xaxisLabels[i]).position
 
+        if (x1 < 0 || x1 - 2 > w.layout.gridWidth) continue
+
         this._drawGridLines({
           i,
           x1,

--- a/tests/unit/issue-5273-datetime-gridline-overhang.spec.js
+++ b/tests/unit/issue-5273-datetime-gridline-overhang.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { createChartWithOptions } from './utils/utils.js'
+
+/**
+ * #5273: on a step-1 datetime interval, `DateTime.ceilToBoundary()` returns the
+ * calendar boundary at or *before* the first data point, so `TimeScale` gives
+ * that tick a negative position. The label and the axis tick are both dropped
+ * for being outside the plot, but `Grid.datetimeLines()` drew the gridline
+ * verbatim, and gridlines get no clip-path, so the line landed in the y-axis
+ * label gutter.
+ *
+ * 159 monthly points from 21 May 2013 span 13.2 years, which picks year x 1.
+ */
+
+const DATA = Array.from({ length: 159 }, (_, i) => [
+  new Date(2013, 4 + i, 21).getTime(),
+  100 + (i % 17),
+])
+
+function render() {
+  return createChartWithOptions({
+    chart: { type: 'line', width: 800, height: 400 },
+    series: [{ name: 'Series', data: DATA }],
+    xaxis: { type: 'datetime' },
+    yaxis: { labels: { minWidth: 60 } },
+    grid: { xaxis: { lines: { show: true } } },
+  })
+}
+
+function verticalGridlineXs() {
+  return Array.from(
+    document.querySelectorAll('.apexcharts-gridlines-vertical line'),
+  ).map((line) => parseFloat(line.getAttribute('x1')))
+}
+
+describe('Issue 5273: datetime gridline drawn outside the plot', () => {
+  it('draws no gridline left of the plot area', () => {
+    const chart = render()
+
+    // control: the timescale really does put a tick before the plot origin
+    expect(chart.w.labelData.timescaleLabels[0].position).toBeLessThan(0)
+
+    expect(verticalGridlineXs().filter((x) => x < 0)).toEqual([])
+  })
+
+  it('still draws a gridline for every tick inside the plot', () => {
+    const chart = render()
+
+    const inside = chart.w.labelData.timescaleLabels.filter(
+      (label) => label.position >= 0,
+    )
+
+    expect(verticalGridlineXs()).toEqual(inside.map((label) => label.position))
+  })
+})


### PR DESCRIPTION
On a step-1 datetime interval, `DateTime.ceilToBoundary()` returns the calendar boundary at or *before* the first data point, so `TimeScale.generateBaseTicks()` emits a tick with a negative position. The x-axis label for that tick is dropped (`label.x + halfWidth < 0`) and `drawXaxisTicks()` returns early on it, but `Grid.datetimeLines()` passed the position straight to `_drawGridLine()`. Gridlines carry no clip-path, only grid bands get `gridRectMask`, so the line rendered in the y-axis label gutter, left of the plot.

The loop now applies the same bounds check `drawXaxisTicks()` already uses, so a tick outside the plot no longer contributes a line. Ticks inside the plot are untouched, and a chart whose first tick already lands at or after `minX` renders exactly as before, which the e2e sweep confirms.

Fixes #5273

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch