### PR TITLE
fix: fix Grouped Sparkline Tooltip Synchronization

### DIFF
--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -61,8 +61,18 @@ class Intersect {
 
     if (canvasCells) {
       const seriesBound = opt.elGrid.getBoundingClientRect()
-      const clientX = e.type === 'touchmove' ? e.touches[0].clientX : e.clientX
-      const clientY = e.type === 'touchmove' ? e.touches[0].clientY : e.clientY
+      // `opt.elGrid` is THIS chart's grid, so the pointer has to be this
+      // chart's too. In a group the event belongs to whichever sibling was
+      // hovered, and `seriesHover` hands down the pointer already translated
+      // into each member's own space; pairing the raw event with a sibling's
+      // grid puts the hit test a whole chart-width off and every sibling
+      // resolves to "no cell".
+      const clientX =
+        opt.clientX ??
+        (e.type === 'touchmove' ? e.touches[0].clientX : e.clientX)
+      const clientY =
+        opt.clientY ??
+        (e.type === 'touchmove' ? e.touches[0].clientY : e.clientY)
       const hit = renderer.hitTest(
         clientX - seriesBound.left,
         clientY - seriesBound.top,

--- a/src/modules/tooltip/Position.js
+++ b/src/modules/tooltip/Position.js
@@ -301,14 +301,18 @@ export default class Position {
       if (!elGrid) return null
       const seriesBound = elGrid.getBoundingClientRect()
 
-      x = ttCtx.e.clientX - seriesBound.left
+      // Same pairing rule as the canvas hit test in Intersect: `seriesBound` is
+      // this chart's own grid, so measure from this chart's pointer. `ttCtx.e`
+      // is the raw event and in a group it belongs to the hovered sibling, so
+      // on its own it would place the box a chart-width outside the plot.
+      x = (ttCtx.clientX ?? ttCtx.e.clientX) - seriesBound.left
       if (x > w.layout.gridWidth / 2) {
         x = x - ttW
         placement = 'left'
       } else {
         placement = 'right'
       }
-      y = ttCtx.e.clientY + w.layout.translateY - seriesBound.top
+      y = (ttCtx.clientY ?? ttCtx.e.clientY) + w.layout.translateY - seriesBound.top
       if (y > w.layout.gridHeight / 2) {
         y = y - ttH
       }

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -770,15 +770,33 @@ export default class Tooltip {
        */
       chartGroups.forEach((ch) => {
         const tooltipEl = this.getElTooltip(ch)
+        const elGrid = ch.w.globals.tooltip.getElGrid()
+        const sourceRect = opt.elGrid?.getBoundingClientRect()
+        const targetRect = elGrid?.getBoundingClientRect()
+        const pointer = e.type === 'touchmove' ? e.touches[0] : e
+        const clientX =
+          sourceRect && targetRect
+            ? targetRect.left +
+              ((pointer.clientX - sourceRect.left) / sourceRect.width) *
+                targetRect.width
+            : pointer.clientX
+        const clientY =
+          sourceRect && targetRect
+            ? targetRect.top +
+              ((pointer.clientY - sourceRect.top) / sourceRect.height) *
+                targetRect.height
+            : pointer.clientY
 
         const newOpts = {
           paths: opt.paths,
           tooltipEl,
           tooltipY: opt.tooltipY,
           tooltipX: opt.tooltipX,
-          elGrid: opt.elGrid,
-          hoverArea: opt.hoverArea,
+          elGrid: elGrid || opt.elGrid,
+          hoverArea: ch.w.dom.Paper?.node || opt.hoverArea,
           ttItems: ch.w.globals.tooltip.ttItems,
+          clientX,
+          clientY,
         }
 
         // all the charts should have the same minX and maxX (same xaxis) for multiple tooltips to work correctly
@@ -868,8 +886,12 @@ export default class Tooltip {
 
     const seriesBound = opt.elGrid.getBoundingClientRect()
 
-    const clientX = e.type === 'touchmove' ? e.touches[0].clientX : e.clientX
-    const clientY = e.type === 'touchmove' ? e.touches[0].clientY : e.clientY
+    const clientX =
+      opt.clientX ??
+      (e.type === 'touchmove' ? e.touches[0].clientX : e.clientX)
+    const clientY =
+      opt.clientY ??
+      (e.type === 'touchmove' ? e.touches[0].clientY : e.clientY)
 
     this.clientY = clientY
     this.clientX = clientX

--- a/src/modules/tooltip/Tooltip.js
+++ b/src/modules/tooltip/Tooltip.js
@@ -765,15 +765,15 @@ export default class Tooltip {
     }
 
     if (chartGroups.length) {
+      const sourceRect = opt.elGrid?.getBoundingClientRect()
+      const pointer = e.type === 'touchmove' ? e.touches[0] : e
       /**
        * @param {Record<string, any>} ch
        */
       chartGroups.forEach((ch) => {
         const tooltipEl = this.getElTooltip(ch)
         const elGrid = ch.w.globals.tooltip.getElGrid()
-        const sourceRect = opt.elGrid?.getBoundingClientRect()
         const targetRect = elGrid?.getBoundingClientRect()
-        const pointer = e.type === 'touchmove' ? e.touches[0] : e
         const clientX =
           sourceRect && targetRect
             ? targetRect.left +
@@ -793,7 +793,7 @@ export default class Tooltip {
           tooltipY: opt.tooltipY,
           tooltipX: opt.tooltipX,
           elGrid: elGrid || opt.elGrid,
-          hoverArea: ch.w.dom.Paper?.node || opt.hoverArea,
+          hoverArea: opt.hoverArea,
           ttItems: ch.w.globals.tooltip.ttItems,
           clientX,
           clientY,

--- a/tests/interaction/specs/grouped-pointer-translation.spec.js
+++ b/tests/interaction/specs/grouped-pointer-translation.spec.js
@@ -1,0 +1,229 @@
+/**
+ * Grouped charts: every member resolves the pointer in ITS OWN space.
+ *
+ * `Tooltip.seriesHover` fans a hover out to every chart in the group, handing
+ * each member its own grid plus the pointer translated into that grid. The
+ * rule that keeps the fan-out honest is a pairing rule: wherever a coordinate
+ * is measured against a chart's own grid rect, it has to be measured from that
+ * chart's translated pointer, never from the raw event, which belongs to
+ * whichever sibling the cursor is actually over.
+ *
+ * Two consumers read a pointer against the grid outside the shared/sticky path
+ * that `syncing-charts.spec.js` covers, and neither is exercised by the
+ * side-by-side sparkline case:
+ *
+ *   1. the canvas heatmap hit test (`Intersect.handleHeatTreeTooltip`), which
+ *      converts to grid-local pixels and asks the renderer which cell is under
+ *      them. Pair it wrongly and the sibling resolves to "no cell", so its
+ *      tooltip is hidden entirely rather than merely mispositioned.
+ *   2. `followCursor` placement (`Position.js`), which anchors the box to the
+ *      pointer. Pair it wrongly and the box lands outside the sibling's plot.
+ *
+ * Both are asserted here because both are invisible to the rest of the suite:
+ * the canvas renderer is not in the default bundle, and no existing spec puts
+ * `followCursor` in a group.
+ */
+
+import { test, expect } from '../fixtures/base.js'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = resolve(__dirname, '..', '..', '..')
+
+// Sub-pixel tolerance for comparing two charts' box offsets.
+const TOLERANCE_PX = 1
+
+/** Two heatmaps side by side in one group, sharing an x domain. */
+async function buildGroupedHeatmaps(page, { renderer }) {
+  await page.evaluate(
+    async ({ renderer }) => {
+      window.chart.destroy()
+      document.body.innerHTML =
+        '<div style="display:flex"><div id="hm-a"></div><div id="hm-b"></div></div>'
+
+      const series = (seed) =>
+        ['R1', 'R2', 'R3'].map((name, si) => ({
+          name,
+          data: Array.from({ length: 8 }, (_, i) => ({
+            x: 'C' + i,
+            y: ((i * 7 + si * 3 + seed) % 20) + 1,
+          })),
+        }))
+
+      const options = (id, seed) => ({
+        chart: {
+          id,
+          group: 'hm',
+          type: 'heatmap',
+          width: 320,
+          height: 220,
+          animations: { enabled: false },
+          renderer,
+          // Force the renderer choice rather than waiting for the point count
+          // to cross the default threshold.
+          rendererThreshold: 1,
+        },
+        series: series(seed),
+        dataLabels: { enabled: false },
+      })
+
+      window.hmA = new ApexCharts(document.querySelector('#hm-a'), options('hm-a', 0))
+      window.hmB = new ApexCharts(document.querySelector('#hm-b'), options('hm-b', 5))
+      await Promise.all([window.hmA.render(), window.hmB.render()])
+    },
+    { renderer },
+  )
+  // A canvas heatmap paints its cells instead of animating them in, so it never
+  // raises `animationEnded`. Wait on the renderer being live in both charts,
+  // which is the state this test actually needs.
+  await page.waitForFunction(
+    () =>
+      !!window.hmA?.w.globals.activeRenderer &&
+      !!window.hmB?.w.globals.activeRenderer,
+    { timeout: 10_000 },
+  )
+}
+
+/** Which cell each member of the group thinks is hovered. */
+function readCapturedCells(page) {
+  return page.evaluate(() => ({
+    a: {
+      i: window.hmA.w.interact.capturedSeriesIndex,
+      j: window.hmA.w.interact.capturedDataPointIndex,
+    },
+    b: {
+      i: window.hmB.w.interact.capturedSeriesIndex,
+      j: window.hmB.w.interact.capturedDataPointIndex,
+    },
+    bActive: !!document.querySelector('#hm-b .apexcharts-tooltip.apexcharts-active'),
+    bText: (
+      document.querySelector('#hm-b .apexcharts-tooltip')?.textContent || ''
+    ).trim(),
+  }))
+}
+
+test.describe('Grouped charts translate the pointer per member', () => {
+  test('a canvas heatmap sibling resolves the same cell as the hovered one', async ({
+    page,
+    loadChart,
+  }) => {
+    await loadChart('heatmap', 'basic')
+    // The canvas renderer is an opt-in feature, not part of the default bundle
+    // the samples load, so pull it in explicitly.
+    await page.addScriptTag({
+      path: resolve(rootDir, 'dist', 'features', 'renderer-canvas.js'),
+    })
+    await buildGroupedHeatmaps(page, { renderer: 'canvas' })
+
+    const kinds = await page.evaluate(() => ({
+      a: window.hmA.w.globals.activeRenderer?.kind,
+      b: window.hmB.w.globals.activeRenderer?.kind,
+    }))
+    // Guard the guard: if the feature stops loading, this test would otherwise
+    // pass as an SVG heatmap and quietly stop covering the canvas path.
+    expect(kinds, 'expected both charts on the canvas renderer').toEqual({
+      a: 'canvas',
+      b: 'canvas',
+    })
+
+    const box = await page.locator('#hm-a .apexcharts-svg').boundingBox()
+    await page.mouse.move(box.x + box.width * 0.72, box.y + box.height * 0.55)
+    await page.waitForTimeout(150)
+
+    const captured = await readCapturedCells(page)
+
+    expect(captured.a.i, 'the hovered chart resolved no cell').toBeGreaterThan(-1)
+    // The two charts share an x domain and identical geometry, so the sibling
+    // must land on the same cell rather than off the plot.
+    expect(
+      captured.b,
+      'the sibling resolved a different cell than the hovered chart',
+    ).toEqual(captured.a)
+    expect(captured.bActive, 'the sibling tooltip is hidden').toBe(true)
+    expect(captured.bText, 'the sibling tooltip is empty').not.toBe('')
+  })
+
+  test('followCursor anchors each member inside its own plot', async ({
+    page,
+    loadChart,
+  }) => {
+    await loadChart('line', 'syncing-charts')
+    await page.evaluate(async () => {
+      window.chart.destroy()
+      window.chartLine2.destroy()
+      window.chartArea.destroy()
+      document.body.innerHTML =
+        '<div style="display:flex"><div id="fc-a"></div><div id="fc-b"></div></div>'
+
+      const options = (id, data) => ({
+        chart: {
+          id,
+          group: 'fc',
+          type: 'line',
+          width: 320,
+          height: 200,
+          animations: { enabled: false },
+        },
+        series: [{ name: 's', data }],
+        tooltip: { followCursor: true },
+        xaxis: { categories: data.map((_, i) => 'p' + i) },
+      })
+
+      window.fcA = new ApexCharts(
+        document.querySelector('#fc-a'),
+        options('fc-a', [10, 41, 35, 51, 49, 62, 69, 91, 148]),
+      )
+      window.fcB = new ApexCharts(
+        document.querySelector('#fc-b'),
+        options('fc-b', [22, 15, 60, 30, 44, 12, 80, 33, 70]),
+      )
+      await Promise.all([window.fcA.render(), window.fcB.render()])
+    })
+    await page.waitForFunction(
+      () =>
+        window.fcA?.w.globals.animationEnded === true &&
+        window.fcB?.w.globals.animationEnded === true,
+      { timeout: 10_000 },
+    )
+
+    const grid = await page.locator('#fc-a .apexcharts-grid').boundingBox()
+    await page.mouse.move(grid.x + grid.width * 0.7, grid.y + grid.height / 2)
+    await page.waitForTimeout(150)
+
+    const boxes = await page.evaluate(() => {
+      const read = (id) => {
+        const tooltip = document.querySelector(`${id} .apexcharts-tooltip`)
+        const gridRect = document
+          .querySelector(`${id} .apexcharts-grid`)
+          .getBoundingClientRect()
+        const rect = tooltip.getBoundingClientRect()
+        return {
+          // Offset of the box inside its OWN plot: the number that has to match
+          // across members, since the absolute positions never can.
+          offsetInGrid: rect.left - gridRect.left,
+          gridWidth: gridRect.width,
+          text: tooltip.textContent.trim(),
+        }
+      }
+      return { a: read('#fc-a'), b: read('#fc-b') }
+    })
+
+    expect(boxes.a.text, 'the hovered chart tooltip is empty').not.toBe('')
+    expect(boxes.b.text, 'the sibling tooltip is empty').not.toBe('')
+
+    // The charts are the same size and share an x domain, so the sibling's box
+    // sits at the same offset inside its own plot as the hovered chart's.
+    expect(
+      Math.abs(boxes.b.offsetInGrid - boxes.a.offsetInGrid),
+      'the sibling box is not at the same offset inside its own plot',
+    ).toBeLessThanOrEqual(TOLERANCE_PX)
+
+    // Stated directly, since the offset comparison alone would be satisfied by
+    // both boxes being outside their plots by the same amount.
+    expect(
+      boxes.b.offsetInGrid,
+      'the sibling box is left of its own plot',
+    ).toBeGreaterThanOrEqual(-TOLERANCE_PX)
+  })
+})

--- a/tests/interaction/specs/syncing-charts.spec.js
+++ b/tests/interaction/specs/syncing-charts.spec.js
@@ -70,4 +70,59 @@ test.describe('Synchronized charts tooltip sync', () => {
     expect(active).toContain('#chart-line2') // the hovered chart itself
     expect(active).toHaveLength(3)
   })
+
+  test('side-by-side sparklines translate the pointer into each chart', async ({
+    page,
+    loadChart,
+  }) => {
+    await loadChart('line', 'syncing-charts')
+    await page.evaluate(async () => {
+      window.chart.destroy()
+      window.chartLine2.destroy()
+      window.chartArea.destroy()
+      document.body.innerHTML =
+        '<div style="display:flex"><div id="spark-a"></div><div id="spark-b"></div></div>'
+
+      const options = (id, data) => ({
+        chart: {
+          id,
+          group: 'sparks',
+          type: 'line',
+          width: 300,
+          height: 80,
+          sparkline: { enabled: true },
+          animations: { enabled: false },
+        },
+        series: [{ data }],
+        grid: { padding: { left: 110 } },
+        markers: { size: 0 },
+      })
+
+      window.sparkA = new ApexCharts(
+        document.querySelector('#spark-a'),
+        options('spark-a', [25, 66, 41, 59, 25, 44, 12, 36, 9, 21]),
+      )
+      window.sparkB = new ApexCharts(
+        document.querySelector('#spark-b'),
+        options('spark-b', [12, 14, 2, 47, 32, 44, 14, 55, 41, 69]),
+      )
+      await Promise.all([window.sparkA.render(), window.sparkB.render()])
+    })
+
+    const box = await page.locator('#spark-a .apexcharts-svg').boundingBox()
+    await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2)
+    await page.waitForTimeout(80)
+
+    for (const id of ['#spark-a', '#spark-b']) {
+      await expect(page.locator(`${id} .apexcharts-tooltip`)).not.toHaveText('')
+      await expect(page.locator(`${id} .apexcharts-xcrosshairs`)).toHaveClass(
+        /apexcharts-active/,
+      )
+    }
+    const indices = await page.evaluate(() => [
+      window.sparkA.w.interact.capturedDataPointIndex,
+      window.sparkB.w.interact.capturedDataPointIndex,
+    ])
+    expect(indices[1]).toBe(indices[0])
+  })
 })


### PR DESCRIPTION
# New Pull Request

## Summary

Translate pointer coordinates from the hovered chart into each grouped chart's
local grid. This keeps tooltips and crosshairs synchronized when sparkline
charts appear side by side.

Previously, sibling charts received the source chart's absolute pointer
coordinates and grid element. They interpreted the pointer outside their own
plot, producing empty tooltips and edge artifacts.

No new dependencies.

Fixes #5282

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added Chromium E2E coverage for side-by-side grouped sparklines.
- Existing grouped-chart E2E still passes.
- Relevant unit tests: 74 passed.
- Build and ESLint passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch