### PR TITLE
fix(tooltip): keep heatmap and treemap tooltips inside the plot area

### DIFF
--- a/src/modules/tooltip/Intersect.js
+++ b/src/modules/tooltip/Intersect.js
@@ -198,6 +198,22 @@ class Intersect {
         (y > w.layout.gridHeight / 2 ? ttCtx.tooltipRect.ttHeight : 0)
     }
 
+    // A label wider than the space beside the cell pushes the box out of the
+    // plot area — on a narrow screen it then hangs off the viewport and the
+    // text is unreadable. Clamp it back into the plot area horizontally, the
+    // same way the arrow-mode path above does.
+    const ttWidth = ttCtx.tooltipRect.ttWidth || 0
+    const elGridRect = opt.elGrid
+      ? opt.elGrid.getBoundingClientRect()
+      : null
+    const gridLeft = elGridRect
+      ? elGridRect.left - w.dom.elWrap.getBoundingClientRect().left
+      : w.layout.translateX
+    const gridRight = gridLeft + w.layout.gridWidth
+
+    if (x + ttWidth > gridRight) x = gridRight - ttWidth
+    if (x < gridLeft) x = gridLeft
+
     return {
       x,
       y,

--- a/tests/interaction/specs/treemap-tooltip-bounds.spec.js
+++ b/tests/interaction/specs/treemap-tooltip-bounds.spec.js
@@ -1,0 +1,96 @@
+/**
+ * Treemap tooltip — stays inside the plot area.
+ *
+ * A treemap tooltip uses the legacy beside-the-cell placement, which offsets
+ * the box by its own width. With a long label on a narrow chart that offset
+ * pushes the box past the left edge of the plot area, so most of the text ends
+ * up off-screen (issue #5121). The placement is now clamped horizontally, the
+ * same way the arrow-mode heatmap path is.
+ */
+
+import { test, expect } from '../fixtures/base.js'
+
+// Narrow viewport so the tooltip is wider than the space beside a cell.
+test.use({ viewport: { width: 420, height: 700 } })
+
+const LONG_LABELS = [
+  { x: 'Alphabet Incorporated Class A', y: 218 },
+  { x: 'Microsoft Corporation Holdings', y: 149 },
+  { x: 'International Business Machines', y: 184 },
+  { x: 'Advanced Micro Devices Included', y: 55 },
+  { x: 'Amazon Web Services Global Unit', y: 84 },
+  { x: 'Meta Platforms Incorporated Ltd', y: 31 },
+]
+
+/** Replace the sample data with labels long enough to overflow. */
+async function useLongLabels(page) {
+  await page.evaluate((data) => {
+    window.chart.updateSeries([{ data }])
+  }, LONG_LABELS)
+  await page.waitForFunction(
+    () => window.chart.w.globals.animationEnded === true,
+    { timeout: 5_000 },
+  )
+}
+
+/** Tooltip box and plot-area bounds, in viewport coordinates. */
+async function readBounds(page) {
+  return page.evaluate(() => {
+    const tt = document.querySelector('.apexcharts-tooltip')
+    const grid = document.querySelector('.apexcharts-inner')
+    const tr = tt.getBoundingClientRect()
+    const gr = grid.getBoundingClientRect()
+    return {
+      ttLeft: tr.left,
+      ttRight: tr.right,
+      ttWidth: tr.width,
+      gridLeft: gr.left,
+      gridRight: gr.right,
+      viewportWidth: window.innerWidth,
+    }
+  })
+}
+
+test.describe('Treemap tooltip bounds', () => {
+  test('never hangs off the left edge of the plot area', async ({
+    page,
+    loadChart,
+  }) => {
+    await loadChart('treemap', 'basic')
+    await useLongLabels(page)
+
+    const cells = page.locator('.apexcharts-treemap-rect')
+    const count = await cells.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let j = 0; j < count; j++) {
+      await cells.nth(j).hover({ force: true })
+      await page.waitForSelector('.apexcharts-tooltip.apexcharts-active', {
+        timeout: 3_000,
+      })
+
+      const b = await readBounds(page)
+
+      // The box is only clamped when it is narrower than the plot area; a
+      // tooltip wider than the chart itself cannot fit by definition.
+      if (b.ttWidth <= b.gridRight - b.gridLeft) {
+        // 1px tolerance for sub-pixel rounding of the CSS left offset.
+        expect(
+          b.ttLeft,
+          `cell ${j}: tooltip starts left of the plot area`,
+        ).toBeGreaterThanOrEqual(b.gridLeft - 1)
+        expect(
+          b.ttRight,
+          `cell ${j}: tooltip ends right of the plot area`,
+        ).toBeLessThanOrEqual(b.gridRight + 1)
+      }
+
+      // Whatever the width, the box must stay on screen.
+      expect(b.ttLeft, `cell ${j}: tooltip is off-screen`).toBeGreaterThanOrEqual(-1)
+
+      // Move away so the next hover re-fires the tooltip.
+      await page.mouse.move(2, 2)
+      await page.waitForTimeout(50)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #5121

## Problem

A treemap tooltip is placed beside the hovered cell by the legacy path in
`Intersect.handleHeatTreeTooltip`. That path offsets the box by its own width:

```js
x = cx + ttWidth / 2 + width
if (x > gridWidth / 2) {
  x = cx - ttWidth / 2 + width
}
```

When the label is long and the chart is narrow, `x` goes negative and the box
hangs off the left edge, so most of the text is unreadable. The arrow-mode
heatmap path a few lines above already clamps its placement into the plot area
(`finalX` bounds check), the legacy path does not.

## Measurement

Six-cell treemap, 350px chart in a 375px viewport, company names as labels.
Tooltip left edge relative to the viewport, before the fix:

| cell | tooltip left | tooltip right | result |
|---|---|---|---|
| 0 | 0 | 202 | inside |
| 1 | 2 | 200 | inside |
| 2 | -254 | 2 | off-screen by 254px |
| 3 | 2 | 230 | inside |
| 4 | -234 | 2 | off-screen by 234px |
| 5 | -226 | 2 | off-screen by 226px |

After the fix all six sit inside the plot area (left edge at the grid's left
bound, right edge well inside the viewport).

## Fix

Clamp the legacy placement horizontally at the end of the function, using the
same grid bounds the arrow-mode path uses. The clamp runs after the
`followCursor` branch so it covers that mode too.

Vertical placement is untouched: no vertical overflow showed up in the
measurement, so this stays a minimal change.

## Test

`tests/interaction/specs/treemap-tooltip-bounds.spec.js` hovers every cell of a
treemap in a 420px viewport with labels long enough to overflow, and asserts the
tooltip stays inside the plot area and on screen.

Verified both ways: the test fails on `main` without the source change and
passes with it.
