### PR TITLE
fix(exports): key unequal-x CSV rows without `Object.prototype`

### DIFF
--- a/src/modules/Exports.js
+++ b/src/modules/Exports.js
@@ -999,7 +999,9 @@ class Exports {
 
     const handleUnequalXValues = () => {
       const categories = new Set()
-      const data = {}
+      // Map stops a plain object category named `__proto__` from writing
+      /** @type {Map<string, string[]>} */
+      const byCategory = new Map()
 
       /**
        * @param {Record<string, any>} s
@@ -1020,13 +1022,13 @@ class Exports {
           } else {
             return
           }
-          if (!(/** @type {Record<string,any>} */ (data)[cat])) {
-            ;/** @type {Record<string,any>} */ (data)[cat] = Array(
-              series.length,
-            ).fill('')
+          const key = String(cat)
+          let values = byCategory.get(key)
+          if (!values) {
+            values = Array(series.length).fill('')
+            byCategory.set(key, values)
           }
-          ;/** @type {Record<string,any>} */ (data)[cat][sI] =
-            getFormattedValue(value)
+          values[sI] = getFormattedValue(value)
           categories.add(cat)
         })
       })
@@ -1040,7 +1042,7 @@ class Exports {
         .forEach((cat) => {
           // Join here: pushing the array would leave rows.join() to stringify
           // it, which always uses a comma between category and values.
-          const values = /** @type {Record<string,any>} */ (data)[cat]
+          const values = /** @type {string[]} */ (byCategory.get(String(cat)))
           rows.push([getFormattedCategory(cat), ...values].join(columnDelimiter))
         })
     }

--- a/tests/unit/download-csv.spec.js
+++ b/tests/unit/download-csv.spec.js
@@ -466,4 +466,52 @@ describe('Export Csv', () => {
       expect.stringContaining('.csv')
     )
   })
+
+  it('export csv from unequal series with a category named toString', () => {
+    var options = {
+      chart: {
+        type: 'line',
+      },
+      xaxis: {
+        type: 'datetime',
+      },
+      series: [
+        { name: 'series1', data: [{ x: 'toString', y: 1 }] },
+        { name: 'series2', data: [{ x: '2000-01-02T00:00:00.000', y: 2 }] },
+      ],
+    }
+    const csvData =
+      'category,series1,series2\n' + 'Sun Jan 02 2000,,2\n' + 'toString,1,'
+    const chart = createChartWithOptions(options)
+    const exports = new Exports(chart.ctx.w, chart.ctx)
+    vi.spyOn(Exports.prototype, 'triggerDownload')
+    exports.exportToCSV(chart.w.config.series, 'fileName')
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledTimes(1)
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(csvData)),
+      expect.toBeUndefined,
+      expect.stringContaining('.csv')
+    )
+  })
+
+  it('export csv from unequal series leaves Object.prototype alone when a category is named __proto__', () => {
+    var options = {
+      chart: {
+        type: 'line',
+      },
+      xaxis: {
+        type: 'datetime',
+      },
+      series: [
+        { name: 'series1', data: [{ x: '__proto__', y: 1 }] },
+        { name: 'series2', data: [{ x: '2000-01-02T00:00:00.000', y: 2 }] },
+      ],
+    }
+    const chart = createChartWithOptions(options)
+    const exports = new Exports(chart.ctx.w, chart.ctx)
+    vi.spyOn(Exports.prototype, 'triggerDownload')
+    exports.exportToCSV(chart.w.config.series, 'fileName')
+    expect(Exports.prototype.triggerDownload).toHaveBeenCalledTimes(1)
+    expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain('0')
+  })
 })


### PR DESCRIPTION
`handleUnequalXValues` grouped rows in a plain unvalidated object keyed by the category. So a category named `toString` threw `values is not iterable`; while one named `__proto__` wrote through to `Object.prototype`, leaving every object on the page with an `0` property.

Now it is keyed in a Map by the category name.

# New Pull Request

I tried searching and there doesn't seem to be an open issue for this. I made a codepen to show a before and after. https://codepen.io/editor/81reap/pen/01a097ef-876f-7276-9108-4369f365387f

#3481 sounds similar but I'm not entirely sure if its the same issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch

## AI Usage 

Hi 👋🏽 I'm a human. I don't let agents post or act fully autonomously on my behalf. But I did use claude code to help make the fix and codepen. I have reviewed the code and it makes sense to me but I'm happy to make edits. :)  