### PR TITLE
fix: keep millisecond resolution when x is a Date on a datetime axis

### DIFF
--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -331,7 +331,12 @@ export default class Data {
           }
         } else {
           if (cnf.xaxis.type === 'datetime') {
-            this.twoDSeriesX.push(dt.parseDate(x.toString()))
+            // A Date already carries an exact epoch value, so read it
+            // directly. Date.prototype.toString() has second resolution, and
+            // parsing its output back drops the milliseconds silently.
+            this.twoDSeriesX.push(
+              x instanceof Date ? x.getTime() : dt.parseDate(x.toString())
+            )
           } else {
             this.w.axisFlags.dataFormatXNumeric = true
             this.w.axisFlags.isXNumeric = true

--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -309,7 +309,7 @@ export default class Data {
       const isXDate = !isXArr && !!dt.isValidDate(x)
 
       if (isXString || isXDate) {
-        // user supplied '01/01/2017' or a date string (a JS date object is not supported)
+        // user supplied a date string ('01/01/2017') or a JS Date object
         if (isXString || cnf.xaxis.convertedCatToNumeric) {
           const isRangeColumn =
             gl.isBarHorizontal && this.w.axisFlags.isRangeData
@@ -335,7 +335,7 @@ export default class Data {
             // directly. Date.prototype.toString() has second resolution, and
             // parsing its output back drops the milliseconds silently.
             this.twoDSeriesX.push(
-              x instanceof Date ? x.getTime() : dt.parseDate(x.toString())
+              x instanceof Date ? x.getTime() : dt.parseDate(x.toString()),
             )
           } else {
             this.w.axisFlags.dataFormatXNumeric = true

--- a/tests/types/consumer-patterns.ts
+++ b/tests/types/consumer-patterns.ts
@@ -285,6 +285,18 @@ const _violinRaw: ApexCharts.ApexOptions = {
 }
 void _boxRaw; void _violinRaw
 
+// datetime axis: a Date, a timestamp and a date string are all valid x values
+const _dateX: ApexCharts.ApexOptions = {
+  chart: { type: 'line' },
+  xaxis: { type: 'datetime' },
+  series: [
+    { name: 'Date', data: [{ x: new Date(1748924002500), y: 1 }] },
+    { name: 'Timestamp', data: [{ x: 1748924002500, y: 2 }] },
+    { name: 'String', data: [{ x: '2025-06-03T04:13:22.500Z', y: 3 }] },
+  ],
+}
+void _dateX
+
 // SSR statics from the apexcharts/ssr entry
 async function _ssrUse() {
   const html = await ApexChartsClass.renderToHTML({ chart: { type: 'bar' } }, { width: 500 })

--- a/tests/unit/datetime-date-object-x.spec.js
+++ b/tests/unit/datetime-date-object-x.spec.js
@@ -1,0 +1,77 @@
+import Data from '../../src/modules/Data'
+import { createChart } from './utils/utils.js'
+
+// A datetime axis kept millisecond resolution for a numeric x but not for a
+// Date, because the Date branch went through x.toString() first and
+// Date.prototype.toString() has second resolution. Two points 500ms apart
+// landed on the same x, which draws as a vertical line. (#5054)
+
+const T0 = 1748924002000
+const T_HALF = 1748924002500
+const T1 = 1748924003000
+
+function parsedX(series) {
+  const chart = createChart('line', series, 'datetime')
+  chart.w.globals.seriesX = []
+
+  const data = new Data(chart.w, chart)
+  const w = data.parseDataAxisCharts(series, series, chart)
+
+  return w.globals.seriesX
+}
+
+describe('datetime axis with Date objects as x', () => {
+  it('keeps milliseconds for Date x values', () => {
+    const [xs] = parsedX([
+      {
+        name: 'Date',
+        data: [
+          { x: new Date(T0), y: 1 },
+          { x: new Date(T_HALF), y: 2 },
+          { x: new Date(T1), y: 1 },
+        ],
+      },
+    ])
+
+    expect(xs).toEqual([T0, T_HALF, T1])
+  })
+
+  it('parses Date x the same way as the equivalent number', () => {
+    const [fromNumbers] = parsedX([
+      {
+        name: 'Number',
+        data: [
+          { x: T0, y: 1 },
+          { x: T_HALF, y: 2 },
+          { x: T1, y: 1 },
+        ],
+      },
+    ])
+    const [fromDates] = parsedX([
+      {
+        name: 'Date',
+        data: [
+          { x: new Date(T0), y: 1 },
+          { x: new Date(T_HALF), y: 2 },
+          { x: new Date(T1), y: 1 },
+        ],
+      },
+    ])
+
+    expect(fromDates).toEqual(fromNumbers)
+  })
+
+  it('still parses date strings', () => {
+    const [xs] = parsedX([
+      {
+        name: 'String',
+        data: [
+          { x: '2010-01-01T00:00:00.000Z', y: 1 },
+          { x: '2010-01-02T00:00:00.000Z', y: 2 },
+        ],
+      },
+    ])
+
+    expect(xs).toEqual([1262304000000, 1262390400000])
+  })
+})

--- a/types/apexcharts.d.ts
+++ b/types/apexcharts.d.ts
@@ -1845,7 +1845,11 @@ type ApexAxisChartSeries = {
  data:
  | (number | null)[]
  | {
-   x: string | number;
+   /**
+    * A category label, a timestamp, or a `Date`. On a `datetime` axis all
+    * three keep millisecond resolution.
+    */
+   x: string | number | Date;
    /**
     * A plain value for most charts. For `candlestick`/`boxPlot`, the
     * summary array (`[O,H,L,C]` / `[min,Q1,median,Q3,max]`). For `violin`, an


### PR DESCRIPTION
Closes #5054.

It's the `toString()` in `Data.js`:

```js
this.twoDSeriesX.push(dt.parseDate(x.toString()))
```

`Date.prototype.toString()` only has second resolution, so parsing its output back loses the milliseconds:

```js
new Date(1748924002500).toString()
// 'Tue Jun 03 2025 11:13:22 GMT+0700 (Indochina Time)'   <- .500 gone
```

Which is why two points 500ms apart end up on the same x and draw as a vertical line. A numeric x never reaches that branch, and that's what the reporter noticed when switching to raw numbers fixed it.

A Date already holds the exact epoch, so this reads it directly instead of round-tripping through a string. Note `parseDate(x)` on the line above (the `isXString` branch) already preserves it, since `Date.parse` coerces internally and `getTimeStamp` then does `new Date(x).getTime()` — only the `.toString()` call is lossy.

Added `tests/unit/datetime-date-object-x.spec.js` covering the milliseconds, Date-vs-number parity, and that date strings still parse. Against the unpatched `Data.js` the first two fail and the string one passes, which is the right shape.
