### PR TITLE
docs: fix two dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Browse [100+ ready-to-use samples](https://apexcharts.com/javascript-chart-demos
 ## Chart types
 
 - [Line](https://apexcharts.com/javascript-chart-demos/line-charts/) · [Area](https://apexcharts.com/javascript-chart-demos/area-charts/) · [Range Area](https://apexcharts.com/javascript-chart-demos/range-area-charts/)
-- [Bar](https://apexcharts.com/javascript-chart-demos/bar-charts/) · [Column](https://apexcharts.com/javascript-chart-demos/column-charts/) · [Range Bar / Timeline](https://apexcharts.com/javascript-chart-demos/range-bar-charts/) 
+- [Bar](https://apexcharts.com/javascript-chart-demos/bar-charts/) · [Column](https://apexcharts.com/javascript-chart-demos/column-charts/) · [Range Bar / Timeline](https://apexcharts.com/javascript-chart-demos/timeline-charts/) 
 - [Scatter](https://apexcharts.com/javascript-chart-demos/scatter-charts/) · [Bubble](https://apexcharts.com/javascript-chart-demos/bubble-charts/)
 - [Candlestick](https://apexcharts.com/javascript-chart-demos/candlestick-charts/) · [BoxPlot](https://apexcharts.com/javascript-chart-demos/boxplot-charts/) · [Violin](samples/vanilla-js/violin/)
 - [Pie](https://apexcharts.com/javascript-chart-demos/pie-charts/) · [Donut](https://apexcharts.com/javascript-chart-demos/pie-charts/) · [Polar Area](https://apexcharts.com/javascript-chart-demos/polar-area-charts/) · [Radial Bar / Gauge](https://apexcharts.com/javascript-chart-demos/radialbar-charts/)
@@ -307,7 +307,7 @@ We've partnered with [Infragistics](https://www.infragistics.com/), creators of 
 
 Available for:
 
-[Angular](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/grid) · [React](https://www.infragistics.com/products/ignite-ui-react/react/components/grids) · [Blazor](https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/data-grid) · [Web Components](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/data-grid) · [jQuery](https://www.igniteui.com/grid/overview)
+[Angular](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/grid) · [React](https://www.infragistics.com/products/ignite-ui-react/react/components/grids/data-grid) · [Blazor](https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/data-grid) · [Web Components](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/data-grid) · [jQuery](https://www.igniteui.com/grid/overview)
 
 ## Contact
 


### PR DESCRIPTION
Two links in `README.md` return 404:

- The **Range Bar / Timeline** demo link points at `/javascript-chart-demos/range-bar-charts/`, which no longer exists. The demos live under `/javascript-chart-demos/timeline-charts/`.
- The **Ignite UI React** grid link (`/products/ignite-ui-react/react/components/grids`) is gone. Repointed to `/grids/data-grid`, matching the Blazor and Web Components links right next to it.

Both new targets return 200. Documentation only, no code changes, no linked issue.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My branch is up to date with any changes from the main branch