### PR TITLE
fix(ssr): estimate text bounds so the DOM shim can measure labels

### DIFF
--- a/src/ssr/DOMShim.js
+++ b/src/ssr/DOMShim.js
@@ -4,6 +4,14 @@
  * Provides just enough SVG element emulation to create chart structure without full DOM
  */
 
+// Approximate sans-serif metrics, in em, used to estimate SVG text bounds when
+// no font engine is available to measure the glyphs.
+const CHAR_WIDTH_EM = 0.55
+const ASCENT_EM = 0.917
+const DESCENT_EM = 0.25
+const LINE_HEIGHT_EM = 1.1
+const DEFAULT_FONT_SIZE = 11
+
 /**
  * Mock SVG element for SSR environment
  */
@@ -146,6 +154,48 @@ class SSRElement {
       x: 0,
       y: 0,
     }
+  }
+
+  getBBox() {
+    if (this.nodeName !== 'text' && this.nodeName !== 'tspan') {
+      return { x: 0, y: 0, width: 0, height: 0 }
+    }
+
+    const lines = this._textLines()
+    const longest = lines.reduce((acc, line) => Math.max(acc, line.length), 0)
+    if (!longest) {
+      return { x: 0, y: 0, width: 0, height: 0 }
+    }
+
+    const fontSize =
+      parseFloat(this.attributes.get('font-size')) || DEFAULT_FONT_SIZE
+    const width = longest * fontSize * CHAR_WIDTH_EM
+    const height =
+      fontSize * (ASCENT_EM + DESCENT_EM) +
+      (lines.length - 1) * fontSize * LINE_HEIGHT_EM
+
+    const anchor = this.attributes.get('text-anchor')
+    const x = parseFloat(this.attributes.get('x')) || 0
+    const y = parseFloat(this.attributes.get('y')) || 0
+
+    return {
+      x: anchor === 'middle' ? x - width / 2 : anchor === 'end' ? x - width : x,
+      y: y - fontSize * ASCENT_EM,
+      width,
+      height,
+    }
+  }
+
+  /**
+   * Text of this element, one entry per rendered line
+   * @returns {string[]}
+   */
+  _textLines() {
+    const tspans = this.children.filter((child) => child.nodeName === 'tspan')
+    if (tspans.length) {
+      return tspans.map((tspan) => String(tspan.textContent ?? ''))
+    }
+    return [String(this.textContent ?? '')]
   }
 
   getRootNode() {

--- a/tests/unit/ssr/dom-shim.spec.js
+++ b/tests/unit/ssr/dom-shim.spec.js
@@ -189,6 +189,71 @@ describe('SSRDOMShim', () => {
     })
   })
 
+  describe('SSRElement Text Bounds', () => {
+    it('should return an empty box for a non-text element', () => {
+      const element = new SSRElement('rect')
+      element.setAttribute('width', '100')
+
+      expect(element.getBBox()).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+    })
+
+    it('should return an empty box for text with no content', () => {
+      const element = new SSRElement('text')
+      element.setAttribute('font-size', '12px')
+
+      expect(element.getBBox()).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+    })
+
+    it('should estimate the box from the font size and content', () => {
+      const element = new SSRElement('text')
+      element.setAttribute('font-size', '12px')
+      element.textContent = 'Second'
+
+      const box = element.getBBox()
+
+      expect(box.width).toBeCloseTo(39.6, 2)
+      expect(box.height).toBeCloseTo(14.004, 2)
+    })
+
+    it('should measure numeric content', () => {
+      const element = new SSRElement('text')
+      element.setAttribute('font-size', '12px')
+      element.textContent = 4
+
+      expect(element.getBBox().width).toBeCloseTo(6.6, 2)
+    })
+
+    it('should measure the longest line and grow with the line count', () => {
+      const element = new SSRElement('text')
+      element.setAttribute('font-size', '10px')
+      const first = new SSRElement('tspan')
+      first.textContent = 'ab'
+      const second = new SSRElement('tspan')
+      second.textContent = 'abcd'
+      element.appendChild(first)
+      element.appendChild(second)
+
+      const box = element.getBBox()
+
+      expect(box.width).toBeCloseTo(22, 2)
+      expect(box.height).toBeCloseTo(11.67 + 11, 2)
+    })
+
+    it('should place the box from the anchor and the baseline', () => {
+      const element = new SSRElement('text')
+      element.setAttribute('font-size', '12px')
+      element.setAttribute('x', '100')
+      element.setAttribute('y', '50')
+      element.setAttribute('text-anchor', 'middle')
+      element.textContent = 'Second'
+
+      const box = element.getBBox()
+
+      expect(box.x).toBeCloseTo(100 - 39.6 / 2, 2)
+      expect(box.y).toBeCloseTo(50 - 11.004, 2)
+    })
+  })
+
   describe('SSRElement Root Node', () => {
     it('should return self as root when no parent', () => {
       const element = new SSRElement('svg')

--- a/tests/unit/ssr/ssr-renderer.spec.js
+++ b/tests/unit/ssr/ssr-renderer.spec.js
@@ -328,5 +328,47 @@ describe('SSRRenderer', () => {
       // One datalabels group per series (not per data point)
       expect(dataLabels.length).toBe(1)
     })
+
+    it('horizontal bar chart: centres each data label on its bar', async () => {
+      const fontSize = 12
+      const svg = await SSRRenderer.renderToString(
+        {
+          chart: {
+            type: 'bar',
+            width: 600,
+            height: 180,
+            animations: { enabled: false },
+          },
+          series: [{ name: 'Count', data: [4, 2] }],
+          xaxis: { categories: ['First', 'Second'] },
+          plotOptions: {
+            bar: { horizontal: true, dataLabels: { position: 'center' } },
+          },
+          dataLabels: { enabled: true, style: { fontSize: `${fontSize}px` } },
+        },
+        { width: 600, height: 180 }
+      )
+
+      const bars = [
+        ...svg.matchAll(
+          /<path d="M [\d.]+ ([\d.]+) L[^>]*barHeight="([\d.]+)"/g
+        ),
+      ].map((m) => parseFloat(m[1]) + parseFloat(m[2]) / 2)
+      const labels = [
+        ...svg.matchAll(
+          /<text x="[\d.]+" y="([\d.]+)"[^>]*apexcharts-datalabel"/g
+        ),
+      ].map((m) => parseFloat(m[1]))
+
+      expect(bars.length).toBe(2)
+      expect(labels.length).toBe(2)
+
+      labels.forEach((baseline, i) => {
+        // `y` on a text element is the alphabetic baseline, so it sits below
+        // the visual centre by roughly a third of the font size.
+        expect(baseline).toBeGreaterThan(bars[i])
+        expect(baseline - bars[i]).toBeLessThan(fontSize / 2)
+      })
+    })
   })
 })


### PR DESCRIPTION
`apexcharts/ssr` puts horizontal bar data labels above the bar centre. The same options rendered in a browser centre them.

The SSR DOM shim has no `getBBox()`, so `SVGElement#bbox()` falls back to a zero rect and every `Graphics.getTextRects()` call in SSR reports a 0x0 label. The horizontal bar label offset adds `textRects.height / 2`, which becomes 0, and the x-axis and y-axis label sizes that set the plot area collapse the same way.

`SSRElement` now estimates the box for `text` and `tspan` nodes from the font size and the content, using average sans-serif metrics. Other elements keep returning an empty rect. On the reported chart the label baseline lands at y=32.087 against a bar centre of 28.085; Chrome gives 32.087 and 28.087 for the same chart.

Fixes #5299
