### PR TITLE
fix(yaxis): skip text alignment for hidden y-axes

### DIFF
--- a/src/modules/axes/YAxis.js
+++ b/src/modules/axes/YAxis.js
@@ -561,32 +561,31 @@ export default class YAxis {
         const yAxisInner = w.dom.baseEl.querySelector(
           `.apexcharts-yaxis[rel='${index}'] .apexcharts-yaxis-texts-g`,
         )
+        // A hidden axis still renders its .apexcharts-yaxis group, so it is part
+        // of the collection above and keeps the rel index aligned, but drawYaxis
+        // returns before adding the texts group — there is nothing to align.
+        if (!yAxisInner) return
+
         const yAxisTexts = Array.from(
           w.dom.baseEl.querySelectorAll(
             `.apexcharts-yaxis[rel='${index}'] .apexcharts-yaxis-label`,
           ),
         )
-        const rect = /** @type {Element} */ (yAxisInner).getBoundingClientRect()
+        const rect = yAxisInner.getBoundingClientRect()
 
         yAxisTexts.forEach((label) => {
           label.setAttribute('text-anchor', yaxe.labels.align)
         })
 
         if (yaxe.labels.align === 'left' && !yaxe.opposite) {
-          ;/** @type {Element} */ (yAxisInner).setAttribute(
-            'transform',
-            `translate(-${rect.width}, 0)`,
-          )
+          yAxisInner.setAttribute('transform', `translate(-${rect.width}, 0)`)
         } else if (yaxe.labels.align === 'center') {
-          ;/** @type {Element} */ (yAxisInner).setAttribute(
+          yAxisInner.setAttribute(
             'transform',
             `translate(${(rect.width / 2) * (!yaxe.opposite ? -1 : 1)}, 0)`,
           )
         } else if (yaxe.labels.align === 'right' && yaxe.opposite) {
-          ;/** @type {Element} */ (yAxisInner).setAttribute(
-            'transform',
-            `translate(${rect.width}, 0)`,
-          )
+          yAxisInner.setAttribute('transform', `translate(${rect.width}, 0)`)
         }
       }
     })

