### PR TITLE
fix(selection): keep resize handles inside the data range

### DIFF
--- a/src/modules/ZoomPanSelection.js
+++ b/src/modules/ZoomPanSelection.js
@@ -21,6 +21,11 @@ const FRAME_MS_60FPS = 16.6667 // one frame at 60fps; normalizes friction to the
 // A pan nudge shifts the x-window by this fraction of the grid width.
 const PAN_NUDGE_DIVISOR = 15
 
+// Left edge of the x-domain in the plot-origin pixel space the selection rect
+// lives in. Under AxisMapping, minX maps to this pixel and maxX maps to
+// gridWidth, so the pair is the data boundary expressed in rect coordinates.
+const PLOT_ORIGIN_PX = 0
+
 /**
  * ApexCharts Zoom Class for handling zooming and panning on axes based charts.
  *
@@ -523,6 +528,11 @@ export default class ZoomPanSelection extends Toolbar {
         })
         .resize()
         .on('resize', () => {
+          // SVGSelectable moves a handle freely (its only guard is a negative
+          // width), so pull the rect back inside the x-domain before anything
+          // reads it. Without this a handle dragged past the first or last point
+          // keeps widening the rect into empty space (#5123).
+          this._clampSelectionRectToPlot()
           if (w.interact.selectionEnabled) {
             // A handle resize re-reports the selection through the SAME shared
             // mapping (and debounce) as the rect-body drag. The old path
@@ -657,6 +667,41 @@ export default class ZoomPanSelection extends Toolbar {
         Graphics.setAttrs(selectionRect.node, scalingAttrs)
       }
     }
+  }
+
+  /**
+   * Clamp the persistent selection rect to the pixel span the x-domain occupies,
+   * i.e. PLOT_ORIGIN_PX..gridWidth, which under AxisMapping is exactly
+   * minX..maxX. A body drag has always obeyed this box through `this.constraints`;
+   * this puts a handle resize on the same footing.
+   *
+   * The rect itself is rewritten rather than only the numbers reported to
+   * listeners, so the range every consumer receives keeps matching the rect the
+   * user sees (the one-mapping invariant selection-geometry.spec.js guards), and
+   * the handles are repositioned onto the clamped edge so a handle held past the
+   * boundary stays visually pinned there.
+   */
+  _clampSelectionRectToPlot() {
+    const rect = this.selectionRect
+    if (!rect || !rect.node) return
+
+    const maxPx = this.w.layout.gridWidth
+    // A domain with no pixel width (pre-layout, or a destroyed chart) has no
+    // meaningful boundary to clamp against.
+    if (!(maxPx > PLOT_ORIGIN_PX)) return
+
+    const x = parseFloat(rect.node.getAttribute('x')) || 0
+    const width = parseFloat(rect.node.getAttribute('width')) || 0
+
+    const clamp = (/** @type {number} */ px) =>
+      Math.min(Math.max(px, PLOT_ORIGIN_PX), maxPx)
+    const left = clamp(x)
+    const right = clamp(x + width)
+
+    if (left === x && right === x + width) return
+
+    rect.attr({ x: left, width: right - left })
+    if (rect._updateSelectPositions) rect._updateSelectPositions()
   }
 
   /**

--- a/tests/interaction/specs/brush-selection-bounds.spec.js
+++ b/tests/interaction/specs/brush-selection-bounds.spec.js
@@ -1,0 +1,213 @@
+/**
+ * Brush selection bounds (regression guard for apexcharts.js#5123).
+ *
+ * Dragging a selection handle past the first or last data point used to keep
+ * widening the rect into empty space: SVGSelectable moves a handle freely (its
+ * only guard is a negative width) and the resize listener in ZoomPanSelection
+ * read the resulting attributes without a bound. The brush then pushed that
+ * out-of-range window onto the target chart, which scrolled off the end of its
+ * own data.
+ *
+ * The x-domain occupies exactly 0..gridWidth pixels in the selection rect's
+ * coordinate space (see AxisMapping), so those two numbers are the data
+ * boundary in rect coordinates and every assertion below is expressed against
+ * them.
+ *
+ * Fixture: samples/vanilla-js/line/brush-charts.html
+ *   - window.chart     = target chart (chart2), driven by the brush
+ *   - window.chartLine = brush chart (chart1), owns the selection rect
+ */
+
+import { test, expect } from '../fixtures/base.js'
+import { getXRange } from '../helpers/chart.js'
+
+const CHART = 'line'
+const FIXTURE = 'brush-charts'
+
+// Handle order created by SVGSelectable: t, b, l, r, lt, rt, lb, rb.
+const HANDLE_INDEX = { l: 2, r: 3 }
+
+// A handle dragged this far past the plot edge is unambiguously out of range:
+// wide enough that an unclamped rect overshoots by hundreds of pixels, so the
+// test cannot pass by accident on a rounding difference.
+const OVERSHOOT_PX = 400
+
+// Geometry is compared to within a pixel's worth of data. Sub-pixel drift comes
+// from float rounding in the px<->data round trip, not from a missing bound.
+const TOLERANCE_PX = 1
+
+/** Wait until both charts in the brush sample have settled. */
+async function waitForBrushPair(page) {
+  await page.waitForFunction(
+    () =>
+      window.chart &&
+      window.chartLine &&
+      window.chart.w.globals.animationEnded === true &&
+      window.chartLine.w.globals.animationEnded === true,
+    { timeout: 10_000 },
+  )
+}
+
+/**
+ * Drag a selection resize handle horizontally.
+ *
+ * dragOnChart() cannot be reused here: it dispatches on `.apexcharts-svg`,
+ * whereas a handle drag starts with mousedown on the handle node and then moves
+ * on `document` (that is where SVGSelectable listens).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {'l'|'r'} which
+ * @param {number} dxPx signed horizontal distance
+ */
+async function dragSelectionHandle(page, which, dxPx) {
+  await page.evaluate(
+    ({ index, dxPx }) => {
+      const handle = window.chartLine.el.querySelectorAll(
+        '.svg_select_points > g',
+      )[index]
+      const box = handle.getBoundingClientRect()
+      const cx = box.left + box.width / 2
+      const cy = box.top + box.height / 2
+      const mouse = (type, x) =>
+        new MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: x,
+          clientY: cy,
+          button: 0,
+          buttons: 1,
+          which: 1,
+        })
+
+      handle.dispatchEvent(mouse('mousedown', cx))
+      const steps = 10
+      for (let i = 1; i <= steps; i++) {
+        document.dispatchEvent(mouse('mousemove', cx + (dxPx * i) / steps))
+      }
+      document.dispatchEvent(mouse('mouseup', cx + dxPx))
+    },
+    { index: HANDLE_INDEX[which], dxPx },
+  )
+  // The resize listener re-reports through a 30ms debounce, which then updates
+  // the target chart.
+  await page.waitForTimeout(400)
+}
+
+/** Selection rect geometry plus the data bounds it must stay inside. */
+function readSelectionBounds(page) {
+  return page.evaluate(() => {
+    const w = window.chartLine.w
+    const rect = window.chartLine.el.querySelector('.apexcharts-selection-rect')
+    const x = parseFloat(rect.getAttribute('x'))
+    const width = parseFloat(rect.getAttribute('width'))
+    const xRatio = (w.globals.maxX - w.globals.minX) / w.layout.gridWidth
+    return {
+      dataMinX: w.globals.minX,
+      dataMaxX: w.globals.maxX,
+      gridWidth: w.layout.gridWidth,
+      xRatio,
+      rectLeftPx: x,
+      rectRightPx: x + width,
+      rectWidthPx: width,
+      // The range the rect claims under the shared mapping.
+      impliedMinX: w.globals.minX + x * xRatio,
+      impliedMaxX: w.globals.minX + (x + width) * xRatio,
+    }
+  })
+}
+
+test.describe('Brush selection handles stay inside the data range', () => {
+  test.beforeEach(async ({ loadChart }) => {
+    await loadChart(CHART, FIXTURE)
+    // loadChart only waits on window.chart (the target); the brush chart that
+    // owns the selection rect renders after it.
+  })
+
+  test('the right handle stops at the last data point', async ({ page }) => {
+    await waitForBrushPair(page)
+    const before = await readSelectionBounds(page)
+
+    await dragSelectionHandle(page, 'r', OVERSHOOT_PX)
+
+    const after = await readSelectionBounds(page)
+
+    // The rect must not extend past the pixel the domain maximum sits on.
+    expect(
+      after.rectRightPx,
+      'rect right edge ran past the plot (gridWidth)',
+    ).toBeLessThanOrEqual(after.gridWidth + TOLERANCE_PX)
+
+    // Same statement in data units: no selection beyond the last data point.
+    expect(
+      (after.impliedMaxX - after.dataMaxX) / after.xRatio,
+      'selection extends past the data maximum',
+    ).toBeLessThanOrEqual(TOLERANCE_PX)
+
+    // The drag must still have done something, otherwise the clamp could be
+    // passing by freezing the handle outright.
+    expect(
+      after.rectWidthPx,
+      'the handle did not move at all',
+    ).toBeGreaterThan(before.rectWidthPx)
+  })
+
+  test('the left handle stops at the first data point', async ({ page }) => {
+    await waitForBrushPair(page)
+    const before = await readSelectionBounds(page)
+
+    await dragSelectionHandle(page, 'l', -OVERSHOOT_PX)
+
+    const after = await readSelectionBounds(page)
+
+    expect(
+      after.rectLeftPx,
+      'rect left edge ran past the plot origin',
+    ).toBeGreaterThanOrEqual(-TOLERANCE_PX)
+
+    expect(
+      (after.dataMinX - after.impliedMinX) / after.xRatio,
+      'selection extends before the data minimum',
+    ).toBeLessThanOrEqual(TOLERANCE_PX)
+
+    expect(
+      after.rectWidthPx,
+      'the handle did not move at all',
+    ).toBeGreaterThan(before.rectWidthPx)
+  })
+
+  test('the target chart is not scrolled into empty space', async ({ page }) => {
+    // The user-visible symptom: the brush pushes its range onto the target
+    // chart, so an unbounded selection drags the target off the end of the data.
+    await waitForBrushPair(page)
+
+    await dragSelectionHandle(page, 'r', OVERSHOOT_PX)
+
+    const bounds = await readSelectionBounds(page)
+    const { maxX } = await getXRange(page) // window.chart = the target chart
+
+    expect(
+      (maxX - bounds.dataMaxX) / bounds.xRatio,
+      'target chart shows empty space past the last data point',
+    ).toBeLessThanOrEqual(TOLERANCE_PX)
+  })
+
+  test('a handle resize inside the plot still moves freely', async ({ page }) => {
+    // Guard rail for the clamp itself: it must only bite at the boundary. A
+    // modest inward drag has to keep tracking the pointer one-to-one.
+    await waitForBrushPair(page)
+    const before = await readSelectionBounds(page)
+
+    // Shrink from the right, well clear of both edges.
+    const shrinkPx = 60
+    await dragSelectionHandle(page, 'r', -shrinkPx)
+
+    const after = await readSelectionBounds(page)
+
+    expect(
+      Math.abs(after.rectWidthPx - (before.rectWidthPx - shrinkPx)),
+      'an in-bounds resize did not follow the pointer',
+    ).toBeLessThanOrEqual(TOLERANCE_PX)
+    expect(after.rectLeftPx).toBeCloseTo(before.rectLeftPx, 1)
+  })
+})


