### PR TITLE
fix(bar): keep the stack border-radius off series the bar renderer never draws

### DIFF
--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -506,13 +506,26 @@ export default class Helpers {
    * not grouped. Order within a bucket follows series order, which is stacking
    * order.
    *
+   * `w.globals.columnSeries` (when set) is the combo chart's own list of which
+   * series it draws as bars; a line or area series never occupies a stack
+   * segment, so it is filtered out here rather than left to compete for the
+   * outermost slot (#5296).
+   *
    * @param {number} numSeries
    * @returns {number[][]}
    */
   getStackedSeriesIndices(numSeries) {
-    const groups = this.w.labelData.seriesGroups
+    const w = this.w
+    const groups = w.labelData.seriesGroups
+    const barIndices = w.globals?.columnSeries
+      ? new Set(/** @type {any} */ (w.globals.columnSeries).i)
+      : null
+    const isBar = (/** @type {number} */ i) => !barIndices || barIndices.has(i)
+
     if (!groups || groups.length < 2) {
-      return [Array.from({ length: numSeries }, (_, i) => i)]
+      return [
+        Array.from({ length: numSeries }, (_, i) => i).filter(isBar),
+      ]
     }
 
     /** @type {number[][]} */
@@ -520,6 +533,7 @@ export default class Helpers {
     /** @type {number[]} */
     const ungrouped = []
     for (let i = 0; i < numSeries; i++) {
+      if (!isBar(i)) continue
       const g = this.getSeriesGroupIndex(i)
       if (g > -1) buckets[g].push(i)
       else ungrouped.push(i)

--- a/src/charts/common/bar/Helpers.js
+++ b/src/charts/common/bar/Helpers.js
@@ -517,15 +517,14 @@ export default class Helpers {
   getStackedSeriesIndices(numSeries) {
     const w = this.w
     const groups = w.labelData.seriesGroups
-    const barIndices = w.globals?.columnSeries
+    const barIndices = w.globals.columnSeries
       ? new Set(/** @type {any} */ (w.globals.columnSeries).i)
       : null
     const isBar = (/** @type {number} */ i) => !barIndices || barIndices.has(i)
 
     if (!groups || groups.length < 2) {
-      return [
-        Array.from({ length: numSeries }, (_, i) => i).filter(isBar),
-      ]
+      const bucket = Array.from({ length: numSeries }, (_, i) => i).filter(isBar)
+      return bucket.length ? [bucket] : []
     }
 
     /** @type {number[][]} */

--- a/tests/unit/border-radius-assignment.spec.js
+++ b/tests/unit/border-radius-assignment.spec.js
@@ -87,6 +87,51 @@ describe('createBorderRadiusArr, which bar rounds which corner', () => {
       const grid = h.createBorderRadiusArr([[-10, -10], [-15, -15], [-12, -12]])
       expect(cornersAt(grid, 0)).toEqual(['top', 'none', 'bottom'])
     })
+
+    it('is a no-op when every series is a bar (pure-bar stacked chart)', () => {
+      const h = makeHelpers({
+        seriesNames: ['S0', 'S1', 'S2'],
+        columnSeries: { i: [0, 1, 2] },
+      })
+      const grid = h.createBorderRadiusArr([
+        [10, 10],
+        [15, 15],
+        [12, 12],
+      ])
+      expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top'])
+    })
+
+    it('skips a line series sitting inside the stack (#5296)', () => {
+      // Trend is a line series stacked alongside three columns; the bar
+      // renderer never draws it, so it must never claim a corner.
+      const h = makeHelpers({
+        seriesNames: ['Trend', 'ColA', 'ColB', 'ColC'],
+        columnSeries: { i: [1, 2, 3] },
+      })
+      const grid = h.createBorderRadiusArr([
+        [180, 290],
+        [100, 200],
+        [50, 60],
+        [30, 30],
+      ])
+      // Pre-fix this was ['bottom', 'none', 'none', 'top']: Trend's index (0)
+      // was treated as the stack's bottom, leaving ColA square.
+      expect(cornersAt(grid, 0)).toEqual(['none', 'bottom', 'none', 'top'])
+    })
+
+    it('inverts correctly when the line sits at the end of the stack (#5296)', () => {
+      const h = makeHelpers({
+        seriesNames: ['ColA', 'ColB', 'ColC', 'Trend'],
+        columnSeries: { i: [0, 1, 2] },
+      })
+      const grid = h.createBorderRadiusArr([
+        [100, 200],
+        [50, 60],
+        [30, 30],
+        [180, 290],
+      ])
+      expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top', 'none'])
+    })
   })
 
   describe('grouped stacks, each group is its own stack', () => {
@@ -167,38 +212,6 @@ describe('createBorderRadiusArr, which bar rounds which corner', () => {
       // shares one stack, the orphan must not silently lose its corner.
       expect(grid[2][0]).not.toBe(undefined)
       expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top'])
-    })
-
-    it('skips a line series sitting inside the stack (#5296)', () => {
-      // Trend is a line series stacked alongside three columns; the bar
-      // renderer never draws it, so it must never claim a corner.
-      const h = makeHelpers({
-        seriesNames: ['Trend', 'ColA', 'ColB', 'ColC'],
-        columnSeries: { i: [1, 2, 3] },
-      })
-      const grid = h.createBorderRadiusArr([
-        [180, 290],
-        [100, 200],
-        [50, 60],
-        [30, 30],
-      ])
-      // Pre-fix this was ['bottom', 'none', 'none', 'top']: Trend's index (0)
-      // was treated as the stack's bottom, leaving ColA square.
-      expect(cornersAt(grid, 0)).toEqual(['none', 'bottom', 'none', 'top'])
-    })
-
-    it('inverts correctly when the line sits at the end of the stack (#5296)', () => {
-      const h = makeHelpers({
-        seriesNames: ['ColA', 'ColB', 'ColC', 'Trend'],
-        columnSeries: { i: [0, 1, 2] },
-      })
-      const grid = h.createBorderRadiusArr([
-        [100, 200],
-        [50, 60],
-        [30, 30],
-        [180, 290],
-      ])
-      expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top', 'none'])
     })
 
     it('handles three groups', () => {
@@ -299,6 +312,14 @@ describe('createBorderRadiusArr, which bar rounds which corner', () => {
         columnSeries: { i: [1, 2, 3] },
       })
       expect(h.getStackedSeriesIndices(4)).toEqual([[1, 2, 3]])
+    })
+
+    it('returns no buckets, not an empty one, when nothing in the ungrouped stack is a bar', () => {
+      const h = makeHelpers({
+        seriesNames: ['Trend0', 'Trend1'],
+        columnSeries: { i: [] },
+      })
+      expect(h.getStackedSeriesIndices(2)).toEqual([])
     })
   })
 })

--- a/tests/unit/border-radius-assignment.spec.js
+++ b/tests/unit/border-radius-assignment.spec.js
@@ -25,6 +25,7 @@ const makeHelpers = ({
   horizontal = false,
   stacked = true,
   borderRadius = 10,
+  columnSeries = null,
 }) => {
   const w = {
     config: {
@@ -33,6 +34,7 @@ const makeHelpers = ({
     },
     seriesData: { seriesNames },
     labelData: { seriesGroups },
+    globals: { columnSeries },
   }
   // Helpers' constructor only reads barCtx.w.
   return new Helpers({ w })
@@ -167,6 +169,38 @@ describe('createBorderRadiusArr, which bar rounds which corner', () => {
       expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top'])
     })
 
+    it('skips a line series sitting inside the stack (#5296)', () => {
+      // Trend is a line series stacked alongside three columns; the bar
+      // renderer never draws it, so it must never claim a corner.
+      const h = makeHelpers({
+        seriesNames: ['Trend', 'ColA', 'ColB', 'ColC'],
+        columnSeries: { i: [1, 2, 3] },
+      })
+      const grid = h.createBorderRadiusArr([
+        [180, 290],
+        [100, 200],
+        [50, 60],
+        [30, 30],
+      ])
+      // Pre-fix this was ['bottom', 'none', 'none', 'top']: Trend's index (0)
+      // was treated as the stack's bottom, leaving ColA square.
+      expect(cornersAt(grid, 0)).toEqual(['none', 'bottom', 'none', 'top'])
+    })
+
+    it('inverts correctly when the line sits at the end of the stack (#5296)', () => {
+      const h = makeHelpers({
+        seriesNames: ['ColA', 'ColB', 'ColC', 'Trend'],
+        columnSeries: { i: [0, 1, 2] },
+      })
+      const grid = h.createBorderRadiusArr([
+        [100, 200],
+        [50, 60],
+        [30, 30],
+        [180, 290],
+      ])
+      expect(cornersAt(grid, 0)).toEqual(['bottom', 'none', 'top', 'none'])
+    })
+
     it('handles three groups', () => {
       const h = makeHelpers({
         seriesNames: ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'],
@@ -257,6 +291,14 @@ describe('createBorderRadiusArr, which bar rounds which corner', () => {
         seriesGroups: [['a1'], ['nobody']],
       })
       expect(h.getStackedSeriesIndices(1)).toEqual([[0]])
+    })
+
+    it('excludes non-bar series when the combo chart reports which are bars (#5296)', () => {
+      const h = makeHelpers({
+        seriesNames: ['Trend', 'ColA', 'ColB', 'ColC'],
+        columnSeries: { i: [1, 2, 3] },
+      })
+      expect(h.getStackedSeriesIndices(4)).toEqual([[1, 2, 3]])
     })
   })
 })


### PR DESCRIPTION
In a stacked combo chart, `plotOptions.bar.borderRadius` rounds the wrong end of the stack: whichever end of the series array a line or area series sits at, that end of the column stack stays square, because the corner gets assigned to a series with no bar.

`createBorderRadiusArr` resolves the outermost segment of each stack from `getStackedSeriesIndices`, which buckets every series in a group by its global index, line and area included. Those non-bar series still landed in the bucket, so the first or last index in it could be a series the bar renderer never draws, and the cap it picked never rendered.

`getStackedSeriesIndices` now filters each bucket against `w.globals.columnSeries.i`, the list the combo chart already builds of which series it actually draws as bars. A line or area series can no longer take either end of the stack.

Same root cause family as #5105, a different code path, both in `src/charts/common/bar/Helpers.js`.

Fixes #5296
