### PR TITLE
fix(tooltip): measure the hover hit-test and bar centers from the plot origin (closes #5272)

### DIFF
--- a/src/modules/AxisMapping.js
+++ b/src/modules/AxisMapping.js
@@ -27,7 +27,8 @@
  * space the series `<g transform="translate(translateX, translateY)">` and the
  * selection rect's transform live in), so a value produced by
  * {@link AxisMapping.dataXToPx} can be used directly as an SVG `x` attribute and
- * a value fed to {@link AxisMapping.pxToDataX} is `screenX - svgLeft - translateX`.
+ * a value fed to {@link AxisMapping.pxToDataX} is what
+ * {@link AxisMapping.screenXToPlotPx} returns.
  *
  * @module modules/AxisMapping
  */
@@ -61,5 +62,24 @@ export default class AxisMapping {
    */
   static pxToDataX(w, px) {
     return w.globals.minX + px * AxisMapping.xRatio(w)
+  }
+
+  /**
+   * Client (screen) x -> pixels from the plot origin. The origin is the svg
+   * element's left edge plus `translateX`, never the `.apexcharts-grid` box
+   * (fact 2 above), so the result does not depend on what the grid happens to
+   * render. `svgWidth` is the unscaled width the svg was drawn at, so the ratio
+   * against the measured one is the CSS zoom of any container the chart sits in.
+   * @param {import('../types/internal').ChartStateW} w
+   * @param {number} screenX
+   * @returns {number}
+   */
+  static screenXToPlotPx(w, screenX) {
+    const baseEl = w.dom.baseEl
+    const svg = baseEl && baseEl.querySelector('.apexcharts-svg')
+    if (!svg) return screenX - w.layout.translateX
+    const svgRect = svg.getBoundingClientRect()
+    const zoom = w.globals.svgWidth ? svgRect.width / w.globals.svgWidth : 1
+    return (screenX - svgRect.left) / (zoom || 1) - w.layout.translateX
   }
 }

--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -1268,10 +1268,7 @@ export default class ZoomPanSelection extends Toolbar {
    * @returns {number}
    */
   _screenXToPlotPx(screenX) {
-    const baseEl = this.w.dom.baseEl
-    const svg = baseEl && baseEl.querySelector('.apexcharts-svg')
-    const svgLeft = svg ? svg.getBoundingClientRect().left : 0
-    return screenX - svgLeft - this.w.layout.translateX
+    return AxisMapping.screenXToPlotPx(this.w, screenX)
   }
 
   /**

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -1,4 +1,5 @@
 // @ts-check
+import AxisMapping from '../AxisMapping'
 import Graphics from '../Graphics'
 import Series from '../Series'
 import { ARROW_TIP_OVERHANG } from './constants'
@@ -661,7 +662,7 @@ export default class Position {
       // for odd-count series. Use the bar's rendered DOM rect instead so
       // the data-point center is correct regardless of stack/group layout.
       if (jBar && !isBoxOrCandle) {
-        const center = this._datapointCenterXFromBars(j, seriesBound)
+        const center = this._datapointCenterXFromBars(j)
         if (center != null) {
           bcx = center
         } else {
@@ -730,10 +731,9 @@ export default class Position {
    * attribute math in `moveStickyTooltipOverBars`. Returns null when no
    * usable bars are found.
    * @param {number} j
-   * @param {DOMRect} gridRect
    * @returns {number | null}
    */
-  _datapointCenterXFromBars(j, gridRect) {
+  _datapointCenterXFromBars(j) {
     const w = this.w
     const bars = w.dom.baseEl.querySelectorAll(
       `.apexcharts-bar-series path[j='${j}'],` +
@@ -752,18 +752,10 @@ export default class Position {
       if (r.right > unionRight) unionRight = r.right
     }
     if (!isFinite(unionLeft)) return null
-    // Convert to data-area-local x. `gridRect` is the `.apexcharts-grid`
-    // element rect, whose `.left` extends `barPadForNumericAxis` pixels LEFT
-    // of the data area on numeric/datetime axes (the apexcharts-gridlines-
-    // horizontal group is widened by that pad on each side so corner bars
-    // don't clip). The hover-test path subtracts the same offset in
-    // tooltip/Utils.getNearestValues; do it here too so the crosshair lands
-    // on the bar center instead of one xDivision to the right.
-    return (
-      (unionLeft + unionRight) / 2 -
-      gridRect.left -
-      (w.globals.barPadForNumericAxis || 0)
-    )
+    // Convert to data-area-local x from the plot origin, the space `cx` and the
+    // crosshair are already in. Measuring from the `.apexcharts-grid` element
+    // rect instead only works while the grid draws nothing outside its own box.
+    return AxisMapping.screenXToPlotPx(w, (unionLeft + unionRight) / 2)
   }
 
   /**

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -1229,8 +1229,7 @@ export default class Tooltip {
     )
       capturedSeries = null
 
-    const bounds = opt.elGrid.getBoundingClientRect()
-    if (capj.hoverX < 0 || capj.hoverX > bounds.width) {
+    if (capj.hoverX < 0 || capj.hoverX > w.layout.gridWidth) {
       this.handleMouseOut(opt)
       return
     }

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -1229,7 +1229,12 @@ export default class Tooltip {
     )
       capturedSeries = null
 
-    if (capj.hoverX < 0 || capj.hoverX > w.layout.gridWidth) {
+    // Bars at the first/last data point straddle the plot edge: their centers
+    // sit at 0 and `gridWidth`, so half of `barPadForNumericAxis` hangs outside
+    // the plot on each side. Hovering that half still has to resolve a tooltip,
+    // so widen the bound by the pad rather than clipping at the plot box.
+    const edgePad = w.globals.barPadForNumericAxis || 0
+    if (capj.hoverX < -edgePad || capj.hoverX > w.layout.gridWidth + edgePad) {
       this.handleMouseOut(opt)
       return
     }

--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -1,5 +1,6 @@
 // @ts-check
 import Utilities from '../../utils/Utils'
+import AxisMapping from '../AxisMapping'
 import Graphics from '../Graphics'
 
 /**
@@ -27,7 +28,7 @@ export default class Utils {
     const w = this.w
 
     const seriesBound = elGrid.getBoundingClientRect()
-    const hoverWidth = seriesBound.width
+    const hoverWidth = w.layout.gridWidth
     const hoverHeight = seriesBound.height
 
     let xDivisor = hoverWidth / (w.globals.dataPoints - 1)
@@ -42,7 +43,7 @@ export default class Utils {
       xDivisor = hoverWidth / w.globals.dataPoints
     }
 
-    const hoverX = clientX - seriesBound.left - w.globals.barPadForNumericAxis
+    const hoverX = AxisMapping.screenXToPlotPx(w, clientX)
     const hoverY = clientY - seriesBound.top
 
     const notInRect =
@@ -101,19 +102,9 @@ export default class Utils {
 
     // if X axis type is not category and tooltip is not shared, then we need to find the cursor position and get the nearest value
     if (w.axisFlags.isXNumeric) {
-      // Change origin of cursor position so that we can compute the relative nearest point to the cursor on our chart
-      // we only need to scale because all points are relative to the bounds.left and bounds.top => origin is virtually (0, 0)
-      const chartGridEl = this.ttCtx.getElGrid()
-      if (!chartGridEl) return { hoverX, hoverY }
-      const chartGridElBoundingRect = chartGridEl.getBoundingClientRect()
-      const transformedHoverX =
-        hoverX * (chartGridElBoundingRect.width / hoverWidth)
-      const transformedHoverY =
-        hoverY * (chartGridElBoundingRect.height / hoverHeight)
-
       closest = this.closestInMultiArray(
-        transformedHoverX,
-        transformedHoverY,
+        hoverX,
+        hoverY,
         seriesXValArr,
         seriesYValArr,
       )
@@ -124,7 +115,7 @@ export default class Utils {
         // initial push, it should be a little smaller than the 1st val
         seriesXValArr = w.globals.seriesXvalues[capturedSeries]
 
-        closest = this.closestInArray(transformedHoverX, seriesXValArr)
+        closest = this.closestInArray(hoverX, seriesXValArr)
 
         j = closest.j ?? 0
       }

--- a/src/modules/tooltip/Utils.js
+++ b/src/modules/tooltip/Utils.js
@@ -46,8 +46,15 @@ export default class Utils {
     const hoverX = AxisMapping.screenXToPlotPx(w, clientX)
     const hoverY = clientY - seriesBound.top
 
+    // Edge bars hang `barPadForNumericAxis / 2` outside the plot box, and the
+    // zoom/pan cursor should still show there. Same allowance as the tooltip
+    // bound in `Tooltip.handleStickyTooltip`.
+    const edgePad = w.globals.barPadForNumericAxis || 0
     const notInRect =
-      hoverX < 0 || hoverY < 0 || hoverX > hoverWidth || hoverY > hoverHeight
+      hoverX < -edgePad ||
+      hoverY < 0 ||
+      hoverX > hoverWidth + edgePad ||
+      hoverY > hoverHeight
 
     if (notInRect) {
       hoverArea.classList.remove('hovering-zoom')

--- a/tests/unit/tooltip-positioning.spec.js
+++ b/tests/unit/tooltip-positioning.spec.js
@@ -64,6 +64,22 @@ function makeCtx(overrides = {}) {
     height: 600,
   })
 
+  // `AxisMapping.screenXToPlotPx` anchors on the svg element, so give every
+  // ctx a measurable one. Without it the helper silently takes its `!svg`
+  // fallback and the tests below stop covering the derivation they describe.
+  const elSvg = document.createElement('div')
+  elSvg.classList.add('apexcharts-svg')
+  elSvg.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    right: 800,
+    bottom: 600,
+    width: 800,
+    height: 600,
+  })
+  w.dom.baseEl.appendChild(elSvg)
+  w.globals.svgWidth = 800
+
   const elGrid = document.createElement('div')
   elGrid.getBoundingClientRect = () => ({
     left: 50, // elWrap.left + translateX
@@ -373,17 +389,6 @@ describe('Position._datapointCenterXFromBars', () => {
       width: 520.5,
       height: 300,
     })
-    const svg = document.createElement('div')
-    svg.classList.add('apexcharts-svg')
-    svg.getBoundingClientRect = () => ({
-      left: 0,
-      top: 0,
-      width: 800,
-      height: 600,
-    })
-    w.dom.baseEl.appendChild(svg)
-    w.globals.svgWidth = 800
-
     const bar = document.createElement('div')
     bar.getBoundingClientRect = () => ({
       left: 180,

--- a/tests/unit/tooltip-positioning.spec.js
+++ b/tests/unit/tooltip-positioning.spec.js
@@ -251,7 +251,7 @@ describe('Position._datapointCenterXFromBars', () => {
   it('returns null when no bars at index j', () => {
     const { ttCtx } = makeCtx()
     const pos = new TooltipPosition(ttCtx)
-    const r = pos._datapointCenterXFromBars(0, { left: 0 })
+    const r = pos._datapointCenterXFromBars(0)
     expect(r).toBeNull()
   })
 
@@ -271,10 +271,10 @@ describe('Position._datapointCenterXFromBars', () => {
     w.dom.baseEl.querySelectorAll = vi.fn(() => [bar])
 
     const pos = new TooltipPosition(ttCtx)
-    // gridRect.left = 50 (elGrid screen-left)
-    const r = pos._datapointCenterXFromBars(2, { left: 50 })
+    // plot origin = svgLeft (0) + translateX (50)
+    const r = pos._datapointCenterXFromBars(2)
 
-    // union: left=100, right=140 → center=120 → grid-local = 120 - 50 = 70
+    // union: left=100, right=140 → center=120 → plot-local = 120 - 50 = 70
     expect(r).toBe(70)
   })
 
@@ -301,9 +301,9 @@ describe('Position._datapointCenterXFromBars', () => {
     w.dom.baseEl.querySelectorAll = vi.fn(() => [a, b])
 
     const pos = new TooltipPosition(ttCtx)
-    const r = pos._datapointCenterXFromBars(0, { left: 50 })
+    const r = pos._datapointCenterXFromBars(0)
 
-    // union: left=100, right=165 → center=132.5 → grid-local = 132.5 - 50 = 82.5
+    // union: left=100, right=165 → center=132.5 → plot-local = 132.5 - 50 = 82.5
     expect(r).toBe(82.5)
   })
 
@@ -337,9 +337,9 @@ describe('Position._datapointCenterXFromBars', () => {
     w.dom.baseEl.querySelectorAll = vi.fn(() => [collapsedBar, visibleBar])
 
     const pos = new TooltipPosition(ttCtx)
-    const r = pos._datapointCenterXFromBars(0, { left: 50 })
+    const r = pos._datapointCenterXFromBars(0)
 
-    // Should ignore the collapsed bar entirely → center 120 → grid-local 70
+    // Should ignore the collapsed bar entirely → center 120 → plot-local 70
     expect(r).toBe(70)
   })
 
@@ -357,7 +357,49 @@ describe('Position._datapointCenterXFromBars', () => {
     w.dom.baseEl.querySelectorAll = vi.fn(() => [zeroBar])
 
     const pos = new TooltipPosition(ttCtx)
-    expect(pos._datapointCenterXFromBars(0, { left: 0 })).toBeNull()
+    expect(pos._datapointCenterXFromBars(0)).toBeNull()
+  })
+
+  it('measures from the plot origin when the grid renders outside its own box', () => {
+    const { ttCtx, w, elGrid } = makeCtx()
+    // A gridline drawn left of the plot origin (a floored datetime tick, or
+    // the barPad widening on a numeric bar chart) pushes the grid element's
+    // left edge 20.5px ahead of the origin the bars are laid out from.
+    elGrid.getBoundingClientRect = () => ({
+      left: 29.5,
+      top: 20,
+      right: 550,
+      bottom: 320,
+      width: 520.5,
+      height: 300,
+    })
+    const svg = document.createElement('div')
+    svg.classList.add('apexcharts-svg')
+    svg.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 800,
+      height: 600,
+    })
+    w.dom.baseEl.appendChild(svg)
+    w.globals.svgWidth = 800
+
+    const bar = document.createElement('div')
+    bar.getBoundingClientRect = () => ({
+      left: 180,
+      right: 220,
+      top: 0,
+      bottom: 100,
+      width: 40,
+      height: 100,
+    })
+    w.dom.baseEl.querySelectorAll = vi.fn(() => [bar])
+
+    const pos = new TooltipPosition(ttCtx)
+
+    // center 200 → 200 - (svg.left 0 + translateX 50) = 150. Measuring from
+    // the grid element instead gives 170.5, an overhang right of the bar.
+    expect(pos._datapointCenterXFromBars(0)).toBe(150)
   })
 })
 

--- a/tests/unit/tooltip.spec.js
+++ b/tests/unit/tooltip.spec.js
@@ -134,6 +134,13 @@ function makeTooltipContext(overrides = {}) {
       baseEl: document.createElement('div'),
       ...(overrides.dom || {}),
     },
+    interact: {
+      zoomEnabled: globals.zoomEnabled,
+      panEnabled: globals.panEnabled,
+      capturedSeriesIndex: globals.capturedSeriesIndex,
+      capturedDataPointIndex: globals.capturedDataPointIndex,
+      ...(overrides.interact || {}),
+    },
     formatters: {
       xLabelFormatter: undefined,
       yLabelFormatters: [],
@@ -216,6 +223,71 @@ function makeTooltipContext(overrides = {}) {
 // ---------------------------------------------------------------------------
 
 describe('Tooltip.Utils', () => {
+  describe('getNearestValues', () => {
+    // A datetime axis floors its first timescale tick to the calendar boundary
+    // before minX, so the gridline drawn there puts the `.apexcharts-grid`
+    // element's left edge 20.5px before the plot origin on an 800px chart.
+    // Neither the origin nor the divisor may be read off that element.
+    function makeHoverCtx(overrides = {}) {
+      const { ttCtx, w } = makeTooltipContext({
+        globals: { dataPoints: 5, svgWidth: 800, barPadForNumericAxis: 0 },
+        layout: { gridWidth: 500, translateX: 50 },
+        ...overrides,
+      })
+
+      const svg = document.createElement('div')
+      svg.classList.add('apexcharts-svg')
+      svg.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600,
+      })
+      w.dom.baseEl.appendChild(svg)
+
+      const elGrid = document.createElement('div')
+      elGrid.getBoundingClientRect = () => ({
+        left: 29.5,
+        top: 20,
+        width: 520.5,
+        height: 300,
+      })
+
+      return { ttCtx, w, elGrid, hoverArea: document.createElement('div') }
+    }
+
+    it('measures the hover position from the plot origin, not the grid element', () => {
+      const { ttCtx, elGrid, hoverArea } = makeHoverCtx()
+      const utils = new TooltipUtils(ttCtx)
+
+      const res = utils.getNearestValues({
+        hoverArea,
+        elGrid,
+        clientX: 237,
+        clientY: 170,
+      })
+
+      // 237 - (svg.left 0 + translateX 50) = 187, over a 500px divisor of 125
+      // → j 1. The grid element gives 207.5 over 130.125 → j 2.
+      expect(res.hoverX).toBe(187)
+      expect(res.j).toBe(1)
+    })
+
+    it('treats a point left of the plot origin as outside the grid', () => {
+      const { ttCtx, elGrid, hoverArea } = makeHoverCtx({
+        interact: { zoomEnabled: true },
+      })
+      const utils = new TooltipUtils(ttCtx)
+      hoverArea.classList.add('hovering-zoom')
+
+      utils.getNearestValues({ hoverArea, elGrid, clientX: 40, clientY: 170 })
+
+      // 10px left of the origin, which the grid element's 20.5px overhang
+      // would otherwise report as still inside the plot.
+      expect(hoverArea.classList.contains('hovering-zoom')).toBe(false)
+    })
+  })
+
   describe('closestInArray', () => {
     // closestInArray starts currIndex=null and only updates when newdiff < diff
     // So the first element is never selected (it sets the baseline diff but not currIndex)

--- a/tests/unit/tooltip.spec.js
+++ b/tests/unit/tooltip.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import TooltipUtils from '../../src/modules/tooltip/Utils.js'
 import TooltipLabels from '../../src/modules/tooltip/Labels.js'
 import TooltipPosition from '../../src/modules/tooltip/Position.js'
+import Tooltip from '../../src/modules/tooltip/Tooltip.js'
 import { createChartWithOptions } from './utils/utils.js'
 
 // ---------------------------------------------------------------------------
@@ -284,6 +285,24 @@ describe('Tooltip.Utils', () => {
 
       // 10px left of the origin, which the grid element's 20.5px overhang
       // would otherwise report as still inside the plot.
+      expect(hoverArea.classList.contains('hovering-zoom')).toBe(false)
+    })
+
+    it('keeps the zoom cursor over the half of an edge bar outside the plot', () => {
+      const { ttCtx, elGrid, hoverArea } = makeHoverCtx({
+        globals: { dataPoints: 5, svgWidth: 800, barPadForNumericAxis: 60 },
+        interact: { zoomEnabled: true },
+      })
+      const utils = new TooltipUtils(ttCtx)
+
+      // Plot origin 50, gridWidth 500, so the last bar's center is at 550 and
+      // it reaches 580. Hovering 570 is 20px past the plot box but still on
+      // the bar, so it must stay "inside".
+      utils.getNearestValues({ hoverArea, elGrid, clientX: 570, clientY: 170 })
+      expect(hoverArea.classList.contains('hovering-zoom')).toBe(true)
+
+      // Beyond the pad it is genuinely outside.
+      utils.getNearestValues({ hoverArea, elGrid, clientX: 615, clientY: 170 })
       expect(hoverArea.classList.contains('hovering-zoom')).toBe(false)
     })
   })
@@ -632,6 +651,55 @@ describe('Tooltip.Utils', () => {
       expect(utils.getHoverMarkerSize(1)).toBe(8) // 6 + 2
       expect(utils.getHoverMarkerSize(2)).toBe(12) // 10 + 2
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tooltip.handleStickyTooltip — the in/out bound around the plot box
+// ---------------------------------------------------------------------------
+
+describe('Tooltip.handleStickyTooltip', () => {
+  /**
+   * Drives the method against a stubbed `this` so the bound is the only thing
+   * under test. `hoverX` is already plot-origin-relative when it arrives here.
+   */
+  function runBound(hoverX, barPadForNumericAxis) {
+    const handleMouseOut = vi.fn()
+    const create = vi.fn()
+    const self = {
+      w: {
+        globals: { barPadForNumericAxis, collapsedSeriesIndices: [] },
+        layout: { gridWidth: 500 },
+        seriesData: { series: [[1, 2, 3]] },
+      },
+      tooltipUtil: {
+        getNearestValues: () => ({ j: 2, capturedSeries: null, hoverX }),
+        isXoverlap: () => true,
+      },
+      handleMouseOut,
+      create,
+    }
+
+    Tooltip.prototype.handleStickyTooltip.call(self, {}, 0, 0, { ttItems: [] })
+    return { handleMouseOut, create }
+  }
+
+  it('dismisses the tooltip outside the plot box when there is no bar pad', () => {
+    expect(runBound(-1, 0).handleMouseOut).toHaveBeenCalled()
+    expect(runBound(501, 0).handleMouseOut).toHaveBeenCalled()
+    expect(runBound(250, 0).create).toHaveBeenCalled()
+  })
+
+  it('keeps the tooltip over the halves of the edge bars that overhang the plot', () => {
+    // Bars at the first and last data point are centred on 0 and `gridWidth`,
+    // so they reach `barPadForNumericAxis / 2` outside the plot on each side.
+    // Clipping at the plot box killed the tooltip over half of both bars.
+    expect(runBound(-40, 120).create).toHaveBeenCalled()
+    expect(runBound(540, 120).create).toHaveBeenCalled()
+
+    // Past the pad it is off the bar and the tooltip goes away again.
+    expect(runBound(-121, 120).handleMouseOut).toHaveBeenCalled()
+    expect(runBound(621, 120).handleMouseOut).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
`getNearestValues()` measured the cursor against the `.apexcharts-grid` element's client rect and subtracted `barPadForNumericAxis`, and `_datapointCenterXFromBars()` did the same to the bar union's center. That pair only cancels while the grid box happens to extend exactly `barPad`, and it stops doing so as soon as the grid draws outside its own box for another reason. A datetime axis does that routinely: `ceilToBoundary()` floors a step-1 interval to the boundary before `minX`, `TimeScale` gives that tick a negative position, and `datetimeLines()` draws the gridline there. On the 13-year monthly series from #5270 that is a 20.5px overhang on an 800px chart.

In `getNearestValues()` the grid rect supplied both the origin and the `hoverWidth` divisor, so the hover x came out an overhang too large while `xDivisor` was computed over a box that much too wide. The resolved `j` was wrong near the plot edges and the `notInRect` guard let in points that sat left of the plot. In `_datapointCenterXFromBars()` the crosshair landed off the bar center by the same amount.

Both now go through `AxisMapping.screenXToPlotPx()`, which anchors on the svg element's left edge plus `translateX`, the origin the bars are laid out from, and scales by the container's CSS zoom. `ZoomPanSelection._screenXToPlotPx()` delegates to it rather than keeping a second copy of the same derivation, and its doc comment already recommended that reference over the grid box. `hoverWidth` becomes `w.layout.gridWidth`, which is the value the divisor actually wants, so the vestigial `hoverX * (gridRect.width / hoverWidth)` rescale ahead of `closestInMultiArray` (always a no-op, since both terms came off the same element) goes away. The bounds check in `handleStickyTooltip` moves to `gridWidth` for the same reason.

Unit tests cover both sites with a grid element whose rect starts 20.5px before the plot origin. All 2185 unit tests and the 211 Playwright interaction tests pass.

Fixes #5272

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My branch is up to date with any changes from the main branch
