### PR TITLE
fix: restore Hidden Series on Reset

### DIFF
--- a/src/apexcharts.js
+++ b/src/apexcharts.js
@@ -1011,6 +1011,9 @@ export default class ApexCharts {
    */
   appendData(newData, overwriteInitialSeries = true) {
     const me = this
+    const initialSeries = overwriteInitialSeries
+      ? undefined
+      : me.w.globals.initialSeries
 
     me.data.resetParsingFlags()
     me.w.globals.dataChanged = true
@@ -1046,7 +1049,9 @@ export default class ApexCharts {
           }
         }
       }
-      return this.update()
+      const updated = this.update()
+      if (!overwriteInitialSeries) me.w.globals.initialSeries = initialSeries
+      return updated
     }
 
     const newSeries = me.w.config.series.slice()
@@ -1073,7 +1078,9 @@ export default class ApexCharts {
       me.w.globals.initialSeries = me.w.config.series
     }
 
-    return this.update()
+    const updated = this.update()
+    if (!overwriteInitialSeries) me.w.globals.initialSeries = initialSeries
+    return updated
   }
 
   /**

--- a/src/modules/legend/Helpers.js
+++ b/src/modules/legend/Helpers.js
@@ -339,6 +339,7 @@ export default class Helpers {
   /** @param {{seriesEl: any, realIndex: any}} opts */
   hideSeries({ seriesEl, realIndex }) {
     const w = this.w
+    const initialSeries = w.globals._initialSeriesPeek
 
     const series = this.getSeriesAfterCollapsing({
       realIndex,
@@ -371,6 +372,7 @@ export default class Helpers {
       w.globals.collapsingSeriesIndices = []
     }
     const updated = this.lgCtx.updateSeries(series, animate)
+    w.globals.initialSeries = initialSeries
     // The render is synchronous inside updateSeries, so the flag has already
     // done its job by the time this returns; the promise arm is the guard for
     // any path that defers.

--- a/src/modules/settings/Globals.js
+++ b/src/modules/settings/Globals.js
@@ -558,12 +558,10 @@ export default class Globals {
    * data array. Re-capturing after it does not undo that: the pushed points
    * are already in the array both snapshots point at, so a snapshot taken
    * before the append reads back as appended. That is the documented
-   * behaviour of appendData(overwriteInitialSeries = true), and the `false`
-   * case is not honoured for a separate, older reason: Data.parseData()
-   * re-captures initialSeries unconditionally on the re-render appendData
-   * triggers. Detaching would mean copying the data arrays, which is exactly
-   * the per-point cost this snapshot exists to avoid. The same exception
-   * applies to `initialConfig.series`, which is captured with the same shape.
+   * behaviour of appendData(overwriteInitialSeries = true). The opt-out path
+   * materializes the lazy snapshot before mutating so it can restore it after
+   * the re-render. The same exception applies to `initialConfig.series`, which
+   * is captured with the same shape.
    *
    * @param {Record<string, any>} globals
    */

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -80,10 +80,9 @@ class Utils {
   // `series[i] = 0` for non-axis charts), and those cannot reach a copy made
   // this way because the series object was copied at capture time. The
   // exception is appendData(), whose push loop grows the shared data array in
-  // place, so a copy taken before it does see the appended points; see the
-  // note above defineLazyInitialSeries(). This is the same cheap shape
-  // `globals.initialSeries` captures, so snapshotting a config stays O(n)
-  // instead of deep-cloning every point.
+  // place; its opt-out path materializes the snapshot before appending. This is
+  // the same cheap shape `globals.initialSeries` captures, so snapshotting a
+  // config stays O(n) instead of deep-cloning every point.
   /**
    * @param {any} series
    */

--- a/tests/interaction/specs/reset-series-zoom.spec.js
+++ b/tests/interaction/specs/reset-series-zoom.spec.js
@@ -119,3 +119,20 @@ test('resetSeries() matches the toolbar reset button after a drag zoom', async (
 
   expect(viaResetSeries).toEqual(viaToolbar)
 })
+
+test('resetSeries() restores a hidden series', async ({ page, loadChart }) => {
+  await loadChart(CHART, FIXTURE)
+
+  const result = await page.evaluate(async () => {
+    const data = window.chart.w.config.series[0].data.slice()
+    await window.chart.updateSeries([
+      { name: 'A', data },
+      { name: 'B', data: data.map((point) => [...point]) },
+    ])
+    window.chart.hideSeries('B')
+    await window.chart.resetSeries()
+    return { expected: data, restored: window.chart.w.config.series[1].data }
+  })
+
+  expect(result.restored).toEqual(result.expected)
+})

--- a/tests/unit/initial-config-hidden-series.spec.js
+++ b/tests/unit/initial-config-hidden-series.spec.js
@@ -29,6 +29,24 @@ describe('initialConfig with a hidden series', () => {
     expect(chart.w.globals.initialConfig.series[1].data).toEqual([4, 5, 6])
   })
 
+  it('restores a hidden series on resetSeries', () => {
+    const chart = chartWith(SERIES)
+
+    chart.hideSeries('B')
+    chart.resetSeries(false)
+
+    expect(chart.w.config.series[1].data).toEqual([4, 5, 6])
+  })
+
+  it('preserves the baseline when appendData opts out of overwriting it', async () => {
+    const chart = chartWith(SERIES)
+
+    await chart.appendData([{ data: [7] }, { data: [8] }], false)
+
+    expect(chart.w.globals.initialSeries[0].data).toEqual([1, 2, 3])
+    expect(chart.w.globals.initialSeries[1].data).toEqual([4, 5, 6])
+  })
+
   it('keeps the hidden series data across updateOptions', async () => {
     const chart = chartWith(SERIES)
     chart.hideSeries('B')


### PR DESCRIPTION
# New Pull Request

## Summary

Preserve the original series snapshot while hiding a series, allowing
`resetSeries()` to restore its data. Also preserve the snapshot when
`appendData(..., false)` explicitly opts out of overwriting it.

This fixes a regression where `parseData()` captured live, mutated series data
during re-rendering. A hidden series therefore replaced its reset baseline with
an empty data array.

No new dependencies.

Fixes #5283

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added unit regressions for hidden-series reset and `appendData(..., false)`.
- Added Chromium E2E coverage for `hideSeries()` followed by `resetSeries()`.
- Relevant unit tests: 38 passed.
- Relevant browser tests: 3 passed.
- Build and ESLint passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch
