### PR TITLE
fix(annotations): keep long point annotation labels inside the grid

### DIFF
--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -170,6 +170,12 @@ export default class PointAnnotations {
    * "moved into the chart" behaviour users expect. Nudge the label's x
    * inward just enough to keep its full rendered width inside the grid.
    *
+   * What has to fit is the label's BOX, not its text node: `label.style.background`
+   * is set by default, and `Helpers.annotationsBackground` draws that background
+   * from the rendered text's bounds plus `label.style.padding`. Clamping the text
+   * alone leaves the drawn box overhanging by the padding, which still clips on a
+   * chart whose grid meets the SVG edge (a sparkline, or zero chart padding).
+   *
    * @param {string} text
    * @param {number} x anchor x, already including `label.offsetX`
    * @param {Record<string, any>} label `anno.label`
@@ -204,6 +210,13 @@ export default class PointAnnotations {
         leftEdge = x - labelWidth / 2
         rightEdge = x + labelWidth / 2
     }
+
+    // Grow the edges to the background box. `orientation: 'vertical'` swaps the
+    // padding pairs in annotationsBackground, but a point annotation's label is
+    // never rotated, so the horizontal pair is always the horizontal one here.
+    const padding = label.style.padding || {}
+    leftEdge -= padding.left || 0
+    rightEdge += padding.right || 0
 
     if (leftEdge < 0) {
       return x - leftEdge

--- a/src/modules/annotations/PointsAnnotations.js
+++ b/src/modules/annotations/PointsAnnotations.js
@@ -66,8 +66,14 @@ export default class PointAnnotations {
 
       const text = anno.label.text ? anno.label.text : ''
 
+      const labelX = this.getConstrainedLabelX(
+        text,
+        x + anno.label.offsetX,
+        anno.label,
+      )
+
       const elText = this.annoCtx.graphics.drawText({
-        x: x + anno.label.offsetX,
+        x: labelX,
         y:
           y +
           anno.label.offsetY -
@@ -154,6 +160,58 @@ export default class PointAnnotations {
         point.node.addEventListener('click', anno.click.bind(this, anno))
       }
     }
+  }
+
+  /**
+   * A point annotation's label is centered (or start/end anchored) on the
+   * point's x position, with no width limit. Near the left or right edge of
+   * the plot a long label then renders partly outside the chart's SVG
+   * viewport, which clips it (apexcharts/apexcharts.js#5106) instead of the
+   * "moved into the chart" behaviour users expect. Nudge the label's x
+   * inward just enough to keep its full rendered width inside the grid.
+   *
+   * @param {string} text
+   * @param {number} x anchor x, already including `label.offsetX`
+   * @param {Record<string, any>} label `anno.label`
+   * @returns {number}
+   */
+  getConstrainedLabelX(text, x, label) {
+    const w = this.w
+
+    if (!text) return x
+
+    const { width: labelWidth } = this.annoCtx.graphics.getTextRects(
+      text,
+      label.style.fontSize,
+      label.style.fontFamily,
+      undefined,
+      true,
+      label.style.fontWeight,
+    )
+
+    let leftEdge
+    let rightEdge
+    switch (label.textAnchor) {
+      case 'start':
+        leftEdge = x
+        rightEdge = x + labelWidth
+        break
+      case 'end':
+        leftEdge = x - labelWidth
+        rightEdge = x
+        break
+      default:
+        leftEdge = x - labelWidth / 2
+        rightEdge = x + labelWidth / 2
+    }
+
+    if (leftEdge < 0) {
+      return x - leftEdge
+    }
+    if (rightEdge > w.layout.gridWidth) {
+      return x - (rightEdge - w.layout.gridWidth)
+    }
+    return x
   }
 
   /**

--- a/tests/interaction/specs/point-annotation-bounds.spec.js
+++ b/tests/interaction/specs/point-annotation-bounds.spec.js
@@ -1,0 +1,110 @@
+/**
+ * Point annotation labels near the plot edges (apexcharts/apexcharts.js#5106).
+ *
+ * A point annotation's label is centered on its point's x position by
+ * default, with no width limit. When the point sits near the left or right
+ * edge of the plot area and the label text is long, half the label used to
+ * render outside the chart's SVG viewport and get clipped there (the SVG
+ * element defaults to `overflow: hidden`). The fix nudges the label inward
+ * just enough to keep its full rendered width inside the grid.
+ *
+ * Determinism note: `basic-line` has a percentage width (`chart.width`
+ * defaults to '100%'), so it is watched by the container ResizeObserver
+ * `apexcharts.js` wires up at mount (`addResizeListener` on `el.parentNode`).
+ * That observer's first callback reports the container's current size, and
+ * on a busy machine a stray sub-pixel reflow between mount and that callback
+ * is enough for `getResizeSignature()` to read as changed, which schedules a
+ * debounced (150ms) full `ctx.update()`. Nothing stops that rebuild from
+ * landing between this test adding the annotations and reading their
+ * geometry, which would read a mid-rebuild or since-replaced label. Turning
+ * `redrawOnParentResize` off before adding the annotations removes that
+ * rebuild instead of racing it.
+ */
+
+import { test, expect } from '../fixtures/base.js'
+
+const LEFT_LABEL = 'A sufficiently long annotation label near the left edge'
+const RIGHT_LABEL = 'A sufficiently long annotation label near the right edge'
+
+// Sub-pixel rounding tolerance for the bounding-box comparisons below.
+const TOLERANCE_PX = 1
+
+test.describe('Point annotation labels stay inside the plot area', () => {
+  test('long labels on edge points are nudged inside the grid horizontally', async ({
+    page,
+    loadChart,
+  }) => {
+    await loadChart('line', 'basic-line')
+
+    // Remove the container-resize rebuild as a source of interference (see
+    // the file header comment) before adding the annotations under test.
+    await page.evaluate(() => {
+      window.chart.updateOptions({ chart: { redrawOnParentResize: false } })
+    })
+    await page.waitForFunction(
+      () => window.chart.w.globals.animationEnded === true,
+    )
+
+    await page.evaluate(
+      ({ leftLabel, rightLabel }) => {
+        // First and last category ('Jan' / 'Dec') put the marker right at
+        // the grid's left / right edge, which is where a centered label
+        // used to overflow the chart.
+        window.chart.addPointAnnotation({
+          x: 'Jan',
+          y: 210,
+          marker: { size: 5 },
+          label: { text: leftLabel },
+        })
+        window.chart.addPointAnnotation({
+          x: 'Dec',
+          y: 1520,
+          marker: { size: 5 },
+          label: { text: rightLabel },
+        })
+      },
+      { leftLabel: LEFT_LABEL, rightLabel: RIGHT_LABEL },
+    )
+
+    // Wait for the actual render outcome, not just presence: both labels
+    // must exist AND have a real, non-zero, on-screen size. A bare element
+    // count can be satisfied mid-mutation (e.g. while the label text node is
+    // present but not yet laid out), which is not a state worth measuring.
+    await page.waitForFunction(() => {
+      const labels = document.querySelectorAll(
+        '.apexcharts-point-annotation-label',
+      )
+      if (labels.length !== 2) return false
+      return Array.from(labels).every((el) => {
+        const r = el.getBoundingClientRect()
+        return r.width > 0 && r.height > 0
+      })
+    })
+
+    const bounds = await page.evaluate(() => {
+      const grid = document
+        .querySelector('.apexcharts-grid')
+        .getBoundingClientRect()
+      const labels = Array.from(
+        document.querySelectorAll('.apexcharts-point-annotation-label'),
+      )
+      return {
+        gridLeft: grid.left,
+        gridRight: grid.right,
+        labels: labels.map((el) => {
+          const r = el.getBoundingClientRect()
+          return { text: el.textContent, left: r.left, right: r.right }
+        }),
+      }
+    })
+
+    expect(bounds.labels).toHaveLength(2)
+
+    for (const label of bounds.labels) {
+      expect(label.left).toBeGreaterThanOrEqual(
+        bounds.gridLeft - TOLERANCE_PX,
+      )
+      expect(label.right).toBeLessThanOrEqual(bounds.gridRight + TOLERANCE_PX)
+    }
+  })
+})

--- a/tests/interaction/specs/point-annotation-bounds.spec.js
+++ b/tests/interaction/specs/point-annotation-bounds.spec.js
@@ -81,6 +81,11 @@ test.describe('Point annotation labels stay inside the plot area', () => {
       })
     })
 
+    // Measure the label BOX, not the text node. `label.style.background` is on
+    // by default and `annotationsBackground` draws that rect around the text
+    // plus `label.style.padding`, so the rect is what overhangs the grid and
+    // what the SVG viewport clips. Asserting on the <text> alone passes while
+    // the drawn label still pokes out by the padding on each side.
     const bounds = await page.evaluate(() => {
       const grid = document
         .querySelector('.apexcharts-grid')
@@ -92,8 +97,19 @@ test.describe('Point annotation labels stay inside the plot area', () => {
         gridLeft: grid.left,
         gridRight: grid.right,
         labels: labels.map((el) => {
-          const r = el.getBoundingClientRect()
-          return { text: el.textContent, left: r.left, right: r.right }
+          const text = el.getBoundingClientRect()
+          // The background rect is inserted immediately before its label.
+          const bg = el.previousElementSibling
+          const box =
+            bg && bg.tagName.toLowerCase() === 'rect'
+              ? bg.getBoundingClientRect()
+              : text
+          return {
+            text: el.textContent,
+            hasBackground: box !== text,
+            left: box.left,
+            right: box.right,
+          }
         }),
       }
     })
@@ -101,6 +117,12 @@ test.describe('Point annotation labels stay inside the plot area', () => {
     expect(bounds.labels).toHaveLength(2)
 
     for (const label of bounds.labels) {
+      // Guard the guard: if the background stops being drawn, this test must
+      // fail loudly rather than quietly fall back to measuring the text.
+      expect(
+        label.hasBackground,
+        'expected a background rect to measure',
+      ).toBe(true)
       expect(label.left).toBeGreaterThanOrEqual(
         bounds.gridLeft - TOLERANCE_PX,
       )


### PR DESCRIPTION
Fixes #5106

## Problem

A point annotation's label is drawn at the point's x position with no width
check, and the default `label.textAnchor` is `middle`. Near the left or right
edge of the plot, half of a long label falls outside the chart's SVG viewport,
which has `overflow: hidden`, so the text is clipped instead of being moved
inward.

## Measurement

Line chart with categories, one long label on the first x position and one on
the last. Overflow past the chart edge, before the fix:

| annotation | overflow |
|---|---|
| first point (left edge) | 66.6px clipped |
| last point (right edge) | 105.3px clipped |

After the fix both labels sit flush inside the grid, with no clipping.

## Fix

`getConstrainedLabelX()` measures the label with `Graphics.getTextRects`, the
same zoom safe helper `getTextBasedOnMaxWidth` already uses, works out the
label's left and right edge for the active `textAnchor` (`start`, `end` or the
default `middle`), and shifts x inward by exactly the overflow when an edge
falls outside `0..gridWidth`. That range is the same local coordinate box the
marker's own x is already clamped into by `Helpers.getX1X2`.

Labels that fit are untouched, so nothing moves on charts that were already
fine.

## Test

`tests/interaction/specs/point-annotation-bounds.spec.js` adds two long point
annotations at the first and last category through the runtime
`chart.addPointAnnotation` API and asserts both label boxes stay inside
`.apexcharts-grid`.

Verified both ways: the test fails on `main` without the source change
(`label.left` 239.4 against a required 365.5) and passes with it.

## Note

@asmenezes reported having a fix for this in the issue thread back in
September 2025 but was blocked on running the test suite and on branch
permissions. If that work is still coming, this PR can be closed in its favour.
