### PR TITLE
fix(bar): stack combo columns on the layer below, not the axis

### DIFF
--- a/src/charts/BarStacked.js
+++ b/src/charts/BarStacked.js
@@ -446,12 +446,10 @@ class BarStacked extends Bar {
       prevBarW = prevBarW + this.groupCtx.prevXF[k][j]
     }
 
-    let gsi = i // an index to keep track of the series inside a group
-    if (/** @type {Record<string,any>} */ (w.config.series[realIndex]).name) {
-      gsi = seriesGroup.indexOf(
-        /** @type {Record<string,any>} */ (w.config.series[realIndex]).name,
-      )
-    }
+    // Where this series sits in its group's stack. See the note in
+    // drawStackedColumnPaths: the index has to count the series this renderer
+    // has already drawn for the group, which is exactly what prevX holds.
+    const gsi = this.groupCtx.prevX.length
 
     if (gsi > 0) {
       let bXP = zeroW
@@ -573,10 +571,14 @@ class BarStacked extends Bar {
         (!isNaN(this.groupCtx.prevYF[k][j]) ? this.groupCtx.prevYF[k][j] : 0)
     }
 
-    let gsi = i // an index to keep track of the series inside a group
-    if (seriesGroup) {
-      gsi = seriesGroup.indexOf(w.seriesData.seriesNames[realIndex])
-    }
+    // Where this series sits in its group's stack, which is what indexes the
+    // prevY/prevYF/prevYVal arrays. Those arrays are pushed once per series
+    // THIS renderer draws, so the index must count stacked bars only.
+    // Reading the position out of seriesGroup counted every member of the
+    // group, line and area series included, so in a mixed chart every bar
+    // that followed a non-bar series looked past the end of prevY, found no
+    // previous layer and restarted its stack from the axis (#5105).
+    const gsi = this.groupCtx.prevY.length
     if (
       (gsi > 0 && !w.axisFlags.isXNumeric) ||
       (gsi > 0 &&

--- a/tests/interaction/specs/mixed-stacked-columns.spec.js
+++ b/tests/interaction/specs/mixed-stacked-columns.spec.js
@@ -1,0 +1,167 @@
+/**
+ * Mixed chart with `chart.stacked`, the columns must stack on each other.
+ *
+ * In a combo chart every series of a group lands in the same
+ * `w.labelData.seriesGroups` bucket, columns and lines alike, but the stacked
+ * renderer only draws the columns. Locating a column inside its stack by its
+ * position in that bucket therefore counted the line series too, so a column
+ * placed after a line looked for a layer beneath it that had never been drawn,
+ * found nothing and restarted from the axis. The stack silently flattened into
+ * overlapping bars (#5105).
+ *
+ * The defect only shows when a non-bar series sits BEFORE a column in the
+ * series array, so both orders are measured here: reversing them is the whole
+ * difference between a stack and a pile.
+ */
+
+import { test, expect } from '../fixtures/base.js'
+
+const CATEGORIES = ['A', 'B', 'C', 'D']
+const COLUMN_A = [100, 200, 300, 400]
+const COLUMN_B = [50, 60, 70, 80]
+const COLUMN_C = [30, 30, 30, 30]
+const TREND = [180, 290, 400, 510]
+
+const COLUMN_COUNT = 3
+const EXPECTED_BARS = COLUMN_COUNT * CATEGORIES.length
+
+// Stack layers are drawn edge to edge, so a closed seam is a sub-pixel affair.
+// A broken stack restarts each layer at the axis, which is tens of pixels away,
+// so this threshold separates the two cases by a wide margin either way.
+const SEAM_TOLERANCE = 1
+
+/**
+ * Build a fresh stacked combo chart in the loaded page and wait until its
+ * columns have real geometry.
+ *
+ * The sample is only there to provide the built bundle; the chart under test is
+ * created here so the series order can be flipped. `redrawOnParentResize` is
+ * off because a resize would schedule a debounced update behind the measurement.
+ */
+async function renderMixedStack(page, { lineFirst }) {
+  await page.evaluate(
+    async ({ lineFirst, categories, a, b, c, trend }) => {
+      window.chart.destroy()
+
+      const host = document.createElement('div')
+      host.id = 'stack-under-test'
+      host.style.width = '700px'
+      document.body.appendChild(host)
+
+      const columns = [
+        { name: 'ColA', type: 'column', data: a },
+        { name: 'ColB', type: 'column', data: b },
+        { name: 'ColC', type: 'column', data: c },
+      ]
+      const line = { name: 'Trend', type: 'line', data: trend }
+
+      // Only the line is stroked. A stroke on a column shrinks its painted box
+      // by half the stroke on every side, which would move the seam the test is
+      // measuring for reasons that have nothing to do with stacking.
+      const chart = new ApexCharts(host, {
+        series: lineFirst ? [line, ...columns] : [...columns, line],
+        chart: {
+          type: 'line',
+          height: 400,
+          stacked: true,
+          animations: { enabled: false },
+          redrawOnParentResize: false,
+        },
+        stroke: { width: lineFirst ? [3, 0, 0, 0] : [0, 0, 0, 3] },
+        xaxis: { categories },
+      })
+      window.chart = chart
+      await chart.render()
+    },
+    {
+      lineFirst,
+      categories: CATEGORIES,
+      a: COLUMN_A,
+      b: COLUMN_B,
+      c: COLUMN_C,
+      trend: TREND,
+    },
+  )
+
+  await page.waitForFunction(
+    (expectedBars) => {
+      const bars = document.querySelectorAll(
+        '#stack-under-test .apexcharts-bar-area',
+      )
+      return (
+        bars.length === expectedBars &&
+        [...bars].every((bar) => bar.getBoundingClientRect().height > 0)
+      )
+    },
+    EXPECTED_BARS,
+    { timeout: 10_000 },
+  )
+}
+
+/**
+ * Painted box of every column, keyed by series name and indexed by category.
+ */
+async function readColumnStacks(page) {
+  return page.evaluate(() => {
+    /** @type {Record<string, {top: number, bottom: number}[]>} */
+    const stacks = {}
+    const groups = document.querySelectorAll(
+      '#stack-under-test .apexcharts-series',
+    )
+    for (const group of groups) {
+      const bars = [...group.querySelectorAll('.apexcharts-bar-area')]
+      if (!bars.length) continue
+      stacks[group.getAttribute('seriesName')] = bars.map((bar) => {
+        const box = bar.getBBox()
+        return { top: box.y, bottom: box.y + box.height }
+      })
+    }
+    return stacks
+  })
+}
+
+for (const lineFirst of [false, true]) {
+  const order = lineFirst
+    ? 'the line series declared before the columns'
+    : 'the line series declared after the columns'
+
+  test.describe(`Stacked combo chart, ${order}`, () => {
+    test('every column sits on the one below it, not on the axis', async ({
+      page,
+      loadChart,
+    }) => {
+      await loadChart('mixed', 'line-column')
+      await renderMixedStack(page, { lineFirst })
+
+      const stacks = await readColumnStacks(page)
+      expect(Object.keys(stacks).sort()).toEqual(['ColA', 'ColB', 'ColC'])
+
+      for (let j = 0; j < CATEGORIES.length; j++) {
+        const base = stacks.ColA[j]
+        const middle = stacks.ColB[j]
+        const top = stacks.ColC[j]
+
+        expect(
+          Math.abs(middle.bottom - base.top),
+          `ColB should start at the top of ColA in category ${CATEGORIES[j]}`,
+        ).toBeLessThan(SEAM_TOLERANCE)
+        expect(
+          Math.abs(top.bottom - middle.top),
+          `ColC should start at the top of ColB in category ${CATEGORIES[j]}`,
+        ).toBeLessThan(SEAM_TOLERANCE)
+
+        // The flattened stack the defect produced: every layer shares the
+        // baseline of the first one. Asserted directly so a regression cannot
+        // pass by collapsing the seams onto the axis together.
+        expect(
+          Math.abs(middle.bottom - base.bottom),
+          `ColB should not be redrawn from the axis in category ${CATEGORIES[j]}`,
+        ).toBeGreaterThan(SEAM_TOLERANCE)
+        expect(
+          Math.abs(top.bottom - base.bottom),
+          `ColC should not be redrawn from the axis in category ${CATEGORIES[j]}`,
+        ).toBeGreaterThan(SEAM_TOLERANCE)
+      }
+    })
+  })
+}


### PR DESCRIPTION
Fixes #5105

## Problem

In a mixed chart with `chart.stacked: true`, columns declared after a line or
area series restart from the axis instead of stacking on the column below.

The order matters, which is why the existing samples never caught it: with the
line declared last the stack is correct today. Declaring the line first or in
the middle flattens every column that follows it.

## Measurement

Three column series plus one line series, categories A to D, animations off,
grid baseline at y=308.4. Column rect bottom edge per series, line declared
first:

| build | ColA bottom | ColB bottom | ColC bottom |
|---|---|---|---|
| 3.47.0 | 314.4 (axis) | 262.0, top of ColA | 235.7, top of ColB |
| 4.7.0 | 308.4 (axis) | 308.4 (axis) | 308.3 (axis) |
| main, before | 308.4 (axis) | 308.4 (axis) | 308.3 (axis) |
| main, after | 308.4 (axis) | 257.0, top of ColA | 231.2, top of ColB |

With the line in the middle the same fix gives ColB bottom 257.0 and ColC
bottom 231.3, both correct.

## Root cause

`src/charts/BarStacked.js`, `drawStackedColumnPaths` and `drawStackedBarPaths`.

`w.labelData.seriesGroups` buckets every series of a group, lines and areas
included (`src/modules/Data.js:821-827`). `prevY`, `prevYF` and `prevYVal` are
pushed once per series this renderer actually draws
(`BarStacked.js:277-282`). Taking the stack position from
`seriesGroup.indexOf(...)` therefore counted non bar members too, so a column
declared after a line indexed past the end of `prevY`, `bYP` came back
undefined, fell through to `w.layout.gridHeight` and the bar restarted at the
axis.

On 3.47.0 the same line read `seriesGroup.indexOf(w.config.series[i].name)`
with `i` being the bar loop index, which always resolved back to `i`, so it was
accidentally correct. The 4.x rewrite switched it to the global series index,
which is where this starts.

## Fix

Take the position from `this.groupCtx.prevY.length` (and `prevX.length` for
the horizontal path), which counts the bars this renderer has drawn for the
group by construction. No behaviour change outside a mixed group.

## Test

`tests/interaction/specs/mixed-stacked-columns.spec.js`, two cases: line
declared before the columns, and line declared after as a control.

Without the source change the first case fails
(`ColB should start at the top of ColA in category A, expected < 1, received
51.39`) and the control passes, which is the point. With the change both pass.

## Regression checks

Full interaction suite run three times: 570 passed, 0 failed in each run, the
four `stacked-*` specs green (33/33) in each. Unit suite 3332 passed across
140 files.

Beyond the suite, all 30 samples containing `stacked: true` were rendered
before and after and their `.apexcharts-bar-area` `d` attributes compared: 30
of 30 byte identical, so this is a no-op for every non mixed stacked chart,
including the grouped and border radius ones.

## One thing left alone

The numeric x branch of the same condition (`BarStacked.js:582-585`) compares
`w.seriesData.seriesX[realIndex - 1][j]` against `seriesX[realIndex][j]`. In a
combo chart `realIndex - 1` can be a line series rather than the previous bar,
which looks like the same bug class. It was equally wrong before this change,
and the reproduction here uses a category axis so it never reaches that branch.
Left untouched rather than fixed blind. Happy to follow up separately.
