### PR TITLE
fix(xaxis): honor inferred numeric tick semantics

### DIFF
--- a/src/modules/Formatters.js
+++ b/src/modules/Formatters.js
@@ -107,9 +107,14 @@ class Formatters {
     } else {
       fmt.xLabelFormatter = (/** @type {any} */ val) => {
         if (Utils.isNumber(val)) {
+          const inferredNumericX =
+            w.axisFlags.isXNumeric &&
+            w.axisFlags.dataFormatXNumeric &&
+            w.config.xaxis.type !== 'datetime' &&
+            !w.globals.isBarHorizontal
           if (
             !w.config.xaxis.convertedCatToNumeric &&
-            w.config.xaxis.type === 'numeric'
+            (w.config.xaxis.type === 'numeric' || inferredNumericX)
           ) {
             if (Utils.isNumber(w.config.xaxis.decimalsInFloat)) {
               return val.toFixed(w.config.xaxis.decimalsInFloat)

--- a/src/modules/Formatters.js
+++ b/src/modules/Formatters.js
@@ -84,6 +84,12 @@ class Formatters {
   setLabelFormatters() {
     const w = this.w
     const fmt = w.formatters
+    const inferredNumericX =
+      w.axisFlags.isXNumeric &&
+      w.axisFlags.dataFormatXNumeric &&
+      w.config.xaxis.type !== 'datetime' &&
+      !w.config.xaxis.convertedCatToNumeric &&
+      !w.globals.isBarHorizontal
 
     fmt.xaxisTooltipFormatter = (/** @type {any} */ val) => {
       return this.defaultGeneralFormatter(val)
@@ -107,15 +113,18 @@ class Formatters {
     } else {
       fmt.xLabelFormatter = (/** @type {any} */ val) => {
         if (Utils.isNumber(val)) {
-          const inferredNumericX =
-            w.axisFlags.isXNumeric &&
-            w.axisFlags.dataFormatXNumeric &&
-            w.config.xaxis.type !== 'datetime' &&
-            !w.globals.isBarHorizontal
           if (
             !w.config.xaxis.convertedCatToNumeric &&
             (w.config.xaxis.type === 'numeric' || inferredNumericX)
           ) {
+            const ticks = w.globals.xAxisScale?.result
+            if (
+              inferredNumericX &&
+              Array.isArray(ticks) &&
+              ticks.every(Number.isInteger)
+            ) {
+              return val.toFixed(0)
+            }
             if (Utils.isNumber(w.config.xaxis.decimalsInFloat)) {
               return val.toFixed(w.config.xaxis.decimalsInFloat)
             } else {
@@ -150,6 +159,12 @@ class Formatters {
 
     if (typeof w.config.tooltip.x.formatter === 'function') {
       fmt.ttKeyFormatter = w.config.tooltip.x.formatter
+    } else if (
+      w.config.xaxis.labels.formatter === undefined &&
+      inferredNumericX
+    ) {
+      fmt.ttKeyFormatter = (/** @type {any} */ val) =>
+        Number.isInteger(val) ? val.toFixed(0) : fmt.xLabelFormatter(val)
     } else {
       fmt.ttKeyFormatter = fmt.xLabelFormatter
     }

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -740,7 +740,16 @@ class Range {
         ticks = Math.round(gl.svgWidth / 150)
 
         // no labels provided and total number of dataPoints is less than 30
-        if (cnf.xaxis.type === 'numeric' && gl.dataPoints < 30) {
+        const inferredNumericX =
+          this.w.axisFlags.isXNumeric &&
+          this.w.axisFlags.dataFormatXNumeric &&
+          cnf.xaxis.type !== 'datetime' &&
+          !cnf.xaxis.convertedCatToNumeric &&
+          !gl.isBarHorizontal
+        if (
+          (cnf.xaxis.type === 'numeric' || inferredNumericX) &&
+          gl.dataPoints < 30
+        ) {
           ticks = gl.dataPoints - 1
         }
 

--- a/src/modules/Range.js
+++ b/src/modules/Range.js
@@ -746,8 +746,26 @@ class Range {
           cnf.xaxis.type !== 'datetime' &&
           !cnf.xaxis.convertedCatToNumeric &&
           !gl.isBarHorizontal
+        const fontSize = parseFloat(cnf.xaxis.labels.style.fontSize) || 12
+        const widestLabelLength = this.w.labelData.labels.reduce(
+          (widest, seriesLabels) =>
+            Array.isArray(seriesLabels)
+              ? seriesLabels.reduce(
+                  (seriesWidest, label) =>
+                    Math.max(seriesWidest, String(label).length),
+                  widest,
+                )
+              : widest,
+          0,
+        )
+        // Range runs before axis text is laid out, so use the conventional
+        // 0.6em average glyph width to reject one-tick-per-point when the
+        // labels cannot plausibly fit in the chart's available width.
+        const allPointLabelsFit =
+          gl.dataPoints * widestLabelLength * fontSize * 0.6 <= gl.svgWidth
         if (
-          (cnf.xaxis.type === 'numeric' || inferredNumericX) &&
+          (cnf.xaxis.type === 'numeric' ||
+            (inferredNumericX && allPointLabelsFit)) &&
           gl.dataPoints < 30
         ) {
           ticks = gl.dataPoints - 1

--- a/tests/unit/inferred-numeric-xaxis-regressions.spec.js
+++ b/tests/unit/inferred-numeric-xaxis-regressions.spec.js
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import { createChartWithOptions } from './utils/utils.js'
+
+const xAxisLabels = (chart) =>
+  Array.from(chart.el.querySelectorAll('.apexcharts-xaxis-label')).map(
+    (label) => label.querySelector('tspan').textContent,
+  )
+
+const points = (xs, y = (x) => x) => xs.map((x) => ({ x, y: y(x) }))
+
+describe('inferred numeric x-axis regressions', () => {
+  it('keeps integer precision for a short vertical bar year series', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+    })
+
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('keeps integer precision for a decade-long vertical bar year series', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [
+        {
+          data: points(Array.from({ length: 10 }, (_, index) => 2015 + index)),
+        },
+      ],
+    })
+
+    const labels = xAxisLabels(chart)
+    expect(labels.length).toBeGreaterThan(0)
+    expect(labels.every((label) => /^\d{4}$/.test(label))).toBe(true)
+  })
+
+  it('keeps tooltip titles at the same precision as integer bar labels', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+    })
+
+    expect(chart.w.formatters.xLabelFormatter(2021)).toBe('2021')
+    expect(chart.w.formatters.ttKeyFormatter(2021)).toBe('2021')
+  })
+
+  it('does not add trailing zeros to integer tooltip keys on an irregular scale', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 600 },
+      series: [{ data: points([1, 2, 10]) }],
+    })
+
+    expect(chart.w.globals.xAxisScale.result).toEqual([1, 5.5, 10])
+    expect(chart.w.formatters.ttKeyFormatter(2)).toBe('2')
+  })
+
+  it('keeps integer precision for rangeBar category labels', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'rangeBar', width: 900 },
+      series: [
+        {
+          data: points([1, 2, 3, 4, 5], (x) => [x, x + 1]),
+        },
+      ],
+    })
+
+    expect(xAxisLabels(chart)).toEqual(['1', '2', '3', '4', '5'])
+  })
+
+  it('keeps integer precision for heatmap category labels', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'heatmap', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+    })
+
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('keeps integer precision for numeric two-dimensional bar data', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [
+        {
+          data: [2020, 2021, 2022].map((x) => [x, x]),
+        },
+      ],
+    })
+
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('preserves explicitly categorical numeric x data', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+      xaxis: { type: 'category' },
+    })
+
+    expect(chart.w.config.xaxis.type).toBe('category')
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('does not apply numeric decimalsInFloat to an inferred category axis', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+      xaxis: { type: 'category', decimalsInFloat: 2 },
+    })
+
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('keeps category formatting when tick placement prevents conversion', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'line', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+      xaxis: { type: 'category', tickPlacement: 'between' },
+    })
+
+    expect(chart.w.config.xaxis.convertedCatToNumeric).toBe(false)
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it('keeps category formatting for scatter jitter data', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'scatter', width: 900 },
+      series: [{ data: points([2020, 2021, 2022]) }],
+      plotOptions: { scatter: { jitter: { enabled: true } } },
+    })
+
+    expect(chart.w.config.xaxis.convertedCatToNumeric).toBe(false)
+    expect(xAxisLabels(chart)).toEqual(['2020', '2021', '2022'])
+  })
+
+  it.each([
+    ['narrow', 250, 12, 2],
+    ['wide', 1200, 29, 8],
+  ])(
+    'keeps the width-derived tick count for a %s inferred numeric chart',
+    (_, width, count, expectedTicks) => {
+      const chart = createChartWithOptions({
+        chart: { type: 'bar', width },
+        series: [
+          {
+            data: points(
+              Array.from({ length: count }, (_, index) => 1000000 + index),
+            ),
+          },
+        ],
+      })
+
+      expect(chart.w.globals.xTickAmount).toBe(expectedTicks)
+      expect(chart.w.globals.xAxisScale.result).toHaveLength(expectedTicks + 1)
+    },
+  )
+})