### PR DESCRIPTION
Fixes #5123

## Problem

Dragging a selection handle past the first or last data point keeps expanding
the selection into empty space. The target chart of a brush pair follows it and
scrolls into a range where nothing is drawn.

A body drag of the selection was always bounded by `this.constraints`
(`ZoomPanSelection.js:82`). A handle resize never was.

## Measurement

`samples/vanilla-js/line/brush-charts.html`, gridWidth 585.5px, data from
2024-09-30 to 2025-03-28. Handle dragged 400px past the plot:

| handle | before | after |
|---|---|---|
| right, pixels past the grid | 246.3px | 0.0px |
| right, days past the data max | 75.3 days | 0.0 days |
| left, rect x | -86.0px | 0.0px |
| left, days before the data min | 26.3 days | 0.0 days |

After the fix the target chart's max lands exactly on 2025-03-28.

## Root cause and where the fix sits

The unbounded write is in `src/svg/SVGSelectable.js:148-167`: `onMove` sets the
rect's `x` and `width` straight from the pointer, its only guard being
`if (newW < 0) newW = 0`. The consumer, the `resize` listener at
`ZoomPanSelection.js:525`, then reads those attributes into
`w.interact.selection` and the emitted range.

The clamp is applied in `ZoomPanSelection.js` rather than in `SVGSelectable`
on purpose: `SVGSelectable` is a generic SVG helper with no knowledge of the
plot area, while the grid bounds belong to the chart module. Happy to move it
if you prefer the guard at the source.

