### PR TITLE
test(data): cover the null and undefined x the same guard un-breaks

### DIFF
--- a/tests/unit/date-x-edge-cases.spec.js
+++ b/tests/unit/date-x-edge-cases.spec.js
@@ -103,3 +103,62 @@ describe('an invalid Date as x', () => {
     ).not.toThrow()
   })
 })
+
+// The same guard un-breaks a null or undefined x, which threw from that same
+// line and is the more common way to hit it: a gap in a data set is spelt
+// `null` far more often than a Date is built from garbage. Without the guard
+// `[{x: 1}, {x: null}, {x: 3}]` renders nothing at all.
+describe('a null or undefined x', () => {
+  function dt() {
+    const chart = createChart(
+      'line',
+      [{ name: 'n', data: [{ x: 1, y: 1 }] }],
+      'numeric',
+    )
+    return new DateTime(chart.w)
+  }
+
+  it('makes isValidDate answer false rather than throw', () => {
+    const d = dt()
+
+    expect(() => d.isValidDate(null)).not.toThrow()
+    expect(() => d.isValidDate(undefined)).not.toThrow()
+    expect(d.isValidDate(null)).toBe(false)
+    expect(d.isValidDate(undefined)).toBe(false)
+  })
+
+  it('leaves the points around the gap where they were', () => {
+    const [seriesX] = parsedX(
+      [
+        {
+          name: 'gap',
+          data: [
+            { x: 1, y: 1 },
+            { x: null, y: 2 },
+            { x: 3, y: 3 },
+          ],
+        },
+      ],
+      'category',
+    )
+
+    expect(seriesX).toEqual([1, null, 3])
+  })
+
+  it('does not take the render down', () => {
+    expect(() =>
+      parsedX(
+        [
+          {
+            name: 'gap',
+            data: [
+              { x: 1, y: 1 },
+              { x: undefined, y: 2 },
+            ],
+          },
+        ],
+        'category',
+      ),
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
Follow-up to #5279, tests only, no `src/` change.

You pointed out that the guard there also un-breaks `null` and `undefined` x values, and that it was the one thing in the PR with no test on it. You were right on both counts, and it is the more common case: a gap in a data set is spelt `null` far more often than a `Date` is built from garbage.

Reverting the guard on this branch, all three new assertions go red:

```
AssertionError: expected [Function] to not throw an error but
  'TypeError: Cannot read properties of null (reading 'replace')' was thrown
AssertionError: expected [Function] to not throw an error but
  'TypeError: Cannot read properties of undefined (reading 'replace')' was thrown
```

`Tests 5 failed | 3 passed (8)` with the guard reverted, `8 passed` with it in place. The 5 are the 2 from #5279 plus these 3, so neither set is vacuous.

What the render does, measured rather than assumed. Without the guard, `[{x: 1}, {x: null}, {x: 3}]` gives 0 `.apexcharts-line` paths and 0 x axis labels. With it, 1 path and labels `1, 2, 3`.

Full unit suite: **136 files, 3257 tests, 0 failures.** `npm run lint` clean. `npm run typecheck` still 23 errors, all pre-existing in `Drilldown.js`. `prettier --write` on the spec touched only one block this PR adds, and that reformat is included.