### PR TITLE
fix(config): keep initialConfig unadulterated when series are hidden

### DIFF
--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -284,13 +284,13 @@ export default class UpdateHelpers {
       this.ctx._writeParsedAxisFlags(parsedState.axisFlags)
 
       if (overwriteInitialSeries) {
-        // initialConfig.series has aliased w.config.series since Globals.init
-        // (Utils.extend copies arrays by reference); keep that alias fresh.
+        // Refresh the initialConfig snapshot with the series the caller just
+        // defined. A copy, never the live array: this site used to assign
+        // w.config.series itself, restoring the very alias #5118 came from, so
+        // one updateSeries() would undo the capture Globals.init now makes.
         // initialSeries was already captured by parseData above through the
         // lazy-snapshot setter, so no deep clone happens here either.
         if (w.globals.initialConfig) {
-          // A copy, not the alias the comment above describes: sharing the array
-          // is what let a later collapse empty the snapshot (#5118).
           w.globals.initialConfig.series = Utils.copySeriesShallow(
             w.config.series,
           )

--- a/src/modules/helpers/UpdateHelpers.js
+++ b/src/modules/helpers/UpdateHelpers.js
@@ -161,7 +161,25 @@ export default class UpdateHelpers {
               : []
 
             // After forgetting lastAxes, we need to restore the new config in initialConfig/initialSeries
-            w.globals.initialConfig = Utils.extend({}, w.config)
+            // Two traps here. Utils.extend() copies arrays by reference, so
+            // the snapshot would hand back the LIVE series array; and
+            // w.config.series carries the legend-collapse state
+            // (`series[i].data = []` for every hidden series), so
+            // re-snapshotting it made the "initial" config forget the data of
+            // everything the user had toggled off (#5118). Only a call that
+            // actually redefines the series may move that baseline; a plain
+            // updateOptions() keeps the one it already had.
+            const prevInitialSeries =
+              w.globals.initialConfig && w.globals.initialConfig.series
+            const initialConfig =
+              /** @type {NonNullable<typeof w.globals.initialConfig>} */ (
+                Utils.extend({}, w.config)
+              )
+            initialConfig.series =
+              !options.series && prevInitialSeries
+                ? prevInitialSeries
+                : Utils.copySeriesShallow(w.config.series)
+            w.globals.initialConfig = initialConfig
             // lazy snapshot: deep clone deferred to first read
             w.globals.initialSeries = w.config.series
 
@@ -271,7 +289,11 @@ export default class UpdateHelpers {
         // initialSeries was already captured by parseData above through the
         // lazy-snapshot setter, so no deep clone happens here either.
         if (w.globals.initialConfig) {
-          w.globals.initialConfig.series = w.config.series
+          // A copy, not the alias the comment above describes: sharing the array
+          // is what let a later collapse empty the snapshot (#5118).
+          w.globals.initialConfig.series = Utils.copySeriesShallow(
+            w.config.series,
+          )
         }
         w.globals.initialSeries = w.config.series
       }

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -552,9 +552,18 @@ export default class Globals {
    * Why sharing the data arrays is safe: internal "mutations" of a series'
    * data are property REPLACEMENTS (`series[i].data = []` on legend collapse),
    * which cannot reach the captured copies because each series object was
-   * copied at capture time. The one in-place mutator (appendData's push loop)
-   * re-captures immediately after mutating, so the pending snapshot never
-   * spans the mutation.
+   * copied at capture time.
+   *
+   * The one in-place mutator is appendData(), whose push loop grows the shared
+   * data array. Re-capturing after it does not undo that: the pushed points
+   * are already in the array both snapshots point at, so a snapshot taken
+   * before the append reads back as appended. That is the documented
+   * behaviour of appendData(overwriteInitialSeries = true), and the `false`
+   * case is not honoured for a separate, older reason: Data.parseData()
+   * re-captures initialSeries unconditionally on the re-render appendData
+   * triggers. Detaching would mean copying the data arrays, which is exactly
+   * the per-point cost this snapshot exists to avoid. The same exception
+   * applies to `initialConfig.series`, which is captured with the same shape.
    *
    * @param {Record<string, any>} globals
    */
@@ -573,11 +582,7 @@ export default class Globals {
         return snap
       },
       set(value) {
-        src = Array.isArray(value)
-          ? value.map((s) =>
-              s && typeof s === 'object' && !Array.isArray(s) ? { ...s } : s,
-            )
-          : value
+        src = Utils.copySeriesShallow(value)
         snap = null
         // Read-only peek for hot-path consumers (tooltip's same-length check
         // runs per update): reading it does NOT materialize the deep snapshot.

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -597,7 +597,15 @@ export default class Globals {
 
     this.defineLazyInitialSeries(globals)
 
-    globals.initialConfig = Utils.extend({}, config)
+    // Utils.extend() copies arrays by reference (isObject() excludes arrays),
+    // so initialConfig.series WAS config.series. Collapsing a series replaces
+    // series[i].data with [] in place, and the snapshot lost the data with it.
+    const initialConfig =
+      /** @type {NonNullable<typeof globals.initialConfig>} */ (
+        Utils.extend({}, config)
+      )
+    initialConfig.series = Utils.copySeriesShallow(config.series)
+    globals.initialConfig = initialConfig
     globals.initialSeries = config.series
 
     globals.lastXAxis = Utils.clone(

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -75,11 +75,15 @@ class Utils {
   }
 
   // A per-series shallow copy: the series OBJECTS are copied, their data arrays
-  // are shared. Internal "mutations" of a series' data are property
-  // REPLACEMENTS (`series[i].data = []` on legend collapse, `series[i] = 0` for
-  // non-axis charts), and neither can reach a copy made this way. This is the
-  // same cheap shape `globals.initialSeries` captures, so snapshotting a config
-  // stays O(n) instead of deep-cloning every point.
+  // are shared. Almost every internal "mutation" of a series' data is a
+  // property REPLACEMENT (`series[i].data = []` on legend collapse,
+  // `series[i] = 0` for non-axis charts), and those cannot reach a copy made
+  // this way because the series object was copied at capture time. The
+  // exception is appendData(), whose push loop grows the shared data array in
+  // place, so a copy taken before it does see the appended points; see the
+  // note above defineLazyInitialSeries(). This is the same cheap shape
+  // `globals.initialSeries` captures, so snapshotting a config stays O(n)
+  // instead of deep-cloning every point.
   /**
    * @param {any} series
    */

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -74,6 +74,21 @@ class Utils {
     return output
   }
 
+  // A per-series shallow copy: the series OBJECTS are copied, their data arrays
+  // are shared. Internal "mutations" of a series' data are property
+  // REPLACEMENTS (`series[i].data = []` on legend collapse, `series[i] = 0` for
+  // non-axis charts), and neither can reach a copy made this way. This is the
+  // same cheap shape `globals.initialSeries` captures, so snapshotting a config
+  // stays O(n) instead of deep-cloning every point.
+  /**
+   * @param {any} series
+   */
+  static copySeriesShallow(series) {
+    return Array.isArray(series)
+      ? series.map((s) => (this.isObject(s) ? { ...s } : s))
+      : series
+  }
+
   /**
    * @param {any[]} arrToExtend
    * @param {any} resultArr

--- a/tests/unit/initial-config-hidden-series.spec.js
+++ b/tests/unit/initial-config-hidden-series.spec.js
@@ -1,0 +1,59 @@
+import { createChartWithOptions } from './utils/utils.js'
+
+// globals.initialConfig is meant to be the untouched config the chart started
+// with — resetSeries, the toolbar reset-home button and custom tooltips all
+// read it. But Utils.extend() copies arrays by reference (isObject() excludes
+// arrays), so initialConfig.series WAS w.config.series, and collapsing a
+// series replaces series[i].data with [] in place. The "initial" config lost
+// the data along with the live one. (#5118)
+
+const SERIES = [
+  { name: 'A', data: [1, 2, 3] },
+  { name: 'B', data: [4, 5, 6] },
+]
+
+function chartWith(series) {
+  return createChartWithOptions({
+    chart: { type: 'line' },
+    series: series.map((s) => ({ name: s.name, data: [...s.data] })),
+    xaxis: { categories: ['x', 'y', 'z'] },
+  })
+}
+
+describe('initialConfig with a hidden series', () => {
+  it('keeps the hidden series data after hideSeries', () => {
+    const chart = chartWith(SERIES)
+
+    chart.hideSeries('B')
+
+    expect(chart.w.globals.initialConfig.series[1].data).toEqual([4, 5, 6])
+  })
+
+  it('keeps the hidden series data across updateOptions', async () => {
+    const chart = chartWith(SERIES)
+    chart.hideSeries('B')
+
+    await chart.updateOptions({ title: { text: 'changed' } })
+
+    expect(chart.w.globals.initialConfig.series[1].data).toEqual([4, 5, 6])
+  })
+
+  it('does not share series objects with the live config', () => {
+    const chart = chartWith(SERIES)
+
+    expect(chart.w.globals.initialConfig.series).not.toBe(chart.w.config.series)
+    expect(chart.w.globals.initialConfig.series[0]).not.toBe(
+      chart.w.config.series[0],
+    )
+  })
+
+  it('still records what the chart started with', () => {
+    const chart = chartWith(SERIES)
+
+    expect(chart.w.globals.initialConfig.series.map((s) => s.name)).toEqual([
+      'A',
+      'B',
+    ])
+    expect(chart.w.globals.initialConfig.series[0].data).toEqual([1, 2, 3])
+  })
+})

--- a/tests/unit/initial-config-hidden-series.spec.js
+++ b/tests/unit/initial-config-hidden-series.spec.js
@@ -47,6 +47,53 @@ describe('initialConfig with a hidden series', () => {
     )
   })
 
+  it('does not re-alias the live config when updateSeries redefines it', async () => {
+    const chart = chartWith(SERIES)
+
+    await chart.updateSeries([
+      { name: 'A', data: [7, 8, 9] },
+      { name: 'B', data: [10, 11, 12] },
+    ])
+
+    // This capture site used to assign w.config.series itself, which restored
+    // the alias Globals.init no longer makes.
+    expect(chart.w.globals.initialConfig.series).not.toBe(chart.w.config.series)
+    expect(chart.w.globals.initialConfig.series[0]).not.toBe(
+      chart.w.config.series[0],
+    )
+  })
+
+  it('keeps a collapsed series intact when updateOptions redefines the series', async () => {
+    const chart = chartWith(SERIES)
+    chart.hideSeries('B')
+
+    await chart.updateOptions({
+      series: [
+        { name: 'A', data: [7, 8, 9] },
+        { name: 'B', data: [10, 11, 12] },
+      ],
+    })
+
+    // The call redefines the series, so the baseline moves — to what was
+    // passed in, not to the collapse-emptied version of it.
+    expect(chart.w.globals.initialConfig.series[1].data).toEqual([10, 11, 12])
+  })
+
+  it('captures initialConfig.series in the same shape as initialSeries', () => {
+    const chart = chartWith(SERIES)
+    const { globals, config } = chart.w
+
+    // Series objects copied, data arrays shared — both snapshots, one helper.
+    // _initialSeriesPeek is the lazy snapshot's non-materializing view.
+    for (const snapshot of [
+      globals._initialSeriesPeek,
+      globals.initialConfig.series,
+    ]) {
+      expect(snapshot[0]).not.toBe(config.series[0])
+      expect(snapshot[0].data).toBe(config.series[0].data)
+    }
+  })
+
   it('still records what the chart started with', () => {
     const chart = chartWith(SERIES)
 


### PR DESCRIPTION
Fixes #5118. The report points straight at `Series.js`, and that turned out to be the symptom rather than the cause: `globals.initialConfig` was never a snapshot at all.

### Why it emptied

`Utils.extend()` copies arrays by reference, because `isObject()` excludes them:

```js
static isObject(item) {
  return item && typeof item === 'object' && !Array.isArray(item)
}
```

So `globals.initialConfig = Utils.extend({}, config)` left `initialConfig.series === config.series`, the very same array of the very same objects. A legend collapse replaces `series[i].data` with `[]` in place, and the "initial" config lost the data along with the live one.

Fixing only that is not enough. `updateOptions()` re-captures the snapshot from `w.config`, which by then carries the collapse state, so an unrelated option change baked the emptied series back into the baseline. That capture now moves only when the call actually redefines the series; a plain `updateOptions({title})` keeps the baseline it already had.

The copy is per-series and shallow — series objects copied, data arrays shared — the same shape `globals.initialSeries` already captures. Internal edits to a series' data are property *replacements* (`series[i].data = []`, or `series[i] = 0` for non-axis charts) and neither can reach a copy made this way, so snapshotting stays O(n) instead of deep-cloning every point. That keeps the ~23ms-per-50k-update budget the lazy `initialSeries` snapshot was built to protect.

### Evidence

New spec `tests/unit/initial-config-hidden-series.spec.js`, 4 tests. On `main` (b0dc6af), with the spec and without the `src/` change:

```
✓ keeps the hidden series data after hideSeries
× keeps the hidden series data across updateOptions
    AssertionError: expected [] to deeply equal [ 4, 5, 6 ]
× does not share series objects with the live config
    AssertionError: expected [ { name: 'A', …(2) }, …(1) ] not to be [ { name: 'A', …(2) }, …(1) ] // Object.is equality
✓ still records what the chart started with
```

Each half of the fix was then reverted on its own, to confirm neither test is vacuous:

| reverted | failing test |
|---|---|
| `Globals.js` capture only | does not share series objects with the live config |
| `UpdateHelpers.js` capture only | keeps the hidden series data across updateOptions |
| neither | 4 passed |

Full unit suite: **134 files, 3180 tests, 0 failures.** `npm run lint` clean. `npm run typecheck` reports the same 23 pre-existing `Drilldown.js` errors as `main` — the two `NonNullable<...>` casts are there to keep that number from moving.

Prettier: pre-existing deviations left alone, as on #5277. `prettier --write` on the touched files moves only `Utils.js:432`, `UpdateHelpers.js:185`, `UpdateHelpers.js:304` and `UpdateHelpers.js:437`, none of which are lines this PR adds.

### Not included

`globals.initialSeries` is also refreshed from the live config during a collapse-driven re-render, so it carries the emptied series too. Nothing in this PR depends on that, `resetSeries` clears the collapsed indices before restoring, and it predates this change — mentioning it here rather than widening the diff.