The clamp rewrites the rect itself, not just the reported numbers, because
`selection-geometry.spec.js` asserts that the reported range matches the range
implied by the rect pixels.

## Scope

Every handle resize of the persistent selection rect, so brush charts and the
selection toolbar mode alike. Both use the same rect and the same handles, and
the clamp target `0..gridWidth` is by definition `minX..maxX` under
`AxisMapping`, which is the box body drags already obeyed.

Drag to zoom is untouched: `selectionDrawing` bounds its own rect to the grid
before this code runs. Nothing that is actually drawn becomes unselectable.

One case is worth flagging: on a chart that sets `xaxis.min` or `xaxis.max`
wider than its data, the clamp binds to the visible domain rather than to the
data points. The selection still stays on the chart and everything drawn stays
selectable, but the two boundaries only coincide when the domain is data
driven, as it is on the brush demo.

## Test

`tests/interaction/specs/brush-selection-bounds.spec.js`, four tests. With the
fix all four pass. Without it (verified by stashing only the source file and
rebuilding) three fail, the failing value being 246.27px, which matches the
manual measurement. The fourth passes either way by design: it guards that an
in-bounds resize is not frozen by the clamp.

`zoom-pan-selection.spec.js` and `selection-geometry.spec.js` stay green,
including the resize handle and full width brush cases.
