### PR TITLE
feat(locales): add Azerbaijani (az) locale

### DIFF
--- a/src/locales/az.json
+++ b/src/locales/az.json
@@ -1,0 +1,56 @@
+{
+  "name": "az",
+  "options": {
+    "months": [
+      "Yanvar",
+      "Fevral",
+      "Mart",
+      "Aprel",
+      "May",
+      "İyun",
+      "İyul",
+      "Avqust",
+      "Sentyabr",
+      "Oktyabr",
+      "Noyabr",
+      "Dekabr"
+    ],
+    "shortMonths": [
+      "Yan",
+      "Fev",
+      "Mar",
+      "Apr",
+      "May",
+      "İyn",
+      "İyl",
+      "Avq",
+      "Sen",
+      "Okt",
+      "Noy",
+      "Dek"
+    ],
+    "days": [
+      "Bazar",
+      "Bazar ertəsi",
+      "Çərşənbə axşamı",
+      "Çərşənbə",
+      "Cümə axşamı",
+      "Cümə",
+      "Şənbə"
+    ],
+    "shortDays": ["Baz", "BzE", "ÇAx", "Çər", "CAx", "Cüm", "Şən"],
+    "toolbar": {
+      "exportToSVG": "SVG Yüklə",
+      "exportToPNG": "PNG Yüklə",
+      "exportToCSV": "CSV Yüklə",
+      "menu": "Menyu",
+      "selection": "Seçim",
+      "selectionZoom": "Seçimi Yaxınlaşdır",
+      "zoomIn": "Yaxınlaşdır",
+      "zoomOut": "Uzaqlaşdır",
+      "pan": "Sürüşdürmə",
+      "reset": "Yaxınlaşdırmanı Sıfırla",
+      "measure": "Ölçmə"
+    }
+  }
+}


### PR DESCRIPTION
Adds an Azerbaijani (`az`) locale following the same structure as `src/locales/en.json`: full and short month names, full and short day names, and toolbar labels (export, menu, selection, zoom, pan, reset, measure).

No other files were changed — `dist/locales/` is rebuilt from `src/locales/` at release time (not per-PR), matching the pattern of the last single-locale addition (Galician, #5096).

**Verification**

- Key structure identical to `en.json` — 0 missing, 0 extra, same order.
- 12 / 12 month names, 12 / 12 short months, 7 / 7 day names, 7 / 7 short days.
- Month and day names use standard Azerbaijani orthography, Latin script.