--- a/src/modules/axes/YAxis.js
+++ b/src/modules/axes/YAxis.js
@@ -551,19 +551,17 @@ export default class YAxis {
 
   setYAxisTextAlignments() {
     const w = this.w
-    const yaxis = Array.from(
-      w.dom.baseEl.getElementsByClassName('apexcharts-yaxis'),
-    )
 
-    yaxis.forEach((y, index) => {
-      const yaxe = w.config.yaxis[index]
+    // Iterate config, not the DOM collection: Axes.drawAxis skips
+    // ignoreYAxisIndexes entirely, so a collapsed axis makes the DOM
+    // shorter than config.yaxis and a later visible axis would be missed.
+    w.config.yaxis.forEach((yaxe, index) => {
       if (yaxe && !yaxe.floating && yaxe.labels.align !== undefined) {
         const yAxisInner = w.dom.baseEl.querySelector(
           `.apexcharts-yaxis[rel='${index}'] .apexcharts-yaxis-texts-g`,
         )
-        // A hidden axis still renders its .apexcharts-yaxis group, so it is part
-        // of the collection above and keeps the rel index aligned, but drawYaxis
-        // returns before adding the texts group — there is nothing to align.
+        // drawYaxis returns before adding .apexcharts-yaxis-texts-g when the
+        // axis is hidden, so there is nothing to align.
         if (!yAxisInner) return
 
         const yAxisTexts = Array.from(

--- a/tests/unit/issue-5305-yaxis-text-alignments.spec.js
+++ b/tests/unit/issue-5305-yaxis-text-alignments.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import ApexCharts from '../../src/entries/full.js'
+
+/**
+ * #5305: setYAxisTextAlignments() threw on a hidden y-axis with labels.align,
+ * which made render() reject and skipped the rest of mount().
+ */
+
+describe('setYAxisTextAlignments hidden y-axis (#5305)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('render() resolves when a hidden y-axis has labels.align', async () => {
+    document.body.innerHTML = '<div id="chart"></div>'
+    const chart = new ApexCharts(document.querySelector('#chart'), {
+      chart: { type: 'line', height: 200, animations: { enabled: false } },
+      series: [
+        { name: 'a', data: [1, 2, 3] },
+        { name: 'b', data: [3, 2, 1] },
+      ],
+      yaxis: [
+        { labels: { align: 'left' } },
+        { show: false, labels: { align: 'left' } },
+      ],
+    })
+
+    await expect(chart.render()).resolves.toBeTruthy()
+    chart.destroy()
+  })
+
+  it('still aligns a later axis when an earlier axis is collapsed', async () => {
+    document.body.innerHTML = '<div id="chart"></div>'
+    const chart = new ApexCharts(document.querySelector('#chart'), {
+      chart: { type: 'line', height: 200, animations: { enabled: false } },
+      series: [
+        { name: 'a', data: [1, 2, 3] },
+        { name: 'b', data: [3, 2, 1] },
+        { name: 'c', data: [2, 1, 3] },
+      ],
+      yaxis: [
+        { labels: { align: 'left' } },
+        { labels: { align: 'left' } },
+        { labels: { align: 'left' } },
+      ],
+    })
+
+    await chart.render()
+    chart.hideSeries('a')
+
+    const lastInner = chart.w.dom.baseEl.querySelector(
+      `.apexcharts-yaxis[rel='2'] .apexcharts-yaxis-texts-g`,
+    )
+    expect(lastInner).not.toBeNull()
+    expect(lastInner.getAttribute('transform')).toMatch(/translate\(/)
+
+    chart.destroy()
+  })
+})


### PR DESCRIPTION
## Description

`setYAxisTextAlignments()` throws `TypeError: Cannot read properties of null (reading 'getBoundingClientRect')` whenever a **hidden** y-axis has `labels.align` set.

`drawYaxis()` always creates the `.apexcharts-yaxis` group (so the `rel` index stays aligned with `w.config.yaxis`), but returns before adding `.apexcharts-yaxis-texts-g` when the axis is hidden:

https://github.com/apexcharts/apexcharts.js/blob/main/src/modules/axes/YAxis.js#L52-L56

```js
const elYaxis = graphics.group({ class: 'apexcharts-yaxis', rel: realIndex, ... })

if (this.axesUtils.isYAxisHidden(realIndex)) return elYaxis   // no texts group

const elYaxisTexts = graphics.group({ class: 'apexcharts-yaxis-texts-g' })
```

`setYAxisTextAlignments()` then iterates the `.apexcharts-yaxis` groups — hidden ones included — and dereferences the texts group unconditionally:

```js
const yAxisInner = w.dom.baseEl.querySelector(
  `.apexcharts-yaxis[rel='${index}'] .apexcharts-yaxis-texts-g`,
)
// ...
const rect = /** @type {Element} */ (yAxisInner).getBoundingClientRect()   // yAxisInner === null
```

The `/** @type {Element} */` casts are what currently silence the `@ts-check` warning about the possible `null`, so the type checker had already flagged this.

`isYAxisHidden()` returns `true` for `show: false`, for an axis whose series are all collapsed, and (with `showForNullSeries: false`) for all-null series — so this is reachable both from static config and at runtime, e.g. by clicking the legend until every series of one axis is collapsed on a chart that sets `labels.align`.

## Steps to Reproduce

```js
new ApexCharts(document.querySelector('#chart'), {
  chart: { type: 'line', height: 200 },
  series: [
    { name: 'a', data: [1, 2, 3] },
    { name: 'b', data: [3, 2, 1] },
  ],
  yaxis: [
    { labels: { align: 'left' } },
    { show: false, labels: { align: 'left' } },
  ],
}).render()
```

## Expected Behavior

The chart renders and the visible axis gets its label alignment; hidden axes are skipped.

## Actual Behavior

`setYAxisTextAlignments()` throws on the hidden axis, which aborts the remaining alignment work in the same `forEach` and surfaces as an uncaught error in the console on every render.

## Fix

Skip the entry when the texts group is absent. This mirrors the guard already used a few methods above in the same file, in `yAxisTitleRotate()`:

```js
const yAxisLabelsCoord = elYAxisLabelsWrap
  ? elYAxisLabelsWrap.getBoundingClientRect()
  : { width: 0, height: 0 }
```

With the early return, `yAxisInner` narrows to `Element`, so the four `/** @type {Element} */` casts are no longer needed and are removed.

## Notes

Found while debugging a two-series chart in [apexcharts-card](https://github.com/RomRider/apexcharts-card) (Home Assistant), where the second y-axis ends up hidden while inheriting `labels.align: 'left'` from the first — three uncaught exceptions per page load, with the chart itself rendering correctly.