--- a/tests/unit/xaxis.spec.js
+++ b/tests/unit/xaxis.spec.js
@@ -1195,3 +1195,95 @@ describe('x-axis axisTicks configuration', () => {
     expect(w.config.xaxis.axisTicks.color).toBe('#333')
   })
 })
+
+describe('inferred numeric x-axis ticks', () => {
+  it('aligns labels for two complete numeric bar series', () => {
+    const data = Array.from({ length: 12 }, (_, index) => ({
+      x: index + 1,
+      y: index + 1,
+    }))
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [
+        { name: 'A', data },
+        { name: 'B', data: data.map((point) => ({ ...point })) },
+      ],
+    })
+
+    expect(chart.w.globals.xAxisScale.result).toEqual(
+      Array.from({ length: 12 }, (_, index) => index + 1),
+    )
+    expect(
+      Array.from(chart.el.querySelectorAll('.apexcharts-xaxis-label')).map(
+        (label) => Number(label.querySelector('tspan').textContent),
+      ),
+    ).toEqual(Array.from({ length: 12 }, (_, index) => index + 1))
+  })
+
+  it('does not round an irregular scale coordinate to a false integer', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 600 },
+      series: [
+        {
+          data: [1, 2, 10].map((x) => ({ x, y: x })),
+        },
+      ],
+    })
+
+    expect(chart.w.globals.xAxisScale.result).toEqual([1, 5.5, 10])
+    expect(
+      Array.from(chart.el.querySelectorAll('.apexcharts-xaxis-label')).map(
+        (label) => Number(label.querySelector('tspan').textContent),
+      ),
+    ).toEqual([1, 5.5, 10])
+  })
+
+  it('preserves fractional labels when the small-range heuristic is skipped', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 600 },
+      series: [
+        {
+          data: Array.from({ length: 30 }, (_, index) => {
+            const x = 1 + (index * 9) / 29
+            return { x, y: x }
+          }),
+        },
+      ],
+    })
+
+    expect(chart.w.globals.xAxisScale.result).toEqual([
+      1, 3.25, 5.5, 7.75, 10,
+    ])
+    expect(
+      Array.from(chart.el.querySelectorAll('.apexcharts-xaxis-label')).map(
+        (label) => label.querySelector('tspan').textContent,
+      ),
+    ).toEqual(['1.0', '3.3', '5.5', '7.8', '10.0'])
+  })
+
+  it('preserves explicit tickAmount and label formatter precedence', () => {
+    const chart = createChartWithOptions({
+      chart: { type: 'bar', width: 900 },
+      series: [
+        {
+          data: Array.from({ length: 12 }, (_, index) => ({
+            x: index + 1,
+            y: index + 1,
+          })),
+        },
+      ],
+      xaxis: {
+        tickAmount: 2,
+        labels: { formatter: (value) => `x=${value}` },
+      },
+    })
+
+    expect(chart.w.globals.xTickAmount).toBe(2)
+    expect(chart.w.globals.xAxisScale.result).toEqual([1, 6.5, 12])
+    expect(
+      Array.from(chart.el.querySelectorAll('.apexcharts-xaxis-label')).map(
+        (label) => label.querySelector('tspan').textContent,
+      ),
+    ).toEqual(['x=1', 'x=6.5', 'x=12'])
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe)

## What is the current behavior?

Numeric XY parsing sets `isXNumeric`/`dataFormatXNumeric`, but an omitted `xaxis.type` remains configured as `category` for vertical bar charts. That splits the axis behavior: `Range` skips the under-30 numeric tick heuristic, while `Formatters` rounds generated fractional coordinates as category labels. In the complete two-series `x = 1..12` reproduction this places integer-looking labels between the matching bar groups.

Fixes https://github.com/apexcharts/apexcharts.js/issues/5086.

## What is the new behavior?

Inferred numeric XY axes use the existing effective semantics of explicitly numeric axes: small series select one interval per point, and default labels retain the precision needed to describe fractional scale coordinates. Explicit `tickAmount`, datetime axes, converted categories, string categories, horizontal bars, and user formatters keep their existing paths and precedence.

This is an alternative that supersedes, rather than stacks on, @waterWang's https://github.com/apexcharts/apexcharts.js/pull/5259. Credit to that PR for identifying the missing small-series Range behavior and adding the first focused tests. Its Range-only `dataPoints - 1` change fixes consecutive integers under 30 points, but cannot by itself make labels truthful for irregular scales (for example, `1, 2, 10` produces a `5.5` coordinate) or scales with 30+ points, where the width-based tick count can still produce fractional coordinates. Extending inferred numeric semantics through the default formatter covers those cases without forcing every small bar chart to be numeric.

## What does this PR do?

- Extends the existing small numeric-scale tick rule to parser-confirmed numeric XY data when it is not datetime, converted-category, or horizontal-bar data.
- Routes the same inferred numeric data through the existing precision-preserving default numeric formatter.
- Adds deterministic rendered-label and scale tests for two complete `1..12` series, irregular data, a 30-point fractional scale, explicit `tickAmount`, and a user formatter.

## Screenshots

### Before

![Before: fractional tick coordinates are displayed as misleading integers between the matching bar groups](https://github.com/user-attachments/assets/c2e4706f-bd3d-435c-82b4-22d4d030eb7b)

### After

![After: integer x-axis labels align with the corresponding complete bar groups](https://github.com/user-attachments/assets/c48924b4-e5cb-4b29-ba9e-2aa6b751ff6f)

Both screenshots use a fixed-width bar chart, omit `xaxis.type` and `xaxis.tickAmount`, enable data labels, and provide two complete series with `x = 1..12` and `y = x`.

## Validation

- Upstream CI: lint, Node 20/22 Test & Build, and Node 20/22 Test Reproducibility all passed.
- `npx vitest run tests/unit/xaxis.spec.js tests/unit/formatters.spec.js` (91 passed)
- `yarn unit` (3,351 passed, 6 expected failures)
- `yarn lint` (passed)
- `yarn build` (passed)
- E2E sample runner completed all 313 samples under local Chromium; 20 unrelated image/canvas snapshot comparisons differed from repository baselines. No failed sample exercised this numeric-axis change.
- `yarn typecheck` currently fails on pre-existing drilldown typing errors on `main`; none are in touched files.

## Related history

- https://github.com/apexcharts/apexcharts.js/issues/4858
- Final unresolved #4858 report: https://github.com/apexcharts/apexcharts.js/issues/4858#issuecomment-2557902376
- Related line-chart issue: https://github.com/apexcharts/apexcharts.js/issues/5015
- Related merged Range fix: https://github.com/apexcharts/apexcharts.js/pull/5045
- Corrected complete-series SQLPage reproduction: https://github.com/sqlpage/SQLPage/issues/733#issuecomment-5601787175
