### PR TITLE
fix(annotations): clamp point annotation label x within chart bounds (Fixes #5106)

### DIFF
--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -66,8 +66,34 @@ export default class PointAnnotations {
 
       const text = anno.label.text ? anno.label.text : ''
 
+      // Clamp label x to keep it within chart bounds (prevents cutting off
+      // labels near left/right chart boundary — fixes apexcharts/apexcharts.js#5106)
+      const gridWidth = w.layout.gridWidth
+      const labelWidth = text
+        ? this.annoCtx.graphics.getTextRects(
+            text,
+            anno.label.style.fontSize,
+            anno.label.style.fontFamily
+          ).width
+        : 0
+
+      let labelX = x + anno.label.offsetX
+      if (labelWidth > 0) {
+        if (anno.label.textAnchor === 'end') {
+          labelX = Math.max(labelWidth, Math.min(labelX, gridWidth))
+        } else if (anno.label.textAnchor === 'middle') {
+          labelX = Math.max(
+            labelWidth / 2,
+            Math.min(labelX, gridWidth - labelWidth / 2)
+          )
+        } else {
+          // 'start' (default)
+          labelX = Math.max(0, Math.min(labelX, gridWidth - labelWidth))
+        }
+      }
+
       const elText = this.annoCtx.graphics.drawText({
-        x: x + anno.label.offsetX,
+        x: labelX,
         y:
           y +
           anno.label.offsetY -

--- a/tests/unit/points-annotations.spec.js
+++ b/tests/unit/points-annotations.spec.js
@@ -1,6 +1,7 @@
 import Annotations from '../../src/modules/annotations/Annotations.js'
 import PointsAnnotations from '../../src/modules/annotations/PointsAnnotations.js'
 import { createChartWithOptions } from './utils/utils.js'
+import ApexCharts from '../../src/entries/full.js'
 
 describe('PointsAnnotations', () => {
   let chart
@@ -630,6 +631,102 @@ describe('PointsAnnotations', () => {
       expect(
         group.querySelectorAll('.apexcharts-point-annotation-marker').length
       ).toBe(0)
+    })
+  })
+
+  // =========================================================================
+  // Boundary clamping (apexcharts/apexcharts.js#5106)
+  // =========================================================================
+  describe('boundary clamping', () => {
+    it('should clamp label x near the right edge to prevent cutting off', () => {
+      document.body.innerHTML = '<div id="chart" style="width:600px;height:400px" />'
+      chart = new ApexCharts(document.querySelector('#chart'), {
+        chart: { type: 'line', width: '600', height: '400', animations: { enabled: false } },
+        series: [{ data: [10, 20, 30, 40, 50] }],
+        annotations: {
+          points: [
+            {
+              x: 5, // last data point (right edge)
+              y: 50,
+              marker: { size: 6 },
+              label: {
+                text: 'A very long label that would overflow the chart boundary',
+                style: { fontSize: '14px', fontFamily: 'Arial' },
+              },
+            },
+          ],
+        },
+      })
+      chart.render()
+
+      const label = chart.w.globals.dom.baseEl.querySelector(
+        '.apexcharts-point-annotation-label'
+      )
+      expect(label).not.toBeNull()
+      const labelX = parseFloat(label.getAttribute('x'))
+      const gridWidth = chart.w.layout.gridWidth
+      // label should be clamped to gridWidth - some margin
+      expect(labelX).toBeLessThan(gridWidth)
+    })
+
+    it('should clamp label x near the left edge to prevent cutting off', () => {
+      document.body.innerHTML = '<div id="chart" style="width:600px;height:400px" />'
+      chart = new ApexCharts(document.querySelector('#chart'), {
+        chart: { type: 'line', width: '600', height: '400', animations: { enabled: false } },
+        series: [{ data: [10, 20, 30, 40, 50] }],
+        annotations: {
+          points: [
+            {
+              x: 0, // first data point (left edge)
+              y: 10,
+              marker: { size: 6 },
+              label: {
+                text: 'A very long label that would overflow on the left',
+                style: { fontSize: '14px', fontFamily: 'Arial' },
+              },
+            },
+          ],
+        },
+      })
+      chart.render()
+
+      const label = chart.w.globals.dom.baseEl.querySelector(
+        '.apexcharts-point-annotation-label'
+      )
+      expect(label).not.toBeNull()
+      const labelX = parseFloat(label.getAttribute('x'))
+      // Label should not be clipped — its x should be >= 0
+      expect(labelX).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should not affect labels that already fit within the grid', () => {
+      document.body.innerHTML = '<div id="chart" style="width:600px;height:400px" />'
+      chart = new ApexCharts(document.querySelector('#chart'), {
+        chart: { type: 'line', width: '600', height: '400', animations: { enabled: false } },
+        series: [{ data: [10, 20, 30, 40, 50] }],
+        annotations: {
+          points: [
+            {
+              x: 2, // middle data point
+              y: 30,
+              marker: { size: 6 },
+              label: {
+                text: 'Short',
+                style: { fontSize: '14px', fontFamily: 'Arial' },
+              },
+            },
+          ],
+        },
+      })
+      chart.render()
+
+      const label = chart.w.globals.dom.baseEl.querySelector(
+        '.apexcharts-point-annotation-label'
+      )
+      expect(label).not.toBeNull()
+      const labelX = parseFloat(label.getAttribute('x'))
+      // Should be > 0 and within grid
+      expect(labelX).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## Description

Fixes #5106 — Point annotation labels near the left or right chart boundary are cut off when the label text extends beyond the chart area.

### Problem

When a point annotation has a long label text and is positioned near the left or right edge of the chart, the label extends beyond the chart's grid bounds and gets clipped (hidden) by the SVG viewport.

### Fix

Measure the label text width using  before rendering, then clamp the label x position to keep it within the chart's grid boundaries:

- **textAnchor = "start"** (default): clamp x to [0, gridWidth - labelWidth]
- **textAnchor = "end"**: clamp x to [labelWidth, gridWidth]
- **textAnchor = "middle"**: clamp x to [labelWidth/2, gridWidth - labelWidth/2]

### Test

Added 3 new tests in the boundary-clamping describe block:
- Right-edge label: verify x is clamped to less than gridWidth
- Left-edge label: verify x is clamped to >= 0
- Already-fitting label: verify x is > 0