### PR TITLE
fix(data): a Date x on a non-datetime axis, and an invalid Date

### DIFF
--- a/src/modules/Data.js
+++ b/src/modules/Data.js
@@ -340,7 +340,14 @@ export default class Data {
           } else {
             this.w.axisFlags.dataFormatXNumeric = true
             this.w.axisFlags.isXNumeric = true
-            this.twoDSeriesX.push(parseFloat(x))
+            // The two lines above have already decided this x is numeric.
+            // parseFloat() reads a Date through toString(), which starts with
+            // a weekday name, so every Date arrived here as NaN. A Date's
+            // numeric value is its epoch, the same one the datetime branch
+            // above reads.
+            this.twoDSeriesX.push(
+              x instanceof Date ? x.getTime() : parseFloat(x),
+            )
           }
         }
       } else if (isXArr) {

--- a/src/utils/DateTime.js
+++ b/src/utils/DateTime.js
@@ -58,12 +58,21 @@ class DateTime {
   }
 
   /**
-   * @param {string} dateStr
+   * @param {any} dateStr - a date string, or anything isValidDate() was handed
    */
   parseDate(dateStr) {
     const parsed = Date.parse(dateStr)
     if (!isNaN(parsed)) {
       return this.getTimeStamp(dateStr)
+    }
+
+    // The salvage pass below re-spells the input and parses it again. Only a
+    // string has an alternate spelling to try: on an invalid Date, or on any
+    // other object, .replace() does not exist and the call threw. That took
+    // isValidDate() down with it, so a single bad x killed the whole render
+    // instead of being reported as "not a date".
+    if (typeof dateStr !== 'string') {
+      return NaN
     }
 
     let output = Date.parse(dateStr.replace(/-/g, '/').replace(/[a-z]+/gi, ' '))

--- a/tests/unit/date-x-edge-cases.spec.js
+++ b/tests/unit/date-x-edge-cases.spec.js
@@ -1,0 +1,105 @@
+import Data from '../../src/modules/Data'
+import DateTime from '../../src/utils/DateTime'
+import { createChart } from './utils/utils.js'
+
+// Two adjacent problems the review of #5277 named and deliberately left out of
+// that PR, because they predate it:
+//
+//   1. On a non-datetime axis a Date x went through parseFloat(), which reads
+//      the Date through its toString() ("Wed Jun 03 2026 ..."), so every point
+//      became NaN even though the surrounding code had just declared this x
+//      numeric.
+//   2. isValidDate(new Date('garbage')) threw instead of answering false,
+//      because parseDate()'s salvage pass calls .replace() on its argument and
+//      an invalid Date has no such method. That took the whole render down.
+
+const T0 = 1748924002000
+const T1 = 1748924003000
+
+function parsedX(series, xtype) {
+  const chart = createChart('line', series, xtype)
+  chart.w.globals.seriesX = []
+
+  const data = new Data(chart.w, chart)
+  const w = data.parseDataAxisCharts(series, series, chart)
+
+  return w.globals.seriesX
+}
+
+function datesAndNumbers(xtype) {
+  const [fromDates] = parsedX(
+    [
+      {
+        name: 'Date',
+        data: [
+          { x: new Date(T0), y: 1 },
+          { x: new Date(T1), y: 2 },
+        ],
+      },
+    ],
+    xtype,
+  )
+  const [fromNumbers] = parsedX(
+    [
+      {
+        name: 'Number',
+        data: [
+          { x: T0, y: 1 },
+          { x: T1, y: 2 },
+        ],
+      },
+    ],
+    xtype,
+  )
+  return { fromDates, fromNumbers }
+}
+
+describe('a Date x on a non-datetime axis', () => {
+  it('reads the Date as its epoch on a numeric axis', () => {
+    const { fromDates } = datesAndNumbers('numeric')
+
+    expect(fromDates).toEqual([T0, T1])
+  })
+
+  it('lands on the same x as the equivalent number', () => {
+    const { fromDates, fromNumbers } = datesAndNumbers('numeric')
+
+    expect(fromDates).toEqual(fromNumbers)
+  })
+})
+
+describe('an invalid Date as x', () => {
+  function dt() {
+    const chart = createChart(
+      'line',
+      [{ name: 'n', data: [{ x: 1, y: 1 }] }],
+      'numeric',
+    )
+    return new DateTime(chart.w)
+  }
+
+  it('makes isValidDate answer false rather than throw', () => {
+    const d = dt()
+
+    expect(() => d.isValidDate(new Date('garbage'))).not.toThrow()
+    expect(d.isValidDate(new Date('garbage'))).toBe(false)
+  })
+
+  it('still recognises the dates that are real', () => {
+    const d = dt()
+
+    expect(d.isValidDate(new Date(T0))).toBe(true)
+    expect(d.isValidDate('2010-01-01T00:00:00.000Z')).toBe(true)
+    expect(d.isValidDate('01/01/2017')).toBe(true)
+    expect(d.isValidDate('not a date')).toBe(false)
+  })
+
+  it('does not take the render down', () => {
+    expect(() =>
+      parsedX(
+        [{ name: 'bad', data: [{ x: new Date('garbage'), y: 1 }] }],
+        'category',
+      ),
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
Picking up the two adjacent problems you named at the end of your review of #5277 and deliberately did not fold in:

> One adjacent thing I deliberately did not fold in, for anyone who finds this later: on a non-datetime axis a `Date` x still goes through `parseFloat(x)` and becomes `NaN`, and `dt.isValidDate(new Date('garbage'))` throws because `parseDate`'s fallback assumes a string. Both predate this PR and belong in their own change.

Both still reproduce on `main` (b0dc6af).

### 1. A `Date` x on a non-datetime axis becomes `NaN`

`Data.js` sets `dataFormatXNumeric` and `isXNumeric` and then reads the value with `parseFloat(x)`. `parseFloat` stringifies its argument first, and `Date.prototype.toString()` starts with a weekday name:

```js
new Date(1748924002000).toString()   // 'Tue Jun 03 2025 11:13:22 GMT+0700 (Indochina Time)'
parseFloat(new Date(1748924002000))  // NaN
```

Those two lines have already decided the x is numeric, and a `Date`'s numeric value is its epoch — the same value the `datetime` branch three lines above reads. So this is the same shape as the fix in #5277, applied to the branch that was left out.

### 2. An invalid `Date` throws instead of answering "not a date"

`isValidDate` hands its argument straight to `parseDate`. For an invalid `Date`, `Date.parse` returns `NaN`, so it falls into the salvage pass, which calls `.replace()` on it:

```js
Date.parse(new Date('garbage'))   // NaN  → falls through to the salvage pass
// → TypeError: dateStr.replace is not a function
```

`Data.js:309` calls `isValidDate(x)` for every x, so a single bad point takes the whole render down with a `TypeError`. Only a string has an alternate spelling worth trying, so anything else now returns `NaN` and `isValidDate` can answer `false`.

**Correction (per @junedchhipa's review):** an earlier draft of this paragraph said the bad x then falls through to the category path. It does not. Failing `isValidDate` means it misses the `isXString || isXDate` branch entirely and lands in the final `else`, which pushes `x` unconverted and sets `isXNumeric` / `dataFormatXNumeric`, so `fallbackToCategory` is never set and `categoryLabels` stays empty. Measured on a category axis: `raw pushed = [object Date]`, `categoryLabels = []`, 0 x axis label texts against 2 for the equivalent numeric x. Still much better than the blank chart it replaces, but it is the numeric path, not the category one.

### Evidence

New spec `tests/unit/date-x-edge-cases.spec.js`, 5 tests. Reverting `src/` and keeping the spec, on `main`:

```
× reads the Date as its epoch on a numeric axis
    AssertionError: expected [ NaN, NaN ] to deeply equal [ 1748924002000, 1748924003000 ]
× lands on the same x as the equivalent number
    AssertionError: expected [ NaN, NaN ] to deeply equal [ 1748924002000, 1748924003000 ]
× makes isValidDate answer false rather than throw
    AssertionError: expected [Function] to not throw an error but 'TypeError: dateStr.replace is not a f…' was thrown
✓ still recognises the dates that are real
× does not take the render down
    AssertionError: expected [Function] to not throw an error but 'TypeError: dateStr.replace is not a f…' was thrown
```

The test that passes before the fix is the control: `isValidDate` still says yes to `new Date(...)`, `'2010-01-01T00:00:00.000Z'` and `'01/01/2017'`, and no to `'not a date'`. It stays green throughout, so the guard does not widen what counts as a date.

Each fix was then reverted on its own, to check that neither test is vacuous:

| reverted | result |
|---|---|
| `DateTime.js` guard only | 2 failed, 3 passed |
| `Data.js` `Date` branch only | 2 failed, 3 passed |
| neither | 5 passed |

Full unit suite: **134 files, 3181 tests, 0 failures.** `npm run lint` is clean. `npm run typecheck` reports 23 errors with and without this change — all in `Drilldown.js`, all pre-existing.

Prettier: I left the pre-existing deviations in both files alone, the way you did on #5277. `prettier --write` on these two files touches only `DateTime.js:432`, `DateTime.js:685`, `Data.js:898` and `Data.js:1775`; none of them are lines this PR adds.

### Not included

Nothing else moved. `getTimeStamp` and `parseDateWithTimezone` keep the string path they always had, and a valid `Date` never reaches the new guard because `Date.parse` succeeds before it.
